### PR TITLE
Suporte para frameworks Netflix - load balancer client-side e circuit breaker

### DIFF
--- a/java-restify-netflix/pom.xml
+++ b/java-restify-netflix/pom.xml
@@ -28,5 +28,12 @@
 			<artifactId>ribbon-httpclient</artifactId>
 			<version>${netflix.ribbon.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-x-discovery</artifactId>
+			<version>2.11.1</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 </project>

--- a/java-restify-netflix/pom.xml
+++ b/java-restify-netflix/pom.xml
@@ -25,6 +25,11 @@
 		</dependency>
 		<dependency>
 			<groupId>com.netflix.ribbon</groupId>
+			<artifactId>ribbon-loadbalancer</artifactId>
+			<version>${netflix.ribbon.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.netflix.ribbon</groupId>
 			<artifactId>ribbon-httpclient</artifactId>
 			<version>${netflix.ribbon.version}</version>
 		</dependency>

--- a/java-restify-netflix/pom.xml
+++ b/java-restify-netflix/pom.xml
@@ -10,6 +10,7 @@
 
 	<properties>
 		<netflix.ribbon.version>2.2.2</netflix.ribbon.version>
+		<netflix.hystrix.version>1.5.8</netflix.hystrix.version>
 	</properties>
 
 	<dependencies>
@@ -32,6 +33,11 @@
 			<groupId>com.netflix.ribbon</groupId>
 			<artifactId>ribbon-httpclient</artifactId>
 			<version>${netflix.ribbon.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.netflix.hystrix</groupId>
+			<artifactId>hystrix-core</artifactId>
+			<version>${netflix.hystrix.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.curator</groupId>

--- a/java-restify-netflix/pom.xml
+++ b/java-restify-netflix/pom.xml
@@ -40,11 +40,23 @@
 			<version>${netflix.hystrix.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.21</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-x-discovery</artifactId>
 			<version>2.11.1</version>
 			<scope>provided</scope>
 			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-test</artifactId>
+			<version>2.11.1</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/java-restify-netflix/pom.xml
+++ b/java-restify-netflix/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.ljtfreitas</groupId>
 		<artifactId>java-restify-group</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>java-restify-netflix</artifactId>
 

--- a/java-restify-netflix/pom.xml
+++ b/java-restify-netflix/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.github.ljtfreitas</groupId>
+		<artifactId>java-restify-group</artifactId>
+		<version>1.0.1-SNAPSHOT</version>
+	</parent>
+	<artifactId>java-restify-netflix</artifactId>
+
+	<properties>
+		<netflix.ribbon.version>2.2.2</netflix.ribbon.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.netflix.ribbon</groupId>
+			<artifactId>ribbon-core</artifactId>
+			<version>${netflix.ribbon.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.netflix.ribbon</groupId>
+			<artifactId>ribbon-httpclient</artifactId>
+			<version>${netflix.ribbon.version}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerEndpointCallExecutable.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerEndpointCallExecutable.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
+
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.util.Tryable;
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+
+class HystrixCircuitBreakerEndpointCallExecutable<T, O> implements EndpointCallExecutable<T, O> {
+
+	private final HystrixCommand.Setter hystrixMetadata;
+	private final EndpointMethod endpointMethod;
+	private final EndpointCallExecutable<T, O> delegate;
+	private final Object fallback;
+
+	public HystrixCircuitBreakerEndpointCallExecutable(HystrixCommand.Setter hystrixMetadata, EndpointMethod endpointMethod,
+			EndpointCallExecutable<T, O> delegate) {
+
+		this(hystrixMetadata, endpointMethod, delegate, null);
+	}
+
+	public HystrixCircuitBreakerEndpointCallExecutable(HystrixCommand.Setter hystrixMetadata, EndpointMethod endpointMethod,
+			EndpointCallExecutable<T, O> delegate, Object fallback) {
+
+		this.hystrixMetadata = hystrixMetadata;
+		this.endpointMethod = endpointMethod;
+		this.delegate = delegate;
+		this.fallback = fallback;
+	}
+
+	@Override
+	public JavaType returnType() {
+		return delegate.returnType();
+	}
+
+	@Override
+	public T execute(EndpointCall<O> call, Object[] args) {
+		return delegate.execute(new HystrixEndpointCall(endpointMethod, call, args), args);
+	}
+
+	class HystrixEndpointCall implements EndpointCall<O> {
+
+		private final EndpointMethod endpointMethod;
+		private final EndpointCall<O> delegate;
+		private Object[] args;
+
+		public HystrixEndpointCall(EndpointMethod endpointMethod, EndpointCall<O> delegate, Object[] args) {
+			this.endpointMethod = endpointMethod;
+			this.delegate = delegate;
+			this.args = args;
+		}
+
+		@Override
+		public O execute() {
+			HystrixCommand<O> hystrixCommand = new HystrixCommand<O>(hystrixMetadata()) {
+				@Override
+				protected O run() throws Exception {
+					return delegate.execute();
+				}
+
+				@Override
+				protected O getFallback() {
+					return Optional.ofNullable(fallback)
+							.map(f -> Tryable.of(() -> doFallback()))
+								.orElseGet(() -> super.getFallback());
+				}
+
+				@SuppressWarnings("unchecked")
+				private O doFallback() throws Exception {
+					return (O) endpointMethod.javaMethod().invoke(fallback, args);
+				}
+			};
+
+			return hystrixCommand.execute();
+		}
+
+		private HystrixCommand.Setter hystrixMetadata() {
+			return Optional.ofNullable(hystrixMetadata)
+					.orElseGet(() ->  HystrixCommand.Setter.withGroupKey(groupKey()).andCommandKey(commandKey()));
+		}
+
+		private HystrixCommandGroupKey groupKey() {
+			return HystrixCommandGroupKey.Factory.asKey(endpointMethod.javaMethod().getDeclaringClass().getCanonicalName());
+		}
+
+		private HystrixCommandKey commandKey() {
+			return HystrixCommandKey.Factory.asKey(endpointMethod.javaMethod().toGenericString());
+		}
+	}
+}

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerEndpointCallExecutableFactory.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerEndpointCallExecutableFactory.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
+
+import java.lang.reflect.Method;
+
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutableDecoratorFactory;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaAnnotationScanner;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.netflix.hystrix.OnCircuitBreaker;
+import com.netflix.hystrix.HystrixCommand;
+
+public class HystrixCircuitBreakerEndpointCallExecutableFactory<T, O> implements EndpointCallExecutableDecoratorFactory<T, T, O> {
+
+	private final HystrixCommand.Setter hystrixMetadata;
+
+	public HystrixCircuitBreakerEndpointCallExecutableFactory() {
+		this.hystrixMetadata = null;
+	}
+
+	public HystrixCircuitBreakerEndpointCallExecutableFactory(HystrixCommand.Setter hystrixMetadata) {
+		this.hystrixMetadata = hystrixMetadata;
+	}
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		Method javaMethod = endpointMethod.javaMethod();
+		return methodOnCircuitBreaker(javaMethod) || classOnCircuitBreaker(javaMethod.getDeclaringClass());
+	}
+
+	private boolean methodOnCircuitBreaker(Method javaMethod) {
+		return new JavaAnnotationScanner(javaMethod).contains(OnCircuitBreaker.class);
+	}
+
+	private boolean classOnCircuitBreaker(Class<?> classType) {
+		return new JavaAnnotationScanner(classType).contains(OnCircuitBreaker.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType();
+	}
+
+	@Override
+	public EndpointCallExecutable<T, O> create(EndpointMethod endpointMethod, EndpointCallExecutable<T, O> delegate) {
+		return new HystrixCircuitBreakerEndpointCallExecutable<>(hystrixMetadata, endpointMethod, delegate);
+	}
+}

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerFallbackEndpointCallExecutableFactory.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerFallbackEndpointCallExecutableFactory.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
+
+import static com.github.ljtfreitas.restify.http.util.Preconditions.nonNull;
+
+import java.lang.reflect.Method;
+
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutableDecoratorFactory;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaAnnotationScanner;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.netflix.hystrix.OnCircuitBreaker;
+import com.netflix.hystrix.HystrixCommand;
+
+public class HystrixCircuitBreakerFallbackEndpointCallExecutableFactory<T, O, F> implements EndpointCallExecutableDecoratorFactory<T, T, O> {
+
+	private final HystrixCommand.Setter hystrixMetadata;
+	private final F fallback;
+
+	public HystrixCircuitBreakerFallbackEndpointCallExecutableFactory(F fallback) {
+		this(null, fallback);
+	}
+
+	public HystrixCircuitBreakerFallbackEndpointCallExecutableFactory(HystrixCommand.Setter hystrixMetadata, F fallback) {
+		this.hystrixMetadata = hystrixMetadata;
+		this.fallback = nonNull(fallback, "Your fallback cannot be null!");
+	}
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		Method javaMethod = endpointMethod.javaMethod();
+		Class<?> classType = javaMethod.getDeclaringClass();
+
+		return sameTypeOfFallback(classType)
+				&& (methodOnCircuitBreaker(javaMethod) || classOnCircuitBreaker(classType));
+	}
+
+	private boolean methodOnCircuitBreaker(Method javaMethod) {
+		return new JavaAnnotationScanner(javaMethod).contains(OnCircuitBreaker.class);
+	}
+
+	private boolean classOnCircuitBreaker(Class<?> classType) {
+		return new JavaAnnotationScanner(classType).contains(OnCircuitBreaker.class);
+	}
+
+	private boolean sameTypeOfFallback(Class<?> classType) {
+		return classType.isAssignableFrom(fallback.getClass());
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType();
+	}
+
+	@Override
+	public EndpointCallExecutable<T, O> create(EndpointMethod endpointMethod, EndpointCallExecutable<T, O> delegate) {
+		return new HystrixCircuitBreakerEndpointCallExecutable<T, O>(hystrixMetadata, endpointMethod, delegate, fallback);
+	}
+}

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandEndpointCallExecutable.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandEndpointCallExecutable.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
+
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.util.Tryable;
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+
+class HystrixCommandEndpointCallExecutable<T, O> implements EndpointCallExecutable<HystrixCommand<T>, O> {
+
+	private final HystrixCommand.Setter hystrixMetadata;
+	private final EndpointMethod endpointMethod;
+	private final EndpointCallExecutable<T, O> delegate;
+	private final Object fallback;
+
+	public HystrixCommandEndpointCallExecutable(HystrixCommand.Setter hystrixMetadata, EndpointMethod endpointMethod,
+			EndpointCallExecutable<T, O> delegate) {
+
+		this(hystrixMetadata, endpointMethod, delegate, null);
+	}
+
+	public HystrixCommandEndpointCallExecutable(HystrixCommand.Setter hystrixMetadata, EndpointMethod endpointMethod,
+			EndpointCallExecutable<T, O> delegate, Object fallback) {
+
+		this.hystrixMetadata = hystrixMetadata;
+		this.endpointMethod = endpointMethod;
+		this.delegate = delegate;
+		this.fallback = fallback;
+	}
+
+	@Override
+	public JavaType returnType() {
+		return delegate.returnType();
+	}
+
+	@Override
+	public HystrixCommand<T> execute(EndpointCall<O> call, Object[] args) {
+		return new HystrixCommand<T>(hystrixMetadata()) {
+			@Override
+			protected T run() throws Exception {
+				return delegate.execute(call, args);
+			}
+
+			@Override
+			protected T getFallback() {
+				return Optional.ofNullable(fallback)
+						.map(f -> Tryable.of(() -> doFallback()))
+							.orElseGet(() -> super.getFallback());
+			}
+
+			@SuppressWarnings("unchecked")
+			private T doFallback() throws Exception {
+				HystrixCommand<T> fallbackCommand = (HystrixCommand<T>) endpointMethod.javaMethod().invoke(fallback, args);
+				return fallbackCommand.execute();
+			}
+		};
+	}
+
+	private HystrixCommand.Setter hystrixMetadata() {
+		return Optional.ofNullable(hystrixMetadata)
+				.orElseGet(() ->  HystrixCommand.Setter.withGroupKey(groupKey()).andCommandKey(commandKey()));
+	}
+
+	private HystrixCommandGroupKey groupKey() {
+		return HystrixCommandGroupKey.Factory.asKey(endpointMethod.javaMethod().getDeclaringClass().getCanonicalName());
+	}
+
+	private HystrixCommandKey commandKey() {
+		return HystrixCommandKey.Factory.asKey(endpointMethod.javaMethod().toGenericString());
+	}
+}

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandEndpointCallExecutableFactory.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandEndpointCallExecutableFactory.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutableDecoratorFactory;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommand.Setter;
+
+public class HystrixCommandEndpointCallExecutableFactory<T, O> implements EndpointCallExecutableDecoratorFactory<HystrixCommand<T>, T, O> {
+
+	private final HystrixCommand.Setter hystrixMetadata;
+
+	public HystrixCommandEndpointCallExecutableFactory() {
+		this.hystrixMetadata = null;
+	}
+
+	public HystrixCommandEndpointCallExecutableFactory(Setter hystrixMetadata) {
+		this.hystrixMetadata = hystrixMetadata;
+	}
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(HystrixCommand.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.of(unwrap(endpointMethod.returnType()));
+	}
+
+	private Type unwrap(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[0] :
+					Object.class;
+	}
+
+	@Override
+	public EndpointCallExecutable<HystrixCommand<T>, O> create(EndpointMethod endpointMethod, EndpointCallExecutable<T, O> delegate) {
+		return new HystrixCommandEndpointCallExecutable<T, O>(hystrixMetadata, endpointMethod, delegate);
+	}
+}

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandFallbackEndpointCallExecutableFactory.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandFallbackEndpointCallExecutableFactory.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
+
+import static com.github.ljtfreitas.restify.http.util.Preconditions.nonNull;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutableDecoratorFactory;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.netflix.hystrix.HystrixCommand;
+
+public class HystrixCommandFallbackEndpointCallExecutableFactory<T, O, F> implements EndpointCallExecutableDecoratorFactory<HystrixCommand<T>, T, O> {
+
+	private final HystrixCommand.Setter hystrixMetadata;
+	private final F fallback;
+
+	public HystrixCommandFallbackEndpointCallExecutableFactory(F fallback) {
+		this(null, fallback);
+	}
+
+	public HystrixCommandFallbackEndpointCallExecutableFactory(HystrixCommand.Setter hystrixMetadata, F fallback) {
+		this.hystrixMetadata = hystrixMetadata;
+		this.fallback = nonNull(fallback, "Your fallback cannot be null!");
+	}
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(HystrixCommand.class)
+				&& sameTypeOfFallback(endpointMethod.javaMethod().getDeclaringClass());
+	}
+
+	private boolean sameTypeOfFallback(Class<?> classType) {
+		return classType.isAssignableFrom(fallback.getClass());
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.of(unwrap(endpointMethod.returnType()));
+	}
+
+	private Type unwrap(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[0] :
+					Object.class;
+	}
+
+	@Override
+	public EndpointCallExecutable<HystrixCommand<T>, O> create(EndpointMethod endpointMethod, EndpointCallExecutable<T, O> delegate) {
+		return new HystrixCommandEndpointCallExecutable<T, O>(hystrixMetadata, endpointMethod, delegate, fallback);
+	}
+}

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonExceptionHandler.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonExceptionHandler.java
@@ -23,55 +23,10 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.netflix.client.request.zookeeper;
+package com.github.ljtfreitas.restify.http.netflix.client.request;
 
-import java.util.Collections;
-import java.util.Map;
+public interface RibbonExceptionHandler {
 
-import org.codehaus.jackson.annotate.JsonProperty;
+	public void onException(RibbonRequest request, Throwable cause);
 
-public class ZookeeperInstance {
-
-	@JsonProperty
-	private String name;
-
-	@JsonProperty
-	private int port;
-
-	@JsonProperty
-	private String address;
-
-	@JsonProperty
-	private Map<String, String> metadata;
-
-	@Deprecated
-	ZookeeperInstance() {
-	}
-
-	public ZookeeperInstance(String name, String address, int port) {
-		this(name, address, port, Collections.emptyMap());
-	}
-
-	public ZookeeperInstance(String name, String address, int port, Map<String, String> metadata) {
-		this.name = name;
-		this.address = address;
-		this.port = port;
-		this.metadata = metadata;
-	}
-
-	public String name() {
-		return name;
-	}
-
-	public int port() {
-		return port;
-	}
-
-	public String address() {
-		return address;
-	}
-
-	public Map<String, String> metadata() {
-		return Collections.unmodifiableMap(metadata);
-	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequest.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequest.java
@@ -23,11 +23,10 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.netflix.client.request.ribbon;
+package com.github.ljtfreitas.restify.http.netflix.client.request;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.Charset;
@@ -37,6 +36,7 @@ import com.github.ljtfreitas.restify.http.client.Headers;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
 import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
+import com.github.ljtfreitas.restify.http.util.Tryable;
 import com.netflix.client.ClientException;
 
 class RibbonHttpClientRequest implements HttpClientRequest {
@@ -94,9 +94,8 @@ class RibbonHttpClientRequest implements HttpClientRequest {
 		return endpointRequest.method().equalsIgnoreCase("GET");
 	}
 
-	public void writeTo(HttpClientRequest httpRequestMessage) throws IOException {
-		if (endpointRequest.body().isPresent()) {
-			byteArrayOutputStream.writeTo(httpRequestMessage.output());
-		}
+	public void writeTo(HttpClientRequest httpRequestMessage) {
+		endpointRequest.body()
+			.ifPresent(b -> Tryable.run(() -> byteArrayOutputStream.writeTo(httpRequestMessage.output())));
 	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequest.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequest.java
@@ -70,6 +70,11 @@ class RibbonHttpClientRequest implements HttpClientRequest {
 	}
 
 	@Override
+	public EndpointRequest source() {
+		return endpointRequest;
+	}
+
+	@Override
 	public HttpResponseMessage execute() throws RestifyHttpException {
 		try {
 			RibbonResponse response = ribbonLoadBalancedClient.executeWithLoadBalancer(new RibbonRequest(this));

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequest.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequest.java
@@ -39,7 +39,7 @@ import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
 import com.github.ljtfreitas.restify.http.util.Tryable;
 import com.netflix.client.ClientException;
 
-class RibbonHttpClientRequest implements HttpClientRequest {
+public class RibbonHttpClientRequest implements HttpClientRequest {
 
 	private final EndpointRequest endpointRequest;
 	private final RibbonLoadBalancedClient ribbonLoadBalancedClient;
@@ -102,5 +102,9 @@ class RibbonHttpClientRequest implements HttpClientRequest {
 	public void writeTo(HttpClientRequest httpRequestMessage) {
 		endpointRequest.body()
 			.ifPresent(b -> Tryable.run(() -> byteArrayOutputStream.writeTo(httpRequestMessage.output())));
+	}
+
+	public String serviceName() {
+		return endpointRequest.endpoint().getHost();
 	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequestFactory.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequestFactory.java
@@ -23,7 +23,7 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.netflix.client.request.ribbon;
+package com.github.ljtfreitas.restify.http.netflix.client.request;
 
 import java.nio.charset.Charset;
 
@@ -49,7 +49,15 @@ public class RibbonHttpClientRequestFactory implements HttpClientRequestFactory 
 	}
 
 	public RibbonHttpClientRequestFactory(HttpClientRequestFactory delegate, ILoadBalancer loadBalancer, IClientConfig clientConfig, Charset charset) {
-		this.ribbonLoadBalancedClient = new RibbonLoadBalancedClient(loadBalancer, clientConfig, delegate);
+		this(new RibbonLoadBalancedClient(loadBalancer, clientConfig, delegate), charset);
+	}
+
+	public RibbonHttpClientRequestFactory(RibbonLoadBalancedClient ribbonLoadBalancedClient) {
+		this(ribbonLoadBalancedClient, Encoding.UTF_8.charset());
+	}
+
+	public RibbonHttpClientRequestFactory(RibbonLoadBalancedClient ribbonLoadBalancedClient, Charset charset) {
+		this.ribbonLoadBalancedClient = ribbonLoadBalancedClient;
 		this.charset = charset;
 	}
 

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonLoadBalancedClient.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonLoadBalancedClient.java
@@ -23,7 +23,7 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.netflix.client.request.ribbon;
+package com.github.ljtfreitas.restify.http.netflix.client.request;
 
 import java.util.Optional;
 
@@ -38,7 +38,7 @@ import com.netflix.client.config.IClientConfig;
 import com.netflix.client.config.IClientConfigKey;
 import com.netflix.loadbalancer.ILoadBalancer;
 
-class RibbonLoadBalancedClient extends AbstractLoadBalancerAwareClient<RibbonRequest, RibbonResponse> {
+public class RibbonLoadBalancedClient extends AbstractLoadBalancerAwareClient<RibbonRequest, RibbonResponse> {
 
 	private final IClientConfig clientConfig;
 	private final HttpClientRequestFactory httpClientRequestFactory;

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonRequest.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonRequest.java
@@ -23,58 +23,30 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.netflix.client.request.ribbon;
+package com.github.ljtfreitas.restify.http.netflix.client.request;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.Map;
-import java.util.stream.Collectors;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
+import com.netflix.client.ClientRequest;
 
-import com.github.ljtfreitas.restify.http.client.Header;
-import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
-import com.netflix.client.ClientException;
-import com.netflix.client.IResponse;
+class RibbonRequest extends ClientRequest {
 
-class RibbonResponse implements IResponse {
+	private final RibbonHttpClientRequest source;
 
-	private final HttpResponseMessage source;
-
-	public RibbonResponse(HttpResponseMessage source) {
+	public RibbonRequest(RibbonHttpClientRequest source) {
+		super(source.ribbonEndpoint());
 		this.source = source;
 	}
 
-	@Override
-	public void close() throws IOException {
-		source.close();
+	public EndpointRequest replaceUri() {
+		return source.replace(super.getUri());
 	}
 
-	@Override
-	public Object getPayload() throws ClientException {
-		return null;
+	public boolean isGet() {
+		return source.isGet();
 	}
 
-	@Override
-	public boolean hasPayload() {
-		return source.isReadable();
-	}
-
-	@Override
-	public boolean isSuccess() {
-		return source.code().isSucess();
-	}
-
-	@Override
-	public URI getRequestedURI() {
-		return null;
-	}
-
-	@Override
-	public Map<String, ?> getHeaders() {
-		return source.headers().all().stream()
-				.collect(Collectors.groupingBy(Header::name));
-	}
-
-	public HttpResponseMessage unwrap() {
-		return source;
+	public void writeTo(HttpClientRequest httpRequestMessage) {
+		source.writeTo(httpRequestMessage);
 	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonRequest.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonRequest.java
@@ -29,7 +29,7 @@ import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
 import com.netflix.client.ClientRequest;
 
-class RibbonRequest extends ClientRequest {
+public class RibbonRequest extends ClientRequest {
 
 	private final RibbonHttpClientRequest source;
 
@@ -48,5 +48,9 @@ class RibbonRequest extends ClientRequest {
 
 	public void writeTo(HttpClientRequest httpRequestMessage) {
 		source.writeTo(httpRequestMessage);
+	}
+
+	public String serviceName() {
+		return source.serviceName();
 	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonResponse.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonResponse.java
@@ -35,7 +35,7 @@ import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
 import com.netflix.client.ClientException;
 import com.netflix.client.IResponse;
 
-class RibbonResponse implements IResponse {
+public class RibbonResponse implements IResponse {
 
 	private final HttpResponseMessage response;
 

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonResponse.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonResponse.java
@@ -37,44 +37,44 @@ import com.netflix.client.IResponse;
 
 class RibbonResponse implements IResponse {
 
-	private final HttpResponseMessage source;
+	private final HttpResponseMessage response;
 
-	public RibbonResponse(HttpResponseMessage source) {
-		this.source = source;
+	public RibbonResponse(HttpResponseMessage response) {
+		this.response = response;
 	}
 
 	@Override
 	public void close() throws IOException {
-		source.close();
+		response.close();
 	}
 
 	@Override
 	public Object getPayload() throws ClientException {
-		return null;
+		return response.request().source().body().orElse(null);
 	}
 
 	@Override
 	public boolean hasPayload() {
-		return source.isReadable();
+		return response.isReadable();
 	}
 
 	@Override
 	public boolean isSuccess() {
-		return source.code().isSucess();
+		return response.code().isSucess();
 	}
 
 	@Override
 	public URI getRequestedURI() {
-		return null;
+		return response.request().source().endpoint();
 	}
 
 	@Override
 	public Map<String, ?> getHeaders() {
-		return source.headers().all().stream()
+		return response.headers().all().stream()
 				.collect(Collectors.groupingBy(Header::name));
 	}
 
 	public HttpResponseMessage unwrap() {
-		return source;
+		return response;
 	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/SimpleRibbonExceptionHandler.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/SimpleRibbonExceptionHandler.java
@@ -23,55 +23,18 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.netflix.client.request.zookeeper;
+package com.github.ljtfreitas.restify.http.netflix.client.request;
 
-import java.util.Collections;
-import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+class SimpleRibbonExceptionHandler implements RibbonExceptionHandler {
 
-public class ZookeeperInstance {
+	private static final Logger log = LoggerFactory.getLogger(SimpleRibbonExceptionHandler.class);
 
-	@JsonProperty
-	private String name;
-
-	@JsonProperty
-	private int port;
-
-	@JsonProperty
-	private String address;
-
-	@JsonProperty
-	private Map<String, String> metadata;
-
-	@Deprecated
-	ZookeeperInstance() {
+	@Override
+	public void onException(RibbonRequest request, Throwable cause) {
+		log.error("Error on execute HTTP request against endpoint: {}", request.getUri(), cause);
 	}
 
-	public ZookeeperInstance(String name, String address, int port) {
-		this(name, address, port, Collections.emptyMap());
-	}
-
-	public ZookeeperInstance(String name, String address, int port, Map<String, String> metadata) {
-		this.name = name;
-		this.address = address;
-		this.port = port;
-		this.metadata = metadata;
-	}
-
-	public String name() {
-		return name;
-	}
-
-	public int port() {
-		return port;
-	}
-
-	public String address() {
-		return address;
-	}
-
-	public Map<String, String> metadata() {
-		return Collections.unmodifiableMap(metadata);
-	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/RibbonHttpClientRequest.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/RibbonHttpClientRequest.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.request.ribbon;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.Charset;
+
+import com.github.ljtfreitas.restify.http.RestifyHttpException;
+import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
+import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
+import com.netflix.client.ClientException;
+
+class RibbonHttpClientRequest implements HttpClientRequest {
+
+	private final EndpointRequest endpointRequest;
+	private final RibbonLoadBalancedClient ribbonLoadBalancedClient;
+	private final Charset charset;
+
+	private final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(1024 * 100);
+	private final BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(byteArrayOutputStream);
+
+	public RibbonHttpClientRequest(EndpointRequest endpointRequest, RibbonLoadBalancedClient ribbonLoadBalancedClient, Charset charset) {
+		this.endpointRequest = endpointRequest;
+		this.ribbonLoadBalancedClient = ribbonLoadBalancedClient;
+		this.charset = charset;
+	}
+
+	@Override
+	public OutputStream output() {
+		return bufferedOutputStream;
+	}
+
+	@Override
+	public Headers headers() {
+		return endpointRequest.headers();
+	}
+
+	@Override
+	public Charset charset() {
+		return charset;
+	}
+
+	@Override
+	public HttpResponseMessage execute() throws RestifyHttpException {
+		try {
+			RibbonResponse response = ribbonLoadBalancedClient.executeWithLoadBalancer(new RibbonRequest(this));
+
+			return response.unwrap();
+
+		} catch (ClientException e) {
+			throw new RestifyHttpException(e);
+		}
+	}
+
+	public URI ribbonEndpoint() {
+		String sourceEndpoint = endpointRequest.endpoint().toString();
+		return URI.create(sourceEndpoint.replaceFirst(endpointRequest.endpoint().getHost(), ""));
+	}
+
+	public EndpointRequest replace(URI ribbonEndpoint) {
+		return endpointRequest.replace(ribbonEndpoint);
+	}
+
+	public boolean isGet() {
+		return endpointRequest.method().equalsIgnoreCase("GET");
+	}
+
+	public void writeTo(HttpClientRequest httpRequestMessage) throws IOException {
+		if (endpointRequest.body().isPresent()) {
+			byteArrayOutputStream.writeTo(httpRequestMessage.output());
+		}
+	}
+}

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/RibbonHttpClientRequestFactory.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/RibbonHttpClientRequestFactory.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.request.ribbon;
+
+import java.nio.charset.Charset;
+
+import com.github.ljtfreitas.restify.http.client.charset.Encoding;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequestFactory;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.ILoadBalancer;
+
+public class RibbonHttpClientRequestFactory implements HttpClientRequestFactory {
+
+	private final RibbonLoadBalancedClient ribbonLoadBalancedClient;
+	private final Charset charset;
+
+	public RibbonHttpClientRequestFactory(HttpClientRequestFactory delegate, ILoadBalancer loadBalancer) {
+		this(delegate, loadBalancer, new DefaultClientConfigImpl(), Encoding.UTF_8.charset());
+	}
+
+	public RibbonHttpClientRequestFactory(HttpClientRequestFactory delegate, ILoadBalancer loadBalancer, IClientConfig clientConfig) {
+		this(delegate, loadBalancer, clientConfig, Encoding.UTF_8.charset());
+	}
+
+	public RibbonHttpClientRequestFactory(HttpClientRequestFactory delegate, ILoadBalancer loadBalancer, IClientConfig clientConfig, Charset charset) {
+		this.ribbonLoadBalancedClient = new RibbonLoadBalancedClient(loadBalancer, clientConfig, delegate);
+		this.charset = charset;
+	}
+
+	@Override
+	public HttpClientRequest createOf(EndpointRequest endpointRequest) {
+		return new RibbonHttpClientRequest(endpointRequest, ribbonLoadBalancedClient, charset);
+	}
+}

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/RibbonLoadBalancedClient.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/RibbonLoadBalancedClient.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.request.ribbon;
+
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequestFactory;
+import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
+import com.netflix.client.AbstractLoadBalancerAwareClient;
+import com.netflix.client.RequestSpecificRetryHandler;
+import com.netflix.client.RetryHandler;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.client.config.IClientConfigKey;
+import com.netflix.loadbalancer.ILoadBalancer;
+
+class RibbonLoadBalancedClient extends AbstractLoadBalancerAwareClient<RibbonRequest, RibbonResponse> {
+
+	private final IClientConfig clientConfig;
+	private final HttpClientRequestFactory httpClientRequestFactory;
+
+	public RibbonLoadBalancedClient(ILoadBalancer loadBalancer, IClientConfig clientConfig, HttpClientRequestFactory httpClientRequestFactory) {
+		super(loadBalancer, clientConfig);
+		this.clientConfig = clientConfig;
+		this.httpClientRequestFactory = httpClientRequestFactory;
+	}
+
+	@Override
+	public RibbonResponse execute(RibbonRequest request, IClientConfig requestConfig) throws Exception {
+		HttpClientRequest ribbonHttpRequestMessage = httpClientRequestFactory.createOf(request.replaceUri());
+
+		request.writeTo(ribbonHttpRequestMessage);
+
+		HttpResponseMessage httpResponse = ribbonHttpRequestMessage.execute();
+
+		return new RibbonResponse(httpResponse);
+	}
+
+	@Override
+	public RequestSpecificRetryHandler getRequestSpecificRetryHandler(RibbonRequest request, IClientConfig requestConfig) {
+		IClientConfig ribbonRequestConfiguration = Optional.ofNullable(requestConfig).orElse(clientConfig);
+		boolean retryAllOperations = ribbonRequestConfiguration.get(IClientConfigKey.Keys.OkToRetryOnAllOperations,
+				DefaultClientConfigImpl.DEFAULT_OK_TO_RETRY_ON_ALL_OPERATIONS);
+
+		return new RequestSpecificRetryHandler(true, (retryAllOperations || request.isGet()) , RetryHandler.DEFAULT, ribbonRequestConfiguration);
+	}
+}

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/RibbonRequest.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/RibbonRequest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.request.ribbon;
+
+import java.io.IOException;
+
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
+import com.netflix.client.ClientRequest;
+
+class RibbonRequest extends ClientRequest {
+
+	private final RibbonHttpClientRequest source;
+
+	public RibbonRequest(RibbonHttpClientRequest source) {
+		super(source.ribbonEndpoint());
+		this.source = source;
+	}
+
+	public EndpointRequest replaceUri() {
+		return source.replace(super.getUri());
+	}
+
+	public boolean isGet() {
+		return source.isGet();
+	}
+
+	public void writeTo(HttpClientRequest httpRequestMessage) throws IOException {
+		source.writeTo(httpRequestMessage);
+	}
+}

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/RibbonResponse.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/RibbonResponse.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.request.ribbon;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.github.ljtfreitas.restify.http.client.Header;
+import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
+import com.netflix.client.ClientException;
+import com.netflix.client.IResponse;
+
+class RibbonResponse implements IResponse {
+
+	private final HttpResponseMessage source;
+
+	public RibbonResponse(HttpResponseMessage source) {
+		this.source = source;
+	}
+
+	@Override
+	public void close() throws IOException {
+		source.close();
+	}
+
+	@Override
+	public Object getPayload() throws ClientException {
+		return null;
+	}
+
+	@Override
+	public boolean hasPayload() {
+		return source.isReadable();
+	}
+
+	@Override
+	public boolean isSuccess() {
+		return source.code().isSucess();
+	}
+
+	@Override
+	public URI getRequestedURI() {
+		return null;
+	}
+
+	@Override
+	public Map<String, ?> getHeaders() {
+		return source.headers().all().stream()
+				.collect(Collectors.groupingBy(Header::name));
+	}
+
+	public HttpResponseMessage unwrap() {
+		return source;
+	}
+}

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperDiscoveryConfiguration.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperDiscoveryConfiguration.java
@@ -23,32 +23,29 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.netflix.client.request.ribbon;
+package com.github.ljtfreitas.restify.http.netflix.client.request.zookeeper;
 
-import java.io.IOException;
+public class ZookeeperDiscoveryConfiguration {
 
-import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
-import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
-import com.netflix.client.ClientRequest;
+	private String serviceName;
 
-class RibbonRequest extends ClientRequest {
+	private String root;
 
-	private final RibbonHttpClientRequest source;
-
-	public RibbonRequest(RibbonHttpClientRequest source) {
-		super(source.ribbonEndpoint());
-		this.source = source;
+	public String root() {
+		return root;
 	}
 
-	public EndpointRequest replaceUri() {
-		return source.replace(super.getUri());
+	public ZookeeperDiscoveryConfiguration root(String root) {
+		this.root = root;
+		return this;
 	}
 
-	public boolean isGet() {
-		return source.isGet();
+	public String serviceName() {
+		return serviceName;
 	}
 
-	public void writeTo(HttpClientRequest httpRequestMessage) throws IOException {
-		source.writeTo(httpRequestMessage);
+	public ZookeeperDiscoveryConfiguration serviceName(String serviceName) {
+		this.serviceName = serviceName;
+		return this;
 	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperInstance.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperInstance.java
@@ -23,41 +23,50 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.util;
+package com.github.ljtfreitas.restify.http.netflix.client.request.zookeeper;
 
-import java.util.function.Supplier;
+import java.util.Collections;
+import java.util.Map;
 
-public interface Tryable {
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonProperty;
 
-	public static <T> T of(TryableSupplier<T> supplier) {
-		try {
-			return supplier.get();
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
+public class ZookeeperInstance {
+
+	@JsonProperty
+	private String name;
+
+	@JsonProperty
+	private int port;
+
+	@JsonProperty
+	private String address;
+
+	@JsonProperty
+	private Map<String, String> metadata;
+
+	@JsonCreator
+	public ZookeeperInstance(@JsonProperty("name") String name, @JsonProperty("address") String address,
+			@JsonProperty("port") int port, @JsonProperty("metadata") Map<String, String> metadata) {
+		this.name = name;
+		this.address = address;
+		this.port = port;
+		this.metadata = metadata;
 	}
 
-	public static <X extends Throwable, T> T of(TryableSupplier<T> supplier, Supplier<? extends X> exception) throws X {
-		try {
-			return supplier.get();
-		} catch (Exception e) {
-			throw exception.get();
-		}
+	public String name() {
+		return name;
 	}
 
-	public static void run(TryableExpression expression) {
-		try {
-			expression.run();
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
+	public int port() {
+		return port;
 	}
 
-	public interface TryableSupplier<T> {
-		T get() throws Exception;
+	public String address() {
+		return address;
 	}
 
-	public interface TryableExpression {
-		void run() throws Exception;
+	public Map<String, String> metadata() {
+		return Collections.unmodifiableMap(metadata);
 	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperServer.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperServer.java
@@ -23,41 +23,16 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.util;
+package com.github.ljtfreitas.restify.http.netflix.client.request.zookeeper;
 
-import java.util.function.Supplier;
+import org.apache.curator.x.discovery.ServiceInstance;
 
-public interface Tryable {
+import com.netflix.loadbalancer.Server;
 
-	public static <T> T of(TryableSupplier<T> supplier) {
-		try {
-			return supplier.get();
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
+public class ZookeeperServer extends Server {
+
+	public ZookeeperServer(ServiceInstance<ZookeeperInstance> instance) {
+		super(instance.getAddress(), instance.getPort());
 	}
 
-	public static <X extends Throwable, T> T of(TryableSupplier<T> supplier, Supplier<? extends X> exception) throws X {
-		try {
-			return supplier.get();
-		} catch (Exception e) {
-			throw exception.get();
-		}
-	}
-
-	public static void run(TryableExpression expression) {
-		try {
-			expression.run();
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	public interface TryableSupplier<T> {
-		T get() throws Exception;
-	}
-
-	public interface TryableExpression {
-		void run() throws Exception;
-	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperServiceDiscovery.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperServiceDiscovery.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.request.zookeeper;
+
+import java.util.Collection;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.apache.curator.x.discovery.ServiceInstanceBuilder;
+import org.apache.curator.x.discovery.UriSpec;
+import org.apache.curator.x.discovery.details.InstanceSerializer;
+
+import com.github.ljtfreitas.restify.http.util.Tryable;
+
+public class ZookeeperServiceDiscovery {
+
+	private final ServiceDiscovery<ZookeeperInstance> serviceDiscovery;
+
+	public ZookeeperServiceDiscovery(ZookeeperDiscoveryConfiguration configuration, CuratorFramework curator,
+			InstanceSerializer<ZookeeperInstance> serializer) {
+		this.serviceDiscovery = buildServiceDiscoveryWith(configuration, curator, serializer);
+	}
+
+	private ServiceDiscovery<ZookeeperInstance> buildServiceDiscoveryWith(ZookeeperDiscoveryConfiguration configuration, CuratorFramework curator,
+			InstanceSerializer<ZookeeperInstance> serializer) {
+
+		ServiceDiscovery<ZookeeperInstance> serviceDiscovery = ServiceDiscoveryBuilder.builder(ZookeeperInstance.class)
+					.client(curator)
+						.basePath(configuration.root())
+						.serializer(serializer)
+							.build();
+
+		try {
+			serviceDiscovery.start();
+
+			return serviceDiscovery;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public Collection<ServiceInstance<ZookeeperInstance>> queryForInstances(String serviceName) {
+		return Tryable.of(() -> serviceDiscovery.queryForInstances(serviceName));
+	}
+
+	public void register(ZookeeperInstance zookeeperInstance) {
+		try {
+			ServiceInstanceBuilder<ZookeeperInstance> builder = ServiceInstance.builder();
+
+			ServiceInstance<ZookeeperInstance> instance = builder.name(zookeeperInstance.name())
+				.payload(zookeeperInstance)
+				.port(zookeeperInstance.port())
+				.address(zookeeperInstance.address())
+				.uriSpec(new UriSpec("{scheme}://{address}:{port}"))
+				.build();
+
+			serviceDiscovery.registerService(instance);
+
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public void close() {
+		Tryable.run(serviceDiscovery::close);
+	}
+}

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/hystrix/OnCircuitBreaker.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/hystrix/OnCircuitBreaker.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.hystrix;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface OnCircuitBreaker {
+
+}

--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerEndpointCallExecutableFactoryTest.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerEndpointCallExecutableFactoryTest.java
@@ -1,0 +1,99 @@
+package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.netflix.hystrix.OnCircuitBreaker;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HystrixCircuitBreakerEndpointCallExecutableFactoryTest {
+
+	@Mock
+	private EndpointCallExecutable<String, String> endpointCallStringExecutable;
+
+	@Mock
+	private EndpointCallExecutable<Future<String>, String> endpointCallFutureExecutable;
+
+	@Mock
+	private EndpointCall<String> endpointCallString;
+
+	private HystrixCircuitBreakerEndpointCallExecutableFactory<String, String> hystrixCircuitBreakerStringExecutableFactory;
+
+	private HystrixCircuitBreakerEndpointCallExecutableFactory<Future<String>, String> hystrixCircuitBreakerFutureExecutableFactory;
+
+	private Object[] arguments;
+
+	@Before
+	public void setup() {
+		arguments = new Object[0];
+
+		when(endpointCallString.execute())
+			.thenReturn("call result");
+
+		when(endpointCallStringExecutable.execute(any(), any()))
+			.then(invocation -> invocation.getArgumentAt(0, EndpointCall.class).execute());
+
+		hystrixCircuitBreakerStringExecutableFactory = new HystrixCircuitBreakerEndpointCallExecutableFactory<>();
+
+		hystrixCircuitBreakerFutureExecutableFactory = new HystrixCircuitBreakerEndpointCallExecutableFactory<>();
+	}
+
+	@Test
+	public void shouldExecuteHystrixCommandUsingEndpointCall() throws Exception {
+
+		EndpointCallExecutable<String, String> executable = hystrixCircuitBreakerStringExecutableFactory
+				.create(new SimpleEndpointMethod(SomeType.class.getMethod("onCircuitBreaker")), endpointCallStringExecutable);
+
+		String result = executable.execute(endpointCallString, arguments);
+
+		assertEquals("call result", result);
+	}
+
+	@Test
+	public void shouldExecuteHystrixCommandOnOtherThread() throws Exception {
+		EndpointCallExecutable<Future<String>, String> executable = hystrixCircuitBreakerFutureExecutableFactory
+				.create(new SimpleEndpointMethod(SomeType.class.getMethod("onCircuitBreaker")), endpointCallFutureExecutable);
+
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+
+		when(endpointCallFutureExecutable.execute(any(), any()))
+			.then(invocation -> executor.submit(() -> invocation.getArgumentAt(0, EndpointCall.class).execute()));
+
+		Future<String> result = executable.execute(endpointCallString, arguments);
+
+		assertEquals("call result", result.get());
+	}
+
+	@Test
+	public void shouldSupportsOnCircuitBreakerEndpointMethod() throws Exception {
+		SimpleEndpointMethod endpointMethod = new SimpleEndpointMethod(SomeType.class.getMethod("onCircuitBreaker"));
+		assertTrue(hystrixCircuitBreakerStringExecutableFactory.supports(endpointMethod));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodIsNotRunningOnOnCircuitBreaker() throws Exception {
+		SimpleEndpointMethod endpointMethod = new SimpleEndpointMethod(SomeType.class.getMethod("withoutCircuitBreaker"));
+		assertFalse(hystrixCircuitBreakerStringExecutableFactory.supports(endpointMethod));
+	}
+
+	interface SomeType {
+
+		@OnCircuitBreaker
+		String onCircuitBreaker();
+
+		String withoutCircuitBreaker();
+	}
+}

--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerFallbackEndpointCallExecutableFactoryTest.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerFallbackEndpointCallExecutableFactoryTest.java
@@ -1,0 +1,132 @@
+package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.netflix.hystrix.OnCircuitBreaker;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HystrixCircuitBreakerFallbackEndpointCallExecutableFactoryTest {
+
+	@Mock
+	private EndpointCallExecutable<String, String> endpointCallStringExecutable;
+
+	@Mock
+	private EndpointCallExecutable<Future<String>, String> endpointCallFutureExecutable;
+
+	@Mock
+	private EndpointCall<String> endpointCallString;
+
+	private HystrixCircuitBreakerFallbackEndpointCallExecutableFactory<String, String, SomeType> hystrixCircuitBreakerStringExecutableFactory;
+
+	private HystrixCircuitBreakerFallbackEndpointCallExecutableFactory<Future<String>, String, SomeType> hystrixCircuitBreakerFutureExecutableFactory;
+
+	private Object[] arguments;
+
+	@Spy
+	private SomeFallback fallback = new SomeFallback();
+
+	@Before
+	public void setup() {
+		arguments = new Object[0];
+
+		when(endpointCallString.execute())
+			.thenReturn("call result");
+
+		when(endpointCallStringExecutable.execute(any(), any()))
+			.then(invocation -> invocation.getArgumentAt(0, EndpointCall.class).execute());
+
+		hystrixCircuitBreakerStringExecutableFactory = new HystrixCircuitBreakerFallbackEndpointCallExecutableFactory<>(fallback);
+
+		hystrixCircuitBreakerFutureExecutableFactory = new HystrixCircuitBreakerFallbackEndpointCallExecutableFactory<>(fallback);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void shouldExecuteHystrixCommandUsingEndpointCall() throws Exception {
+		EndpointCallExecutable<String, String> executable = hystrixCircuitBreakerStringExecutableFactory
+				.create(new SimpleEndpointMethod(SomeType.class.getMethod("onCircuitBreaker")), endpointCallStringExecutable);
+
+		String result = executable.execute(endpointCallString, arguments);
+
+		assertEquals("call result", result);
+
+		verify(endpointCallStringExecutable)
+			.execute(notNull(EndpointCall.class), anyVararg());
+
+		verify(endpointCallString).execute();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void shouldExecuteHystrixCommandOnOtherThread() throws Exception {
+		EndpointCallExecutable<Future<String>, String> executable = hystrixCircuitBreakerFutureExecutableFactory
+				.create(new SimpleEndpointMethod(SomeType.class.getMethod("onCircuitBreaker")), endpointCallFutureExecutable);
+
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+
+		when(endpointCallFutureExecutable.execute(any(), any()))
+			.then(invocation -> executor.submit(() -> invocation.getArgumentAt(0, EndpointCall.class).execute()));
+
+		Future<String> result = executable.execute(endpointCallString, arguments);
+
+		assertEquals("call result", result.get());
+
+		verify(endpointCallFutureExecutable)
+			.execute(notNull(EndpointCall.class), anyVararg());
+
+		verify(endpointCallString).execute();
+	}
+
+	@Test
+	public void shouldSupportsOnCircuitBreakerEndpointMethod() throws Exception {
+		SimpleEndpointMethod endpointMethod = new SimpleEndpointMethod(SomeType.class.getMethod("onCircuitBreaker"));
+		assertTrue(hystrixCircuitBreakerStringExecutableFactory.supports(endpointMethod));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodIsNotRunningOnOnCircuitBreaker() throws Exception {
+		SimpleEndpointMethod endpointMethod = new SimpleEndpointMethod(SomeType.class.getMethod("withoutCircuitBreaker"));
+		assertFalse(hystrixCircuitBreakerStringExecutableFactory.supports(endpointMethod));
+	}
+
+	interface SomeType {
+
+		@OnCircuitBreaker
+		String onCircuitBreaker();
+
+		String withoutCircuitBreaker();
+	}
+
+	private class SomeFallback implements SomeType {
+
+		@Override
+		public String onCircuitBreaker() {
+			return "onCircuitBreaker";
+		}
+
+		@Override
+		public String withoutCircuitBreaker() {
+			return "withoutCircuitBreaker";
+		}
+	}
+}

--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandEndpointCallExecutableFactoryTest.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandEndpointCallExecutableFactoryTest.java
@@ -1,0 +1,92 @@
+package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.exception.HystrixRuntimeException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HystrixCommandEndpointCallExecutableFactoryTest {
+
+	@Mock
+	private EndpointCallExecutable<String, String> delegate;
+
+	private HystrixCommandEndpointCallExecutableFactory<String, String> factory;
+
+	@Before
+	public void setup() {
+		factory = new HystrixCommandEndpointCallExecutableFactory<>();
+
+		when(delegate.execute(any(), any()))
+			.then(invocation -> invocation.getArgumentAt(0, EndpointCall.class).execute());
+
+		when(delegate.returnType())
+			.thenReturn(JavaType.of(String.class));
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsHystrixCommand() throws Exception {
+		assertTrue(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("command"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotHystrixCommand() throws Exception {
+		assertFalse(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void shouldCreateExecutableFromEndpointMethodWithHystrixCommandReturnType() throws Exception {
+		EndpointCallExecutable<HystrixCommand<String>, String> executable = factory
+				.create(new SimpleEndpointMethod(SomeType.class.getMethod("command")), delegate);
+
+		String result = "result";
+
+		HystrixCommand<String> hystrixCommand = executable.execute(() -> result, null);
+
+		assertEquals(result, hystrixCommand.execute());
+		assertEquals(delegate.returnType(), executable.returnType());
+
+		verify(delegate).execute(notNull(EndpointCall.class), any());
+	}
+
+	@Test
+	public void shouldReturnObjectTypeWhenHystrixCommandIsNotParameterized() throws Exception {
+		assertEquals(JavaType.of(Object.class), factory.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbCommand"))));
+	}
+
+	@Test(expected = HystrixRuntimeException.class)
+	public void shouldPropagateExceptionWhenHystrixCommandThrowsException() throws Exception {
+		EndpointCallExecutable<HystrixCommand<String>, String> executable = factory
+				.create(new SimpleEndpointMethod(SomeType.class.getMethod("command")), delegate);
+
+		HystrixCommand<String> hystrixCommand = executable.execute(() -> {throw new RuntimeException("oooh!");}, null);
+
+		hystrixCommand.execute();
+	}
+
+	interface SomeType {
+
+		HystrixCommand<String> command();
+
+		@SuppressWarnings("rawtypes")
+		HystrixCommand dumbCommand();
+
+		String string();
+	}
+}

--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandFallbackEndpointCallExecutableFactoryTest.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandFallbackEndpointCallExecutableFactoryTest.java
@@ -1,0 +1,131 @@
+package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HystrixCommandFallbackEndpointCallExecutableFactoryTest {
+
+	@Mock
+	private EndpointCallExecutable<String, String> delegate;
+
+	private HystrixCommandFallbackEndpointCallExecutableFactory<String, String, SomeType> factory;
+
+	@Spy
+	private SomeFallback fallback = new SomeFallback();
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void setup() {
+		factory = new HystrixCommandFallbackEndpointCallExecutableFactory<>(fallback);
+
+		when(delegate.execute(notNull(EndpointCall.class), anyVararg()))
+			.then(invocation -> invocation.getArgumentAt(0, EndpointCall.class).execute());
+
+		when(delegate.returnType())
+			.thenReturn(JavaType.of(String.class));
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsHystrixCommand() throws Exception {
+		assertTrue(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("command"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotHystrixCommand() throws Exception {
+		assertFalse(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void shouldCreateExecutableFromEndpointMethodWithHystrixCommandReturnType() throws Exception {
+		EndpointCallExecutable<HystrixCommand<String>, String> executable = factory
+				.create(new SimpleEndpointMethod(SomeType.class.getMethod("command")), delegate);
+
+		String result = "result";
+
+		HystrixCommand<String> hystrixCommand = executable.execute(() -> result, null);
+
+		assertEquals(result, hystrixCommand.execute());
+		assertEquals(delegate.returnType(), executable.returnType());
+
+		verify(delegate).execute(notNull(EndpointCall.class), anyVararg());
+	}
+
+	@Test
+	public void shouldReturnObjectTypeWhenHystrixCommandIsNotParameterized() throws Exception {
+		assertEquals(JavaType.of(Object.class), factory.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbCommand"))));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void shouldReturnFallbackValueWhenHystrixCommandExecutionThrowException() throws Exception {
+		EndpointCallExecutable<HystrixCommand<String>, String> executable = factory
+				.create(new SimpleEndpointMethod(SomeType.class.getMethod("command")), delegate);
+
+		HystrixCommand<String> hystrixCommand = executable.execute(() -> {throw new RuntimeException("oooh!");}, null);
+
+		assertEquals("fallback", hystrixCommand.execute());
+		assertEquals(delegate.returnType(), executable.returnType());
+
+		verify(delegate).execute(notNull(EndpointCall.class), anyVararg());
+		verify(fallback).command();
+	}
+
+	interface SomeType {
+
+		HystrixCommand<String> command();
+
+		@SuppressWarnings("rawtypes")
+		HystrixCommand dumbCommand();
+
+		String string();
+	}
+
+	private class SomeFallback implements SomeType {
+
+		@Override
+		public HystrixCommand<String> command() {
+			return new HystrixCommand<String>(HystrixCommandGroupKey.Factory.asKey("fallback")) {
+				@Override
+				protected String run() throws Exception {
+					return "fallback";
+				}
+			};
+		}
+
+		@SuppressWarnings("rawtypes")
+		@Override
+		public HystrixCommand dumbCommand() {
+			return new HystrixCommand(HystrixCommandGroupKey.Factory.asKey("fallback")) {
+				@Override
+				protected Object run() throws Exception {
+					return "fallback";
+				}
+			};
+		}
+
+		@Override
+		public String string() {
+			return "string";
+		}
+	}
+}

--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/SimpleEndpointMethod.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/SimpleEndpointMethod.java
@@ -1,0 +1,17 @@
+package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
+
+import java.lang.reflect.Method;
+
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameters;
+
+class SimpleEndpointMethod extends EndpointMethod {
+
+	public SimpleEndpointMethod(Method javaMethod) {
+		super(javaMethod, "/", "GET");
+	}
+
+	public SimpleEndpointMethod(Method javaMethod, EndpointMethodParameters parameters) {
+		super(javaMethod, "/", "GET", parameters);
+	}
+}

--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequestFactoryTest.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequestFactoryTest.java
@@ -1,4 +1,4 @@
-package com.github.ljtfreitas.restify.http.netflix.client.request.ribbon;
+package com.github.ljtfreitas.restify.http.netflix.client.request;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockserver.model.HttpRequest.request;
@@ -27,6 +27,7 @@ import com.github.ljtfreitas.restify.http.contract.Get;
 import com.github.ljtfreitas.restify.http.contract.Header;
 import com.github.ljtfreitas.restify.http.contract.Path;
 import com.github.ljtfreitas.restify.http.contract.Post;
+import com.github.ljtfreitas.restify.http.netflix.client.request.RibbonHttpClientRequestFactory;
 import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.BaseLoadBalancer;

--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/RibbonHttpClientRequestFactoryTest.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/RibbonHttpClientRequestFactoryTest.java
@@ -1,0 +1,180 @@
+package com.github.ljtfreitas.restify.http.netflix.client.request.ribbon;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+import static org.mockserver.model.StringBody.exact;
+import static org.mockserver.verify.VerificationTimes.once;
+
+import java.util.Arrays;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockserver.client.server.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.HttpRequest;
+
+import com.github.ljtfreitas.restify.http.RestifyProxyBuilder;
+import com.github.ljtfreitas.restify.http.client.request.jdk.JdkHttpClientRequestFactory;
+import com.github.ljtfreitas.restify.http.contract.BodyParameter;
+import com.github.ljtfreitas.restify.http.contract.Get;
+import com.github.ljtfreitas.restify.http.contract.Header;
+import com.github.ljtfreitas.restify.http.contract.Path;
+import com.github.ljtfreitas.restify.http.contract.Post;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.BaseLoadBalancer;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.Server;
+
+public class RibbonHttpClientRequestFactoryTest {
+
+	@Rule
+	public MockServerRule mockServerRule = new MockServerRule(this, 7080, 7081, 7082);
+
+	private MyApi myApi;
+
+	private MockServerClient mockServerClient;
+
+	@Before
+	public void setup() {
+		JdkHttpClientRequestFactory delegate = new JdkHttpClientRequestFactory();
+
+		ILoadBalancer loadBalancer = new BaseLoadBalancer();
+		loadBalancer.addServers(Arrays.asList(new Server("localhost", 7080)));
+		loadBalancer.addServers(Arrays.asList(new Server("localhost", 7081)));
+		loadBalancer.addServers(Arrays.asList(new Server("localhost", 7082)));
+
+		IClientConfig clientConfig = new DefaultClientConfigImpl();
+
+		RibbonHttpClientRequestFactory ribbonHttpClientRequestFactory = new RibbonHttpClientRequestFactory(delegate, loadBalancer, clientConfig);
+
+		myApi = new RestifyProxyBuilder()
+				.client(ribbonHttpClientRequestFactory)
+				.target(MyApi.class, "http://myApi")
+				.build();
+	}
+
+	@Test
+	public void shouldSendGetRequestOnJsonFormat() {
+		mockServerClient = new MockServerClient("localhost", 7080);
+
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/json"))
+			.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "application/json")
+					.withBody(json("{\"name\": \"Tiago de Freitas Lima\",\"age\":31}")));
+
+		MyModel myModel = myApi.json();
+
+		assertEquals("Tiago de Freitas Lima", myModel.name);
+		assertEquals(31, myModel.age);
+	}
+
+	@Test
+	public void shouldSendPostRequestOnJsonFormat() {
+		mockServerClient = new MockServerClient("localhost", 7081);
+
+		HttpRequest httpRequest = request()
+			.withMethod("POST")
+			.withPath("/json")
+			.withHeader("Content-Type", "application/json; charset=UTF-8")
+			.withBody(json("{\"name\":\"Tiago de Freitas Lima\",\"age\":31}"));
+
+		mockServerClient
+			.when(httpRequest)
+			.respond(response()
+				.withStatusCode(201)
+				.withHeader("Content-Type", "text/plain")
+				.withBody(exact("OK")));
+
+		myApi.json(new MyModel("Tiago de Freitas Lima", 31));
+
+		mockServerClient.verify(httpRequest, once());
+	}
+
+	@Test
+	public void shouldSendGetRequestOnXmlFormat() {
+		mockServerClient = new MockServerClient("localhost", 7082);
+
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/xml"))
+			.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "application/xml")
+					.withBody(exact("<model><name>Tiago de Freitas Lima</name><age>31</age></model>")));
+
+		MyModel myModel = myApi.xml();
+
+		assertEquals("Tiago de Freitas Lima", myModel.name);
+		assertEquals(31, myModel.age);
+	}
+
+	@Test
+	public void shouldSendPostRequestOnXmlFormat() {
+		mockServerClient = new MockServerClient("localhost", 7080);
+
+		HttpRequest httpRequest = request()
+			.withMethod("POST")
+			.withPath("/xml")
+			.withHeader("Content-Type", "application/xml; charset=UTF-8")
+			.withBody(exact("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><model><name>Tiago de Freitas Lima</name><age>31</age></model>"));
+
+		mockServerClient
+			.when(httpRequest)
+			.respond(response()
+				.withStatusCode(201)
+				.withHeader("Content-Type", "text/plain")
+				.withBody(exact("OK")));
+
+		myApi.xml(new MyModel("Tiago de Freitas Lima", 31));
+
+		mockServerClient.verify(httpRequest, once());
+	}
+
+	interface MyApi {
+
+		@Path("/json") @Get
+		public MyModel json();
+
+		@Path("/json") @Post
+		@Header(name = "Content-Type", value = "application/json")
+		public void json(@BodyParameter MyModel myModel);
+
+		@Path("/xml") @Get
+		public MyModel xml();
+
+		@Path("/xml") @Post
+		@Header(name = "Content-Type", value = "application/xml")
+		public void xml(@BodyParameter MyModel myModel);
+	}
+
+	@XmlRootElement(name = "model")
+	@XmlAccessorType(XmlAccessType.FIELD)
+	public static class MyModel {
+
+		String name;
+		int age;
+
+		public MyModel() {
+		}
+
+		public MyModel(String name, int age) {
+			this.name = name;
+			this.age = age;
+		}
+
+	}
+
+}

--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperServiceDiscoveryTest.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperServiceDiscoveryTest.java
@@ -1,0 +1,175 @@
+package com.github.ljtfreitas.restify.http.netflix.client.request.zookeeper;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+import static org.mockserver.model.StringBody.exact;
+import static org.mockserver.verify.VerificationTimes.once;
+
+import java.util.Collections;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.x.discovery.details.InstanceSerializer;
+import org.apache.curator.x.discovery.details.JsonInstanceSerializer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockserver.client.server.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.HttpRequest;
+
+import com.github.ljtfreitas.restify.http.RestifyProxyBuilder;
+import com.github.ljtfreitas.restify.http.client.request.jdk.JdkHttpClientRequestFactory;
+import com.github.ljtfreitas.restify.http.contract.BodyParameter;
+import com.github.ljtfreitas.restify.http.contract.Get;
+import com.github.ljtfreitas.restify.http.contract.Header;
+import com.github.ljtfreitas.restify.http.contract.Path;
+import com.github.ljtfreitas.restify.http.contract.Post;
+import com.github.ljtfreitas.restify.http.netflix.client.request.RibbonHttpClientRequestFactory;
+import com.github.ljtfreitas.restify.http.netflix.client.request.RibbonLoadBalancedClient;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.loadbalancer.IPing;
+import com.netflix.loadbalancer.LoadBalancerBuilder;
+import com.netflix.loadbalancer.PingUrl;
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ZoneAffinityServerListFilter;
+import com.netflix.loadbalancer.ZoneAvoidanceRule;
+import com.netflix.loadbalancer.ZoneAwareLoadBalancer;
+
+public class ZookeeperServiceDiscoveryTest {
+
+	@Rule
+	public MockServerRule mockServerRule = new MockServerRule(this, 7080, 7081, 7082);
+
+	private MyApi myApi;
+
+	private MockServerClient mockServerClient;
+
+	private ZookeeperServiceDiscovery zookeeperServiceDiscovery;
+
+	@Before
+	public void setup() throws Exception {
+		DefaultClientConfigImpl ribbonLoadBalacerConfiguration = new DefaultClientConfigImpl();
+		ribbonLoadBalacerConfiguration.setClientName("myApp");
+
+		ZoneAvoidanceRule rule = new ZoneAvoidanceRule();
+		rule.initWithNiwsConfig(ribbonLoadBalacerConfiguration);
+
+		ZoneAffinityServerListFilter<Server> predicate = new ZoneAffinityServerListFilter<>(ribbonLoadBalacerConfiguration);
+
+		IPing ping = new PingUrl();
+
+		ZookeeperDiscoveryConfiguration zookeeperDiscoveryConfiguration = new ZookeeperDiscoveryConfiguration();
+		zookeeperDiscoveryConfiguration.root("/services").serviceName("myApp");
+
+		CuratorFramework curator = CuratorFrameworkFactory.builder()
+				.connectString("localhost:2181")
+				.retryPolicy(new RetryNTimes(0, 0))
+					.build();
+		curator.start();
+
+		InstanceSerializer<ZookeeperInstance> serializer = new JsonInstanceSerializer<>(ZookeeperInstance.class);
+
+		zookeeperServiceDiscovery = new ZookeeperServiceDiscovery(zookeeperDiscoveryConfiguration, curator, serializer);
+		zookeeperServiceDiscovery.register(new ZookeeperInstance("myApp", "localhost", 7080, Collections.emptyMap()));
+		zookeeperServiceDiscovery.register(new ZookeeperInstance("myApp", "localhost", 7081, Collections.emptyMap()));
+		zookeeperServiceDiscovery.register(new ZookeeperInstance("myApp", "localhost", 7082, Collections.emptyMap()));
+
+		ZookeeperServers zookeeperServers = new ZookeeperServers("myApp", zookeeperServiceDiscovery);
+
+		ZoneAwareLoadBalancer<Server> loadBalancer = LoadBalancerBuilder.newBuilder()
+				.withClientConfig(ribbonLoadBalacerConfiguration)
+				.withRule(rule)
+				.withPing(ping)
+				.withDynamicServerList(zookeeperServers)
+				.withServerListFilter(predicate)
+					.buildDynamicServerListLoadBalancer();
+
+		JdkHttpClientRequestFactory delegate = new JdkHttpClientRequestFactory();
+
+		RibbonLoadBalancedClient ribbonLoadBalancedClient = new RibbonLoadBalancedClient(loadBalancer, ribbonLoadBalacerConfiguration, delegate);
+
+		RibbonHttpClientRequestFactory ribbonHttpClientRequestFactory = new RibbonHttpClientRequestFactory(ribbonLoadBalancedClient);
+
+		myApi = new RestifyProxyBuilder()
+				.client(ribbonHttpClientRequestFactory)
+				.target(MyApi.class, "http://myApi")
+				.build();
+	}
+
+	@After
+	public void after() {
+		zookeeperServiceDiscovery.close();
+	}
+
+	@Test
+	public void shouldSendGetRequestOnJsonFormat() {
+		mockServerClient = new MockServerClient("localhost", 7080);
+
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/json"))
+			.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "application/json")
+					.withBody(json("{\"name\": \"Tiago de Freitas Lima\",\"age\":31}")));
+
+		MyModel myModel = myApi.json();
+
+		assertEquals("Tiago de Freitas Lima", myModel.name);
+		assertEquals(31, myModel.age);
+	}
+
+	@Test
+	public void shouldSendPostRequestOnJsonFormat() {
+		mockServerClient = new MockServerClient("localhost", 7081);
+
+		HttpRequest httpRequest = request()
+			.withMethod("POST")
+			.withPath("/json")
+			.withHeader("Content-Type", "application/json; charset=UTF-8")
+			.withBody(json("{\"name\":\"Tiago de Freitas Lima\",\"age\":31}"));
+
+		mockServerClient
+			.when(httpRequest)
+			.respond(response()
+				.withStatusCode(201)
+				.withHeader("Content-Type", "text/plain")
+				.withBody(exact("OK")));
+
+		myApi.json(new MyModel("Tiago de Freitas Lima", 31));
+
+		mockServerClient.verify(httpRequest, once());
+	}
+
+	interface MyApi {
+
+		@Path("/json") @Get
+		public MyModel json();
+
+		@Path("/json") @Post
+		@Header(name = "Content-Type", value = "application/json")
+		public void json(@BodyParameter MyModel myModel);
+	}
+
+	public static class MyModel {
+
+		String name;
+		int age;
+
+		public MyModel() {
+		}
+
+		public MyModel(String name, int age) {
+			this.name = name;
+			this.age = age;
+		}
+
+	}
+
+}

--- a/java-restify-spring-autoconfigure/pom.xml
+++ b/java-restify-spring-autoconfigure/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.github.ljtfreitas</groupId>
 		<artifactId>java-restify-group</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>java-restify-spring-autoconfigure</artifactId>
 

--- a/java-restify-spring-starter/pom.xml
+++ b/java-restify-spring-starter/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.github.ljtfreitas</groupId>
 		<artifactId>java-restify-group</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>java-restify-spring-starter</artifactId>
 
@@ -17,4 +17,5 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<packaging>ear</packaging>
 </project>

--- a/java-restify-spring/pom.xml
+++ b/java-restify-spring/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.github.ljtfreitas</groupId>
 		<artifactId>java-restify-group</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>java-restify-spring</artifactId>
 

--- a/java-restify/pom.xml
+++ b/java-restify/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.ljtfreitas</groupId>
 		<artifactId>java-restify-group</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>java-restify</artifactId>
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyHandler.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyHandler.java
@@ -40,12 +40,10 @@ public class RestifyProxyHandler implements InvocationHandler {
 
 	private final EndpointType endpointType;
 	private final EndpointMethodExecutor endpointMethodExecutor;
-	private final JavaDefaultMethodExecutor javaDefaultMethodExecutor;
 
 	public RestifyProxyHandler(EndpointType endpointType, EndpointMethodExecutor endpointMethodExecutor) {
 		this.endpointType = endpointType;
 		this.endpointMethodExecutor = endpointMethodExecutor;
-		this.javaDefaultMethodExecutor = new JavaDefaultMethodExecutor();
 	}
 
 	@Override
@@ -60,7 +58,7 @@ public class RestifyProxyHandler implements InvocationHandler {
 
 	private Object executeProxyMethod(Method method, Object proxy, Object[] args) {
 		try {
-			return javaDefaultMethodExecutor.execute(method, proxy, args);
+			return JavaDefaultMethodExecutor.execute(method, proxy, args);
 		} catch (Throwable e) {
 			throw new RestifyProxyMethodException("Error on execution method [" + method + "], "
 					+ "on proxy object type [" + proxy.getClass() + "], with method args " + Arrays.toString(args), e);

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequest.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequest.java
@@ -104,6 +104,10 @@ public class EndpointRequest {
 		}
 	}
 
+	public EndpointRequest replace(URI endpoint) {
+		return new EndpointRequest(endpoint, method, headers, body, responseType);
+	}
+
 	@Override
 	public String toString() {
 		StringBuilder report = new StringBuilder();

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/HttpRequestMessage.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/HttpRequestMessage.java
@@ -38,4 +38,6 @@ public interface HttpRequestMessage {
 
 	public Charset charset();
 
+	public EndpointRequest source();
+
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/apache/httpclient/ApacheHttpClientRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/apache/httpclient/ApacheHttpClientRequestFactory.java
@@ -70,7 +70,7 @@ public class ApacheHttpClientRequestFactory implements HttpClientRequestFactory 
 
 		HttpContext context = contextOf(httpRequest);
 
-		return new ApacheHttpClientRequest(httpClient, httpRequest, context, charset, endpointRequest.headers());
+		return new ApacheHttpClientRequest(httpClient, httpRequest, context, charset, endpointRequest.headers(), endpointRequest);
 	}
 
 	private HttpContext contextOf(HttpUriRequest httpRequest) {

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/apache/httpclient/ApacheHttpClientResponse.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/apache/httpclient/ApacheHttpClientResponse.java
@@ -34,6 +34,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
 
 import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.client.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.response.BaseHttpResponseMessage;
 import com.github.ljtfreitas.restify.http.client.response.StatusCode;
 
@@ -43,8 +44,8 @@ class ApacheHttpClientResponse extends BaseHttpResponseMessage {
 	private final HttpResponse httpResponse;
 
 	ApacheHttpClientResponse(StatusCode statusCode, Headers headers, InputStream body,
-			HttpEntity entity, HttpResponse httpResponse) {
-		super(statusCode, headers, body);
+			HttpEntity entity, HttpResponse httpResponse, HttpRequestMessage httpRequest) {
+		super(statusCode, headers, body, httpRequest);
 		this.entity = entity;
 		this.httpResponse = httpResponse;
 	}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequest.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequest.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 
 import com.github.ljtfreitas.restify.http.RestifyHttpException;
 import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
 import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
 import com.github.ljtfreitas.restify.http.client.response.StatusCode;
@@ -43,11 +44,13 @@ public class JdkHttpClientRequest implements HttpClientRequest {
 	private final HttpURLConnection connection;
 	private final Charset charset;
 	private final Headers headers;
+	private final EndpointRequest source;
 
-	public JdkHttpClientRequest(HttpURLConnection connection, Charset charset, Headers headers) {
+	public JdkHttpClientRequest(HttpURLConnection connection, Charset charset, Headers headers, EndpointRequest source) {
 		this.connection = connection;
 		this.charset = charset;
 		this.headers = new JdkHttpClientHeadersDecorator(connection, headers);
+		this.source = source;
 	}
 
 	@Override
@@ -73,7 +76,7 @@ public class JdkHttpClientRequest implements HttpClientRequest {
 
 		InputStream stream = connection.getErrorStream() == null ? connection.getInputStream() : connection.getErrorStream();
 
-		return new JdkHttpClientResponse(statusCode, headers, stream, connection);
+		return new JdkHttpClientResponse(statusCode, headers, stream, connection, this);
 	}
 
 	@Override
@@ -93,6 +96,11 @@ public class JdkHttpClientRequest implements HttpClientRequest {
 	@Override
 	public Headers headers() {
 		return headers;
+	}
+
+	@Override
+	public EndpointRequest source() {
+		return source;
 	}
 
 	private class JdkHttpClientHeadersDecorator extends Headers {

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestFactory.java
@@ -54,7 +54,7 @@ public class JdkHttpClientRequestFactory implements HttpClientRequestFactory {
 			connection.setDoOutput(true);
 			connection.setRequestMethod(request.method());
 
-			return new JdkHttpClientRequest(connection, charset, request.headers());
+			return new JdkHttpClientRequest(connection, charset, request.headers(), request);
 
 		} catch (IOException e) {
 			throw new RestifyHttpException(e);

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientResponse.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientResponse.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 
 import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.client.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.response.BaseHttpResponseMessage;
 import com.github.ljtfreitas.restify.http.client.response.StatusCode;
 
@@ -37,8 +38,8 @@ class JdkHttpClientResponse extends BaseHttpResponseMessage {
 
 	private final HttpURLConnection connection;
 
-	JdkHttpClientResponse(StatusCode statusCode, Headers headers, InputStream body, HttpURLConnection connection) {
-		super(statusCode, headers, body);
+	JdkHttpClientResponse(StatusCode statusCode, Headers headers, InputStream body, HttpURLConnection connection, HttpRequestMessage httpRequest) {
+		super(statusCode, headers, body, httpRequest);
 		this.connection = connection;
 	}
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/okhttp/OkHttpClientRequest.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/okhttp/OkHttpClientRequest.java
@@ -74,6 +74,11 @@ public class OkHttpClientRequest implements HttpClientRequest {
 	}
 
 	@Override
+	public EndpointRequest source() {
+		return endpointRequest;
+	}
+
+	@Override
 	public HttpResponseMessage execute() throws RestifyHttpException {
 		MediaType contentType = endpointRequest.headers().get("Content-Type").map(header -> MediaType.parse(header.value()))
 				.orElse(null);
@@ -107,7 +112,7 @@ public class OkHttpClientRequest implements HttpClientRequest {
 
 		InputStream stream = response.body().byteStream();
 
-		return new OkHttpClientResponse(statusCode, headers, stream, response);
+		return new OkHttpClientResponse(statusCode, headers, stream, response, this);
 	}
 
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/okhttp/OkHttpClientResponse.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/okhttp/OkHttpClientResponse.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.client.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.response.BaseHttpResponseMessage;
 import com.github.ljtfreitas.restify.http.client.response.StatusCode;
 
@@ -38,8 +39,8 @@ class OkHttpClientResponse extends BaseHttpResponseMessage {
 
 	private final Response response;
 
-	OkHttpClientResponse(StatusCode statusCode, Headers headers, InputStream body, Response response) {
-		super(statusCode, headers, body);
+	OkHttpClientResponse(StatusCode statusCode, Headers headers, InputStream body, Response response, HttpRequestMessage httpRequest) {
+		super(statusCode, headers, body, httpRequest);
 		this.response = response;
 	}
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/response/BaseHttpResponseMessage.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/response/BaseHttpResponseMessage.java
@@ -30,19 +30,27 @@ import static com.github.ljtfreitas.restify.http.client.Headers.CONTENT_LENGTH;
 import java.io.InputStream;
 
 import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.client.request.HttpRequestMessage;
 
 public abstract class BaseHttpResponseMessage implements HttpResponseMessage {
 
 	private final StatusCode statusCode;
 	private final Headers headers;
 	private final InputStream body;
+	private final HttpRequestMessage httpRequest;
 
-	protected BaseHttpResponseMessage(StatusCode statusCode, Headers headers, InputStream body) {
+	protected BaseHttpResponseMessage(StatusCode statusCode, Headers headers, InputStream body, HttpRequestMessage httpRequest) {
 		this.statusCode = statusCode;
 		this.headers = headers;
 		this.body = body;
+		this.httpRequest = httpRequest;
 	}
-	
+
+	@Override
+	public HttpRequestMessage request() {
+		return httpRequest;
+	}
+
 	@Override
 	public StatusCode code() {
 		return statusCode;

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/response/HttpResponseMessage.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/response/HttpResponseMessage.java
@@ -29,6 +29,7 @@ import java.io.Closeable;
 import java.io.InputStream;
 
 import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.client.request.HttpRequestMessage;
 
 public interface HttpResponseMessage extends Closeable {
 
@@ -39,4 +40,6 @@ public interface HttpResponseMessage extends Closeable {
 	public InputStream body();
 
 	public boolean isReadable();
+
+	public HttpRequestMessage request();
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaDefaultMethodExecutor.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaDefaultMethodExecutor.java
@@ -38,16 +38,16 @@ import com.github.ljtfreitas.restify.http.RestifyProxyMethodException;
 
 public class JavaDefaultMethodExecutor {
 
-	private final Map<Method, MethodHandle> cache = new ConcurrentHashMap<>();
+	private static final Map<Method, MethodHandle> cache = new ConcurrentHashMap<>();
 
-	public Object execute(Method method, Object target, Object[] args) throws Throwable {
+	public static Object execute(Method method, Object target, Object[] args) throws Throwable {
 		MethodHandle handle = cache.compute(method,
 				(m, h) -> Optional.ofNullable(h).orElseGet(() -> bind(method, target)));
 
 		return handle.invokeWithArguments(args);
 	}
 
-	private MethodHandle bind(Method method, Object target) {
+	private static MethodHandle bind(Method method, Object target) {
 		try {
 			Constructor<Lookup> constructor = Lookup.class.getDeclaredConstructor(Class.class, int.class);
 			constructor.setAccessible(true);

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestWriterTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestWriterTest.java
@@ -49,7 +49,7 @@ public class EndpointRequestWriterTest {
 		EndpointRequest endpointRequest = new EndpointRequest(new URI("http://my.api.com/path"), "POST", headers, body,
 				String.class);
 
-		SimpleHttpRequestMessage httpRequestMessage = new SimpleHttpRequestMessage(headers);
+		SimpleHttpRequestMessage httpRequestMessage = new SimpleHttpRequestMessage(endpointRequest);
 
 		endpointRequestWriter.write(endpointRequest, httpRequestMessage);
 
@@ -61,7 +61,7 @@ public class EndpointRequestWriterTest {
 	public void shouldThrowExceptionWhenHttpRequestMessageHasNoBody() throws Exception {
 		EndpointRequest endpointRequest = new EndpointRequest(new URI("http://my.api.com/path"), "POST");
 
-		endpointRequestWriter.write(endpointRequest, new SimpleHttpRequestMessage());
+		endpointRequestWriter.write(endpointRequest, new SimpleHttpRequestMessage(endpointRequest));
 	}
 
 	@Test
@@ -73,7 +73,7 @@ public class EndpointRequestWriterTest {
 		EndpointRequest endpointRequest = new EndpointRequest(new URI("http://my.api.com/path"), "POST", headers, body,
 				String.class);
 
-		SimpleHttpRequestMessage httpRequestMessage = new SimpleHttpRequestMessage(headers);
+		SimpleHttpRequestMessage httpRequestMessage = new SimpleHttpRequestMessage(endpointRequest);
 
 		endpointRequestWriter.write(endpointRequest, httpRequestMessage);
 

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/RestifyEndpointRequestExecutorTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/RestifyEndpointRequestExecutorTest.java
@@ -23,11 +23,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import com.github.ljtfreitas.restify.http.RestifyHttpException;
 import com.github.ljtfreitas.restify.http.client.Headers;
 import com.github.ljtfreitas.restify.http.client.charset.Encoding;
-import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
-import com.github.ljtfreitas.restify.http.client.request.EndpointRequestWriter;
-import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
-import com.github.ljtfreitas.restify.http.client.request.HttpClientRequestFactory;
-import com.github.ljtfreitas.restify.http.client.request.RestifyEndpointRequestExecutor;
 import com.github.ljtfreitas.restify.http.client.request.interceptor.EndpointRequestInterceptorStack;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponseReader;
@@ -74,7 +69,7 @@ public class RestifyEndpointRequestExecutorTest {
 		EndpointRequest endpointRequest = new EndpointRequest(new URI("http://my.api.com/path"), "GET", String.class);
 
 		when(httpClientRequestFactoryMock.createOf(endpointRequest))
-			.thenReturn(new SimpleHttpClientRequest(response));
+			.thenReturn(new SimpleHttpClientRequest(endpointRequest, response));
 
 		Object result = endpointRequestExecutor.execute(endpointRequest);
 
@@ -91,7 +86,7 @@ public class RestifyEndpointRequestExecutorTest {
 		EndpointRequest endpointRequest = new EndpointRequest(new URI("http://my.api.com/path"), "POST", new Headers(),
 				body, String.class);
 
-		SimpleHttpClientRequest request = new SimpleHttpClientRequest(response);
+		SimpleHttpClientRequest request = new SimpleHttpClientRequest(endpointRequest, response);
 
 		when(httpClientRequestFactoryMock.createOf(endpointRequest))
 			.thenReturn(request);
@@ -106,12 +101,13 @@ public class RestifyEndpointRequestExecutorTest {
 
 	private class SimpleHttpClientRequest implements HttpClientRequest {
 
+		private final EndpointRequest source;
 		private final HttpResponseMessage response;
 
 		private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-		private final Headers headers = new Headers();
 
-		public SimpleHttpClientRequest(HttpResponseMessage response) {
+		public SimpleHttpClientRequest(EndpointRequest source, HttpResponseMessage response) {
+			this.source = source;
 			this.response = response;
 		}
 
@@ -132,7 +128,12 @@ public class RestifyEndpointRequestExecutorTest {
 
 		@Override
 		public Headers headers() {
-			return headers;
+			return source.headers();
+		}
+
+		@Override
+		public EndpointRequest source() {
+			return source;
 		}
 	}
 

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/SimpleHttpRequestMessage.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/SimpleHttpRequestMessage.java
@@ -7,19 +7,19 @@ import org.apache.commons.io.output.ByteArrayOutputStream;
 
 import com.github.ljtfreitas.restify.http.client.Headers;
 import com.github.ljtfreitas.restify.http.client.charset.Encoding;
-import com.github.ljtfreitas.restify.http.client.request.HttpRequestMessage;
 
 public class SimpleHttpRequestMessage implements HttpRequestMessage {
 
 	private final OutputStream output;
 	private final Headers headers;
+	private final EndpointRequest source;
 
-	public SimpleHttpRequestMessage() {
-		this(new ByteArrayOutputStream(), new Headers());
+	public SimpleHttpRequestMessage(EndpointRequest source) {
+		this(source, new ByteArrayOutputStream(), source.headers());
 	}
 
 	public SimpleHttpRequestMessage(Headers headers) {
-		this(new ByteArrayOutputStream(), headers);
+		this(null, new ByteArrayOutputStream(), headers);
 	}
 
 	public SimpleHttpRequestMessage(OutputStream output) {
@@ -27,6 +27,11 @@ public class SimpleHttpRequestMessage implements HttpRequestMessage {
 	}
 
 	public SimpleHttpRequestMessage(OutputStream output, Headers headers) {
+		this(null, output, headers);
+	}
+
+	private SimpleHttpRequestMessage(EndpointRequest source, OutputStream output, Headers headers) {
+		this.source = source;
 		this.output = output;
 		this.headers = headers;
 	}
@@ -44,5 +49,10 @@ public class SimpleHttpRequestMessage implements HttpRequestMessage {
 	@Override
 	public Headers headers() {
 		return headers;
+	}
+
+	@Override
+	public EndpointRequest source() {
+		return source;
 	}
 }

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/response/BaseHttpResponseMessageTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/response/BaseHttpResponseMessageTest.java
@@ -69,11 +69,11 @@ public class BaseHttpResponseMessageTest {
 	private class StubHttpResponseMessage extends BaseHttpResponseMessage {
 
 		public StubHttpResponseMessage(StatusCode statusCode) {
-			super(statusCode, new Headers(), null);
+			super(statusCode, new Headers(), null, null);
 		}
 
 		public StubHttpResponseMessage(StatusCode statusCode, Headers headers) {
-			super(statusCode, headers, null);
+			super(statusCode, headers, null, null);
 		}
 
 		@Override

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/response/SimpleHttpResponseMessage.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/response/SimpleHttpResponseMessage.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.client.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.response.BaseHttpResponseMessage;
 import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
 import com.github.ljtfreitas.restify.http.client.response.StatusCode;
@@ -30,7 +31,7 @@ public class SimpleHttpResponseMessage implements HttpResponseMessage {
 	}
 
 	public SimpleHttpResponseMessage(StatusCode code, Headers headers, InputStream input) {
-		this.delegate = new BaseHttpResponseMessage(code, headers, input) {
+		this.delegate = new BaseHttpResponseMessage(code, headers, input, null) {
 			@Override
 			public void close() throws IOException {
 				input.close();
@@ -61,5 +62,10 @@ public class SimpleHttpResponseMessage implements HttpResponseMessage {
 	@Override
 	public boolean isReadable() {
 		return delegate.isReadable();
+	}
+
+	@Override
+	public HttpRequestMessage request() {
+		return delegate.request();
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 		<module>java-restify-spring</module>
 		<module>java-restify-spring-autoconfigure</module>
 		<module>java-restify-spring-starter</module>
+		<module>java-restify-netflix</module>
 	</modules>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.ljtfreitas</groupId>
 	<artifactId>java-restify-group</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.1.1-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
## Suporte para frameworks Netflix :movie_camera:

:electric_plug: Criação de novo artefato: *java-restfy-netflix* 

--------------------------------
### :package: Load balancer client-side
- Implementa load balancer client-side utilizando o Ribbon;
- Implementa service discovery utilizando o Zookeeper, para utilização com o Ribbon.

--------------------------------
### :package: Circuit breaker
- Implementa suporte para o Hystrix;
- Permite utilizar *HystrixCommand* como retorno de métodos
- Cria nova anotação *OnCircuitBreaker*, para indicar que a requisição http representada pelo método deve ser envolvida por um *HystrixCommand*
- Permite utilizar fallbacks do Hystrix, para devolver valores conhecidos caso a requisição http do método falhe.
