### PR TITLE
Tratamento de parâmetros nulos para QueryParameter, HeaderParameter e PathParameter

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointHeaderParameterResolver.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointHeaderParameterResolver.java
@@ -25,6 +25,7 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.contract.metadata;
 
+import java.util.Optional;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 
@@ -50,7 +51,8 @@ public class EndpointHeaderParameterResolver {
 
 			parameters.find(name)
 				.filter(p -> p.header())
-					.ifPresent(p -> matcher.appendReplacement(builder, p.resolve(args[p.position()])));
+					.ifPresent(p -> matcher.appendReplacement(builder,
+							Optional.ofNullable(args[p.position()]).map(a -> p.resolve(a)).orElse("")));
 		}
 
 		matcher.appendTail(builder);

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethodFormObjectParameterSerializer.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethodFormObjectParameterSerializer.java
@@ -36,7 +36,10 @@ public class EndpointMethodFormObjectParameterSerializer implements EndpointMeth
 
 	@Override
 	public String serialize(String name, Type type, Object source) {
-		if (isFormObject(source)) {
+		if (source == null) {
+			return null;
+
+		} else if (isFormObject(source)) {
 			return doSerialize(source);
 		} else {
 			throw new IllegalArgumentException("EndpointMethodFormObjectParameterSerializer cannot serialize an object without annotation @Form.");

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethodQueryParameterSerializer.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethodQueryParameterSerializer.java
@@ -35,7 +35,10 @@ public class EndpointMethodQueryParameterSerializer implements EndpointMethodPar
 	@SuppressWarnings("rawtypes")
 	@Override
 	public String serialize(String name, Type type, Object source) {
-		if (source instanceof Iterable) {
+		if (source == null) {
+			return null;
+
+		} else if (source instanceof Iterable) {
 			return serializeAsIterable(name, (Iterable) source);
 
 		} else {

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethodQueryParametersSerializer.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethodQueryParametersSerializer.java
@@ -34,12 +34,23 @@ import com.github.ljtfreitas.restify.http.contract.Parameters;
 
 public class EndpointMethodQueryParametersSerializer implements EndpointMethodParameterSerializer {
 
-	private EndpointMethodFormObjectParameterSerializer formObjectSerializer = new EndpointMethodFormObjectParameterSerializer();
+	private final EndpointMethodFormObjectParameterSerializer formObjectSerializer;
+
+	public EndpointMethodQueryParametersSerializer() {
+		this(new EndpointMethodFormObjectParameterSerializer());
+	}
+
+	public EndpointMethodQueryParametersSerializer(EndpointMethodFormObjectParameterSerializer formObjectSerializer) {
+		this.formObjectSerializer = formObjectSerializer;
+	}
 
 	@SuppressWarnings("rawtypes")
 	@Override
 	public String serialize(String name, Type type, Object source) {
-		if (supported(type, source)) {
+		if (source == null) {
+			return null;
+
+		} else if (supported(type, source)) {
 			if (isParameters(source)) {
 				return serializeAsParameters((Parameters) source);
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointPathParameterResolver.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointPathParameterResolver.java
@@ -25,6 +25,7 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.contract.metadata;
 
+import java.util.Optional;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 
@@ -58,7 +59,9 @@ public class EndpointPathParameterResolver {
 
 			parameters.find(name)
 				.filter(p -> p.path())
-					.ifPresent(p -> matcher.appendReplacement(builder, p.resolve(args[p.position()])));
+					.ifPresent(p -> matcher.appendReplacement(builder,
+							Optional.ofNullable(args[p.position()]).map(a -> p.resolve(a))
+								.orElseThrow(() -> new IllegalArgumentException("Your path argument [" + name + "] cannot be null."))));
 		}
 
 		matcher.appendTail(builder);

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointQueryParameterResolver.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointQueryParameterResolver.java
@@ -39,7 +39,7 @@ public class EndpointQueryParameterResolver {
 
 	public String resolve(Object[] args) {
 		String query = parameters.stream().filter(p -> p.query())
-			.map(p -> p.resolve(args[p.position()]))
+			.map(p -> Optional.ofNullable(args[p.position()]).map(a -> p.resolve(a)).orElse(""))
 				.filter(p -> !"".equals(p))
 					.collect(Collectors.joining("&"));
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/SimpleEndpointMethodParameterSerializer.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/SimpleEndpointMethodParameterSerializer.java
@@ -31,7 +31,7 @@ public class SimpleEndpointMethodParameterSerializer implements EndpointMethodPa
 
 	@Override
 	public String serialize(String name, Type type, Object source) {
-		return source.toString();
+		return source == null ? null : source.toString();
 	}
 
 }

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointHeaderParameterResolverTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointHeaderParameterResolverTest.java
@@ -33,7 +33,20 @@ public class EndpointHeaderParameterResolverTest {
 	}
 
 	@Test
-	public void shouldResolveStaticHeaderArgumentOn() {
+	public void shouldResolveToEmptyWhenDynamicHeaderArgumentValueIsNull() {
+		parameters.put(new EndpointMethodParameter(0, "contentType", String.class, EndpointMethodParameterType.HEADER));
+
+		EndpointHeaderParameterResolver resolver = new EndpointHeaderParameterResolver("{contentType}", parameters);
+
+		Object[] args = new Object[] { null };
+
+		String value = resolver.resolve(args);
+
+		assertEquals("", value);
+	}
+
+	@Test
+	public void shouldResolveStaticHeaderArgument() {
 		parameters.put(new EndpointMethodParameter(0, "any", String.class, EndpointMethodParameterType.PATH));
 
 		EndpointHeaderParameterResolver resolver = new EndpointHeaderParameterResolver("application/json", parameters);

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethodFormObjectParameterSerializerTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethodFormObjectParameterSerializerTest.java
@@ -1,13 +1,13 @@
 package com.github.ljtfreitas.restify.http.contract.metadata;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import com.github.ljtfreitas.restify.http.contract.Form;
 import com.github.ljtfreitas.restify.http.contract.Form.Field;
-import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodFormObjectParameterSerializer;
 
 public class EndpointMethodFormObjectParameterSerializerTest {
 
@@ -27,6 +27,15 @@ public class EndpointMethodFormObjectParameterSerializerTest {
 		String result = serializer.serialize("name", MyFormObject.class, myFormObject);
 
 		assertEquals("param1=value1&customParamName=value2", result);
+	}
+
+	@Test
+	public void shouldReturnNullWhenFormObjectSourceIsNull() {
+		MyFormObject myFormObject = null;
+
+		String result = serializer.serialize("name", MyFormObject.class, myFormObject);
+
+		assertNull(result);
 	}
 
 	@Form

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethodQueryParameterSerializerTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethodQueryParameterSerializerTest.java
@@ -1,13 +1,12 @@
 package com.github.ljtfreitas.restify.http.contract.metadata;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
 import org.junit.Test;
-
-import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodQueryParameterSerializer;
 
 public class EndpointMethodQueryParameterSerializerTest {
 
@@ -32,6 +31,15 @@ public class EndpointMethodQueryParameterSerializerTest {
 		String result = serializer.serialize("parameter", String.class, value);
 
 		assertEquals("parameter=value1", result);
+	}
+
+	@Test
+	public void shouldReturnNullWhenStringSourceIsNull() {
+		String value = null;
+
+		String result = serializer.serialize("parameter", String.class, value);
+
+		assertNull(result);
 	}
 
 }

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointPathParameterResolverTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointPathParameterResolverTest.java
@@ -24,7 +24,7 @@ public class EndpointPathParameterResolverTest {
 
 		EndpointPathParameterResolver resolver = new EndpointPathParameterResolver("/method/{first}", parameters);
 
-		Object[] args = new Object[] { "arg" };
+		Object[] args = { "arg" };
 
 		String endpoint = resolver.resolve(args);
 
@@ -45,6 +45,17 @@ public class EndpointPathParameterResolverTest {
 		assertEquals("/method/firstArg/secondArg", endpoint);
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowExceptionWhenPathArgumentIsNull() {
+		parameters.put(new EndpointMethodParameter(0, "first", String.class));
+
+		EndpointPathParameterResolver resolver = new EndpointPathParameterResolver("/method/{first}", parameters);
+
+		Object[] args = { null };
+
+		resolver.resolve(args);
+	}
+
 	@Test
 	public void shouldResolvePathWithoutDynamicArguments() {
 		EndpointPathParameterResolver resolver = new EndpointPathParameterResolver("/method/static/path", parameters);
@@ -55,4 +66,5 @@ public class EndpointPathParameterResolverTest {
 
 		assertEquals("/method/static/path", endpoint);
 	}
+
 }

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointQueryParameterResolverTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointQueryParameterResolverTest.java
@@ -1,0 +1,47 @@
+package com.github.ljtfreitas.restify.http.contract.metadata;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameter.EndpointMethodParameterType;
+
+public class EndpointQueryParameterResolverTest {
+
+	private EndpointMethodParameters parameters;
+
+	private EndpointQueryParameterResolver resolver;
+
+	@Before
+	public void setup() {
+		parameters = new EndpointMethodParameters();
+
+		parameters.put(new EndpointMethodParameter(0, "param1", String.class,
+				EndpointMethodParameterType.QUERY_STRING, new EndpointMethodQueryParameterSerializer()));
+
+		parameters.put(new EndpointMethodParameter(1, "param2", String.class,
+				EndpointMethodParameterType.QUERY_STRING, new EndpointMethodQueryParameterSerializer()));
+
+		resolver = new EndpointQueryParameterResolver(parameters.ofQuery());
+	}
+
+	@Test
+	public void shouldGenerateQueryStringUsingMethodQueryParameters() {
+		String[] args = {"value1", "value2"};
+
+		String query = resolver.resolve(args);
+
+		assertEquals("?param1=value1&param2=value2", query);
+	}
+
+	@Test
+	public void shouldGenerateQueryStringUsingMethodQueryParametersIgnoringNullArgument() {
+		String[] args = {"value1", null};
+
+		EndpointQueryParameterResolver resolver = new EndpointQueryParameterResolver(parameters.ofQuery());
+		String query = resolver.resolve(args);
+
+		assertEquals("?param1=value1", query);
+	}
+}


### PR DESCRIPTION
Bug reportado na issue #2.

Este pull request implementa as modificações:
- parâmetros anotados com `@PathParameter`, com valor nulo, serão desconsiderados durante a construção da query string.
- parâmetros anotados com `@HeaderParameter`, com valor nulo, serão enviados com valor vazio.
- parâmetros anotados com `@PathParameter', com valor nulo, não serão permitidos (uma exceção do tipo IllegalArgumentException será lançada, com uma mensagem explicativa).