### PR TITLE
[spring-web-mvc-contract] Modifica parse dos parâmetros consumes e produces da anotacao RequestMapping do Spring

### DIFF
--- a/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/contract/metadata/reflection/SpringWebRequestMappingMetadata.java
+++ b/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/contract/metadata/reflection/SpringWebRequestMappingMetadata.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -73,27 +74,27 @@ public class SpringWebRequestMappingMetadata {
 					.orElseGet(() -> new String[0]);
 	}
 
-	private Optional<String> consumes() {
+	private Optional<String> produces() {
 		return Optional.ofNullable(mapping)
-			.map(m -> m.consumes())
+			.map(m -> m.produces())
 				.filter(c -> c.length >= 1)
 					.map(h -> Arrays.stream(h)
 							.filter(c -> c != null && !c.isEmpty())
 								.collect(Collectors.joining(", ")))
-				.map(c -> "Accept=".concat(c));
+				.map(c -> HttpHeaders.ACCEPT + "=" + c);
 	}
 
-	private Optional<String> produces() {
+	private Optional<String> consumes() {
 		String[] produces = Optional.ofNullable(mapping)
-			.map(m -> m.produces())
+			.map(m -> m.consumes())
 				.filter(p -> p.length <= 1)
-					.orElseThrow(() -> new IllegalArgumentException("[produces] parameter (of @RequestMapping annotation) "
+					.orElseThrow(() -> new IllegalArgumentException("[consumes] parameter (of @RequestMapping annotation) "
 							+ "must have only single value."));
 
 		return (produces.length == 0) ? Optional.empty()
 				: Optional.ofNullable(produces[0])
 					.filter(p -> !p.isEmpty())
-						.map(p -> "Content-Type=".concat(p));
+						.map(p -> HttpHeaders.CONTENT_TYPE + "=" + p);
 	}
 
 	@Override

--- a/java-restify-spring/src/test/java/com/github/ljtfreitas/restify/http/spring/contract/SpringWebContractReaderTest.java
+++ b/java-restify-spring/src/test/java/com/github/ljtfreitas/restify/http/spring/contract/SpringWebContractReaderTest.java
@@ -1,6 +1,7 @@
 package com.github.ljtfreitas.restify.http.spring.contract;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Matchers.anyString;
@@ -119,6 +120,10 @@ public class SpringWebContractReaderTest {
 		assertTrue(bodyParameter.isPresent());
 		assertEquals("body", bodyParameter.get().name());
 		assertTrue(bodyParameter.get().body());
+
+		EndpointHeader acceptHeader = endpointMethod.headers().first("Accept").orElse(null);
+		assertNotNull(acceptHeader);
+		assertEquals("{contentType}", acceptHeader.value());
 	}
 
 	@Test
@@ -175,6 +180,10 @@ public class SpringWebContractReaderTest {
 		assertTrue(headerParameter.isPresent());
 		assertEquals("customArgumentContentType", headerParameter.get().name());
 		assertTrue(headerParameter.get().header());
+
+		EndpointHeader acceptHeader = endpointMethod.headers().first("Accept").get();
+		assertNotNull(acceptHeader);
+		assertEquals("{customArgumentContentType}", acceptHeader.value());
 	}
 
 	@Test
@@ -328,8 +337,8 @@ public class SpringWebContractReaderTest {
 		@RequestMapping(path = "path", method = RequestMethod.GET)
 		public String pathWithoutSlash();
 
-		@RequestMapping(path = "/mergeHeaders", method = RequestMethod.GET, produces = "application/json",
-				consumes = {"application/json", "application/xml" }, headers = "User-Agent=Spring-Restify-Agent")
+		@RequestMapping(path = "/mergeHeaders", method = RequestMethod.GET, produces = {"application/json", "application/xml"},
+				consumes = "application/json", headers = "User-Agent=Spring-Restify-Agent")
 		public String mergeHeaders();
 
 		@RequestMapping(value = "/{customArgumentPath}", method = RequestMethod.GET,


### PR DESCRIPTION
## Descrição
Modifica a geração de http headers aplicada aos atributos *consumes* e *produces* da anotação *RequestMapping* do Spring. A implementação inicial considerava que, da perspectiva do cliente da api, faria sentido inverter o sentido original desses atributos, gerando o header **Content-Type** a partir do atributo *produces*, e o header **Accept** a partir do atributo *consumes*.

Este pull request inverte esse tratamento, tornando-o mais próximo da utilização no backend do Spring MVC: o atributo *produces* irá gerar o header **Accept**, e o atributo *consumes* irá gerar o header **Content-Type**

## Changelog :hammer: 
- Passa a utilizar o atributo produces (da anotação RequestMapping) para gerar o header Accept
- Passa a utilizar o atributo consumes (da anotação RequestMapping) para gerar o header Content-Type; inclui validação para não permitir informar apenas um elemento neste atributo.
