### PR TITLE
[endpoint-method-annotations] Refatoração do nome da classe EndpointMethodAnnotations

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethod.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethod.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Type;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaMethodAnnotations;
 import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
 
 public class EndpointMethod {
@@ -42,7 +43,7 @@ public class EndpointMethod {
 	private final EndpointMethodParameters parameters;
 	private final EndpointHeaders headers;
 	private final JavaType returnType;
-	private final EndpointMethodAnnotations annotations;
+	private final JavaMethodAnnotations annotations;
 
 	public EndpointMethod(Method javaMethod, String path, String httpMethod) {
 		this(javaMethod, path, httpMethod, new EndpointMethodParameters());
@@ -70,7 +71,7 @@ public class EndpointMethod {
 		this.parameters = nonNull(parameters, "EndpointMethod needs a parameters collection.");
 		this.headers = nonNull(headers, "EndpointMethod needs a HTTP headers collection.");
 		this.returnType = returnType;
-		this.annotations = new EndpointMethodAnnotations(javaMethod);
+		this.annotations = new JavaMethodAnnotations(javaMethod);
 	}
 
 	public String path() {
@@ -101,7 +102,7 @@ public class EndpointMethod {
 		return returnType.voidType() && !parameters.callbacks().isEmpty();
 	}
 
-	public EndpointMethodAnnotations annotations() {
+	public JavaMethodAnnotations annotations() {
 		return annotations;
 	}
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaMethodAnnotations.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaMethodAnnotations.java
@@ -23,7 +23,7 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.contract.metadata;
+package com.github.ljtfreitas.restify.http.contract.metadata.reflection;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -31,12 +31,12 @@ import java.util.Optional;
 
 import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaAnnotationScanner;
 
-public class EndpointMethodAnnotations {
+public class JavaMethodAnnotations {
 
 	private final Method javaMethod;
 	private final Class<?> javaType;
 
-	public EndpointMethodAnnotations(Method javaMethod) {
+	public JavaMethodAnnotations(Method javaMethod) {
 		this.javaMethod = javaMethod;
 		this.javaType = javaMethod.getDeclaringClass();
 	}


### PR DESCRIPTION
## Descrição
- Modifica o nome e o pacote da classe *EndpointMethodAnnotations*. Essa classe representa um wrapper para o conjunto de anotações do método, mas suas operações são realizadas sobre o método da interface (instância de java.lang.reflect.Method) e não sobre o EndpointMethod.

### Changelog :hammer:
- Refatora o nome da classe *EndpointMethodAnnotations* para *JavaMethodAnnotations* 
- Move a classe para o pacote *contract.metadata.reflection*