### PR TITLE
[java-restify-jaxrs] Suporte para anotações do JAX-RS

### DIFF
--- a/java-restify-jaxrs-contract/pom.xml
+++ b/java-restify-jaxrs-contract/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.github.ljtfreitas</groupId>
+		<artifactId>java-restify-group</artifactId>
+		<version>1.2.2-SNAPSHOT</version>
+	</parent>
+	<artifactId>java-restify-jaxrs-contract</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.ws.rs</groupId>
+			<artifactId>javax.ws.rs-api</artifactId>
+			<version>2.0.1</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/JaxRsContractReader.java
+++ b/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/JaxRsContractReader.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.jaxrs.contract;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.stream.Collectors;
+
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointHeader;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointHeaders;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameter.EndpointMethodParameterType;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameterSerializer;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameters;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointTarget;
+import com.github.ljtfreitas.restify.http.contract.metadata.RestifyContractReader;
+import com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.JaxRsEndpointHeader;
+import com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.reflection.JaxRsJavaMethodMetadata;
+import com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.reflection.JaxRsJavaMethodParameterMetadata;
+import com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.reflection.JaxRsJavaMethodParameters;
+import com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.reflection.JaxRsJavaTypeMetadata;
+
+
+public class JaxRsContractReader implements RestifyContractReader {
+
+	@Override
+	public EndpointMethod read(EndpointTarget target, java.lang.reflect.Method javaMethod) {
+		JaxRsJavaTypeMetadata javaTypeMetadata = new JaxRsJavaTypeMetadata(target.type());
+
+		JaxRsJavaMethodMetadata javaMethodMetadata = new JaxRsJavaMethodMetadata(javaMethod);
+
+		JaxRsJavaMethodParameters javaMethodParameters = new JaxRsJavaMethodParameters(javaMethod, target.type());
+
+		String endpointPath = endpointTarget(target) + endpointTypePath(javaTypeMetadata) + endpointMethodPath(javaMethodMetadata);
+
+		String endpointHttpMethod = javaMethodMetadata.httpMethod().value().toUpperCase();
+
+		EndpointMethodParameters parameters = endpointMethodParameters(javaMethodParameters);
+
+		EndpointHeaders headers = endpointMethodHeaders(javaTypeMetadata, javaMethodMetadata, javaMethodParameters);
+
+		Type returnType = javaMethodMetadata.returnType(target.type());
+
+		return new EndpointMethod(javaMethod, endpointPath, endpointHttpMethod, parameters, headers, returnType);
+	}
+
+	private String endpointTarget(EndpointTarget target) {
+		return target.endpoint().orElse("");
+	}
+
+	private String endpointTypePath(JaxRsJavaTypeMetadata javaTypeMetadata) {
+		return Arrays.stream(javaTypeMetadata.paths())
+				.map(p -> p.endsWith("/") ? p.substring(0, p.length() - 1) : p)
+					.collect(Collectors.joining());
+	}
+
+	private String endpointMethodPath(JaxRsJavaMethodMetadata javaMethodMetadata) {
+		String endpointMethodPath = javaMethodMetadata.path().value();
+		return (endpointMethodPath.startsWith("/") ? endpointMethodPath : "/" + endpointMethodPath);
+	}
+
+	private EndpointMethodParameters endpointMethodParameters(JaxRsJavaMethodParameters javaMethodParameters) {
+		EndpointMethodParameters parameters = new EndpointMethodParameters();
+
+		for (int position = 0; position < javaMethodParameters.size(); position ++) {
+			JaxRsJavaMethodParameterMetadata javaMethodParameterMetadata = javaMethodParameters.get(position);
+
+			EndpointMethodParameterType type = javaMethodParameterMetadata.path() ? EndpointMethodParameterType.PATH :
+				javaMethodParameterMetadata.header() ? EndpointMethodParameterType.HEADER :
+					javaMethodParameterMetadata.query() ? EndpointMethodParameterType.QUERY_STRING :
+						EndpointMethodParameterType.BODY;
+
+			EndpointMethodParameterSerializer serializer = javaMethodParameterMetadata.serializer();
+
+			parameters.put(new EndpointMethodParameter(position, javaMethodParameterMetadata.name(), javaMethodParameterMetadata.javaType(), type, serializer));
+		}
+
+		return parameters;
+	}
+
+	private EndpointHeaders endpointMethodHeaders(JaxRsJavaTypeMetadata javaTypeMetadata, JaxRsJavaMethodMetadata javaMethodMetadata, 
+			JaxRsJavaMethodParameters javaMethodParameters) {
+
+		Collection<JaxRsEndpointHeader> headers = new LinkedHashSet<>();
+		headers.addAll(Arrays.asList(javaTypeMetadata.headers()));
+		headers.addAll(Arrays.asList(javaMethodMetadata.headers()));
+		headers.addAll(Arrays.asList(javaMethodParameters.headers()));
+
+		return new EndpointHeaders(headers.stream().map(h -> new EndpointHeader(h.name(), h.value())).collect(Collectors.toSet()));
+	}
+}

--- a/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/JaxRsEndpointHeader.java
+++ b/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/JaxRsEndpointHeader.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.jaxrs.contract.metadata;
+
+import java.util.Objects;
+
+public class JaxRsEndpointHeader {
+
+	private final String name;
+	private final String value;
+
+	public JaxRsEndpointHeader(String name, String value) {
+		this.name = name;
+		this.value = value;
+	}
+
+	public String name() {
+		return name;
+	}
+
+	public String value() {
+		return value;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof JaxRsEndpointHeader) {
+			JaxRsEndpointHeader that = (JaxRsEndpointHeader) obj;
+			return name.equals(that.name);
+
+		} else return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name);
+	}
+}

--- a/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/reflection/JaxRsJavaMethodMetadata.java
+++ b/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/reflection/JaxRsJavaMethodMetadata.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.reflection;
+
+import static com.github.ljtfreitas.restify.http.util.Preconditions.isTrue;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.HttpHeaders;
+
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaAnnotationScanner;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaTypeResolver;
+import com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.JaxRsEndpointHeader;
+
+public class JaxRsJavaMethodMetadata {
+
+	private final java.lang.reflect.Method javaMethod;
+	private final Path path;
+	private final HttpMethod httpMethod;
+	private final Consumes consumes;
+	private final Produces produces;
+
+	public JaxRsJavaMethodMetadata(java.lang.reflect.Method javaMethod) {
+		this.javaMethod = javaMethod;
+
+		this.path = Optional.ofNullable(javaMethod.getAnnotation(Path.class))
+				.orElseThrow(() -> new IllegalArgumentException("Method " + javaMethod + " does not have a @Path annotation"));
+
+		this.httpMethod = Optional.ofNullable(new JavaAnnotationScanner(javaMethod).scan(HttpMethod.class))
+				.orElseThrow(() -> new IllegalArgumentException("Method " + javaMethod + " does not have a @HttpMethod annotation"));
+
+		this.consumes = javaMethod.getAnnotation(Consumes.class);
+		this.produces = javaMethod.getAnnotation(Produces.class);
+	}
+
+	public Path path() {
+		return path;
+	}
+
+	public HttpMethod httpMethod() {
+		return httpMethod;
+	}
+
+	public JaxRsEndpointHeader[] headers() {
+		Collection<JaxRsEndpointHeader> headers = new LinkedHashSet<>();
+
+		Optional.ofNullable(consumes)
+			.ifPresent(c -> headers.add(contentType()));
+
+		Optional.ofNullable(produces)
+			.ifPresent(c -> headers.add(accept()));
+
+		return headers.toArray(new JaxRsEndpointHeader[0]);
+	}
+
+	private JaxRsEndpointHeader contentType() {
+		isTrue(consumes.value().length <= 1, "Only one value is allowed for the @Consumes annotation.");
+		isTrue(consumes.value().length == 1, "Enter the @Consumes annotation value.");
+
+		return new JaxRsEndpointHeader(HttpHeaders.CONTENT_TYPE, consumes.value()[0]);
+	}
+
+	private JaxRsEndpointHeader accept() {
+		isTrue(produces.value().length > 0, "Enter the @Produces annotation value.");
+
+		String accept = Arrays.stream(produces.value()).collect(Collectors.joining(", "));
+
+		return new JaxRsEndpointHeader(HttpHeaders.ACCEPT, accept);
+	}
+
+	public Type returnType(Class<?> rawType) {
+		return new JavaTypeResolver(rawType).returnTypeOf(javaMethod);
+	}
+}

--- a/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/reflection/JaxRsJavaMethodParameterMetadata.java
+++ b/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/reflection/JaxRsJavaMethodParameterMetadata.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.reflection;
+
+import static com.github.ljtfreitas.restify.http.util.Preconditions.isTrue;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Optional;
+
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameterSerializer;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodQueryParameterSerializer;
+import com.github.ljtfreitas.restify.http.contract.metadata.SimpleEndpointMethodParameterSerializer;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaTypeResolver;
+
+public class JaxRsJavaMethodParameterMetadata {
+
+	private final JavaType type;
+	private final String name;
+	private final Annotation annotationParameter;
+	private final EndpointMethodParameterSerializer serializer;
+
+	public JaxRsJavaMethodParameterMetadata(java.lang.reflect.Parameter javaMethodParameter, Class<?> targetClassType) {
+		this.type = JavaType.of(new JavaTypeResolver(targetClassType).parameterizedTypeOf(javaMethodParameter));
+
+		PathParam pathParameter = javaMethodParameter.getAnnotation(PathParam.class);
+		HeaderParam headerParameter = javaMethodParameter.getAnnotation(HeaderParam.class);
+		QueryParam queryParameter = javaMethodParameter.getAnnotation(QueryParam.class);
+
+		isTrue(javaMethodParameter.getAnnotations().length <= 1, "Parameter " + javaMethodParameter + " has more than one annotation.");
+
+		this.annotationParameter = Arrays.asList(pathParameter, headerParameter, queryParameter)
+				.stream().filter(a -> a != null).findFirst().orElse(null);
+
+		this.name = Optional.ofNullable(pathParameter)
+				.map(PathParam::value).filter(s -> !s.trim().isEmpty())
+					.orElseGet(() -> Optional.ofNullable(headerParameter)
+						.map(HeaderParam::value).filter(s -> !s.trim().isEmpty())
+							.orElseGet(() -> Optional.ofNullable(queryParameter)
+								.map(QueryParam::value).filter(s -> !s.trim().isEmpty())
+									.orElseGet(() -> Optional.ofNullable(javaMethodParameter.getName())
+											.orElseThrow(() -> new IllegalStateException("Could not get the name of the parameter " + javaMethodParameter)))));
+
+		this.serializer = (queryParameter != null) ? new EndpointMethodQueryParameterSerializer()
+				: new SimpleEndpointMethodParameterSerializer();
+	}
+
+	public String name() {
+		return name;
+	}
+
+	public JavaType javaType() {
+		return type;
+	}
+
+	public boolean path() {
+		return annotationParameter instanceof PathParam;
+	}
+
+	public boolean body() {
+		return annotationParameter == null;
+	}
+
+	public boolean header() {
+		return annotationParameter instanceof HeaderParam;
+	}
+
+	public boolean query() {
+		return annotationParameter instanceof QueryParam;
+	}
+
+	public EndpointMethodParameterSerializer serializer() {
+		return serializer;
+	}
+
+	@SuppressWarnings("unchecked")
+	public <A extends Annotation> A annotation(Class<A> annotationType) {
+		return (A) annotationParameter;
+	}
+}

--- a/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/reflection/JaxRsJavaMethodParameters.java
+++ b/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/reflection/JaxRsJavaMethodParameters.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.reflection;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.HeaderParam;
+
+import com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.JaxRsEndpointHeader;
+
+public class JaxRsJavaMethodParameters {
+
+	private final List<JaxRsJavaMethodParameterMetadata> parameters;
+
+	public JaxRsJavaMethodParameters(Method javaMethod, Class<?> javaType) {
+		this.parameters = Arrays.stream(javaMethod.getParameters())
+				.map(p -> new JaxRsJavaMethodParameterMetadata(p, javaType))
+					.collect(Collectors.toList());
+	}
+
+	public int size() {
+		return parameters.size();
+	}
+
+	public JaxRsJavaMethodParameterMetadata get(int position) {
+		return parameters.get(position);
+	}
+
+	public JaxRsEndpointHeader[] headers() {
+		return parameters.stream().filter(p -> p.header())
+			.map(p -> p.annotation(HeaderParam.class))
+				.filter(a -> a.value() != null && !"".equals(a.value()))
+					.map(a -> new JaxRsEndpointHeader(a.value(), "{" + a.value() + "}"))
+						.toArray(s -> new JaxRsEndpointHeader[s]);
+	}
+}

--- a/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/reflection/JaxRsJavaTypeMetadata.java
+++ b/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/reflection/JaxRsJavaTypeMetadata.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.reflection;
+
+import static com.github.ljtfreitas.restify.http.util.Preconditions.isFalse;
+import static com.github.ljtfreitas.restify.http.util.Preconditions.isTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.HttpHeaders;
+
+import com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.JaxRsEndpointHeader;
+
+public class JaxRsJavaTypeMetadata {
+
+	private final Class<?> javaType;
+	private final ApplicationPath applicationPath;
+	private final Path path;
+	private final Consumes consumes;
+	private final Produces produces;
+	private final JaxRsJavaTypeMetadata parent;
+
+	public JaxRsJavaTypeMetadata(Class<?> javaType) {
+		isTrue(javaType.isInterface(), "Your type must be a Java interface.");
+		isTrue(javaType.getInterfaces().length <= 1, "Only single inheritance is supported.");
+
+		this.javaType = javaType;
+		this.parent = javaType.getInterfaces().length == 1 ? new JaxRsJavaTypeMetadata(javaType.getInterfaces()[0]) : null;
+
+		this.applicationPath = javaType.getAnnotation(ApplicationPath.class);
+		this.path = javaType.getAnnotation(Path.class);
+
+		isFalse(applicationPath != null && path != null,
+				"Invalid use of the @Path and @ApplicationPath annotations at the top of the interface. Use only one.");
+
+		this.consumes = javaType.getAnnotation(Consumes.class);
+		this.produces = javaType.getAnnotation(Produces.class);
+	}
+
+	public String[] paths() {
+		return Stream.concat(Arrays.stream(allPaths()), Arrays.stream(allApplicationPaths()))
+				.toArray(s -> new String[s]);
+	}
+
+	private String[] allPaths() {
+		ArrayList<String> paths = new ArrayList<>();
+
+		Optional.ofNullable(parent)
+			.map(p -> p.allPaths())
+				.ifPresent(array -> Collections.addAll(paths, array));
+
+		Optional.ofNullable(path).map(Path::value)
+			.ifPresent(p -> paths.add(p));
+
+		return paths.toArray(new String[0]);
+	}
+
+	private String[] allApplicationPaths() {
+		ArrayList<String> applicationPaths = new ArrayList<>();
+
+		Optional.ofNullable(parent)
+			.map(p -> p.allApplicationPaths())
+				.ifPresent(array -> Collections.addAll(applicationPaths, array));
+
+		Optional.ofNullable(applicationPath).map(ApplicationPath::value)
+			.ifPresent(p -> applicationPaths.add(p));
+
+		return applicationPaths.toArray(new String[0]);
+	}
+
+	public JaxRsEndpointHeader[] headers() {
+		Collection<JaxRsEndpointHeader> headers = new LinkedHashSet<>();
+
+		Optional.ofNullable(parent)
+			.ifPresent(p -> headers.addAll(Arrays.asList(parent.headers())));
+
+		Optional.ofNullable(consumes)
+			.ifPresent(c -> headers.add(contentType()));
+
+		Optional.ofNullable(produces)
+			.ifPresent(c -> headers.add(accept()));
+
+		return headers.toArray(new JaxRsEndpointHeader[0]);
+	}
+
+	private JaxRsEndpointHeader contentType() {
+		isTrue(consumes.value().length <= 1, "Only one value is allowed for the @Consumes annotation.");
+		isTrue(consumes.value().length == 1, "Enter the @Consumes annotation value.");
+
+		return new JaxRsEndpointHeader(HttpHeaders.CONTENT_TYPE, consumes.value()[0]);
+	}
+
+	private JaxRsEndpointHeader accept() {
+		isTrue(produces.value().length > 0, "Enter the @Produces annotation value.");
+
+		String accept = Arrays.stream(produces.value()).collect(Collectors.joining(", "));
+
+		return new JaxRsEndpointHeader(HttpHeaders.ACCEPT, accept);
+	}
+
+	public Class<?> javaType() {
+		return javaType;
+	}
+
+	public Optional<JaxRsJavaTypeMetadata> parent() {
+		return Optional.ofNullable(parent);
+	}
+}

--- a/java-restify-jaxrs-contract/src/test/java/com/github/ljtfreitas/restify/http/jaxrs/contract/JaxRsContractReaderTest.java
+++ b/java-restify-jaxrs-contract/src/test/java/com/github/ljtfreitas/restify/http/jaxrs/contract/JaxRsContractReaderTest.java
@@ -1,0 +1,545 @@
+package com.github.ljtfreitas.restify.http.jaxrs.contract;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointHeader;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointTarget;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleGenericArrayType;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleParameterizedType;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleWildcardType;
+import com.github.ljtfreitas.restify.http.jaxrs.contract.JaxRsContractReader;
+
+public class JaxRsContractReaderTest {
+
+	private EndpointTarget myApiTypeTarget;
+
+	private EndpointTarget myInheritanceApiTarget;
+
+	private EndpointTarget myGenericSpecificApiTarget;
+
+	private EndpointTarget myContextApiTarget;
+
+	private JaxRsContractReader jaxRsContractReader;
+
+	@Before
+	public void setup() {
+		myApiTypeTarget = new EndpointTarget(MyApiType.class);
+
+		myInheritanceApiTarget = new EndpointTarget(MyInheritanceApiType.class);
+
+		myGenericSpecificApiTarget = new EndpointTarget(MySpecificApi.class);
+
+		myContextApiTarget = new EndpointTarget(MyContextApi.class, "http://my.api.com");
+
+		jaxRsContractReader = new JaxRsContractReader();
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenMethodHasSingleParameter() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("method", new Class[] { String.class }));
+
+		assertEquals("GET", endpointMethod.httpMethod());
+		assertEquals("http://my.api.com/{path}", endpointMethod.path());
+		assertEquals(String.class, endpointMethod.returnType().classType());
+
+		Optional<EndpointMethodParameter> parameter = endpointMethod.parameters().find("path");
+		assertTrue(parameter.isPresent());
+
+		assertEquals(0, parameter.get().position());
+		assertTrue(parameter.get().path());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenMethodHasMultiplesParameters() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("method", new Class[] { String.class, String.class, Object.class }));
+
+		assertEquals("GET", endpointMethod.httpMethod());
+		assertEquals("http://my.api.com/{path}", endpointMethod.path());
+		assertEquals(String.class, endpointMethod.returnType().classType());
+
+		Optional<EndpointMethodParameter> pathParameter = endpointMethod.parameters().get(0);
+		assertTrue(pathParameter.isPresent());
+		assertEquals("path", pathParameter.get().name());
+		assertTrue(pathParameter.get().path());
+
+		Optional<EndpointMethodParameter> headerParameter = endpointMethod.parameters().get(1);
+		assertTrue(headerParameter.isPresent());
+		assertEquals("Content-Type", headerParameter.get().name());
+		assertTrue(headerParameter.get().header());
+
+		Optional<EndpointMethodParameter> bodyParameter = endpointMethod.parameters().get(2);
+		assertTrue(bodyParameter.isPresent());
+		assertEquals("body", bodyParameter.get().name());
+		assertTrue(bodyParameter.get().body());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWithHeadersWhenMethodHasHeaderParameters() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("headers", new Class[] { String.class, String.class }));
+
+		assertEquals("GET", endpointMethod.httpMethod());
+		assertEquals("http://my.api.com/headers", endpointMethod.path());
+		assertEquals(String.class, endpointMethod.returnType().classType());
+
+		Optional<EndpointMethodParameter> customHeaderParameter = endpointMethod.parameters().get(0);
+		assertTrue(customHeaderParameter.isPresent());
+		assertEquals("X-Custom-Header", customHeaderParameter.get().name());
+		assertTrue(customHeaderParameter.get().header());
+
+		Optional<EndpointMethodParameter> otherCustomHeaderParameter = endpointMethod.parameters().get(1);
+		assertTrue(otherCustomHeaderParameter.isPresent());
+		assertEquals("X-Other-Custom-Header", otherCustomHeaderParameter.get().name());
+		assertTrue(otherCustomHeaderParameter.get().header());
+
+		EndpointHeader customHeader = endpointMethod.headers().first("X-Custom-Header").orElse(null);
+		assertNotNull(customHeader);
+		assertEquals("{X-Custom-Header}", customHeader.value());
+
+		EndpointHeader otherCustomHeader = endpointMethod.headers().first("X-Other-Custom-Header").orElse(null);
+		assertNotNull(otherCustomHeader);
+		assertEquals("{X-Other-Custom-Header}", otherCustomHeader.value());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWithContentTypeHeaderWhenMethodHasConsumesAnnotation() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("consumes", new Class[] { Object.class }));
+
+		assertEquals("GET", endpointMethod.httpMethod());
+		assertEquals("http://my.api.com/consumes", endpointMethod.path());
+		assertEquals(String.class, endpointMethod.returnType().classType());
+
+		Optional<EndpointMethodParameter> bodyParameter = endpointMethod.parameters().get(0);
+		assertTrue(bodyParameter.isPresent());
+		assertTrue(bodyParameter.get().body());
+
+		EndpointHeader contentTypeHeader = endpointMethod.headers().first("Content-Type").orElse(null);
+		assertNotNull(contentTypeHeader);
+		assertEquals("application/json", contentTypeHeader.value());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWithAcceptHeaderWhenMethodHasProducesAnnotation() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("produces", new Class[0]));
+
+		assertEquals("GET", endpointMethod.httpMethod());
+		assertEquals("http://my.api.com/produces", endpointMethod.path());
+		assertEquals(Object.class, endpointMethod.returnType().classType());
+
+		EndpointHeader acceptHeader = endpointMethod.headers().first("Accept").orElse(null);
+		assertNotNull(acceptHeader);
+		assertEquals("application/json", acceptHeader.value());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWithAcceptHeaderWhenMethodHasProducesAnnotationWithMultiplesValues() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("multipleProduces", new Class[0]));
+
+		assertEquals("GET", endpointMethod.httpMethod());
+		assertEquals("http://my.api.com/produces", endpointMethod.path());
+		assertEquals(String.class, endpointMethod.returnType().classType());
+
+		EndpointHeader acceptHeader = endpointMethod.headers().first("Accept").orElse(null);
+		assertNotNull(acceptHeader);
+		assertEquals("text/plain, text/html", acceptHeader.value());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodMergingMethodHeaderAnnotationsWithHeaderParameters() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("mergeHeaders", new Class[] { Object.class, String.class }));
+
+		assertEquals("GET", endpointMethod.httpMethod());
+		assertEquals("http://my.api.com/mergeHeaders", endpointMethod.path());
+		assertEquals(Object.class, endpointMethod.returnType().classType());
+
+		EndpointHeader contentTypeHeader = endpointMethod.headers().first("Content-Type").orElse(null);
+		assertNotNull(contentTypeHeader);
+		assertEquals("application/json", contentTypeHeader.value());
+
+		EndpointHeader acceptHeader = endpointMethod.headers().first("Accept").orElse(null);
+		assertNotNull(acceptHeader);
+		assertEquals("application/json", acceptHeader.value());
+
+		EndpointHeader customHeader = endpointMethod.headers().first("X-Custom-Header").orElse(null);
+		assertNotNull(customHeader);
+		assertEquals("{X-Custom-Header}", customHeader.value());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowExceptionWhenMethodHasNotAPathAnnotation() throws Exception {
+		jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("withoutPath"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowExceptionWhenMethodHasNotAHttpMethodAnnotation() throws Exception {
+		jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("withoutHttpMethod"));
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenPathAnnotationOnMethodHasNoSlashOnStart() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("pathWithoutSlash"));
+
+		assertEquals("GET", endpointMethod.httpMethod());
+		assertEquals("http://my.api.com/path", endpointMethod.path());
+		assertEquals(String.class, endpointMethod.returnType().classType());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenMethodHasCustomizedParameterNames() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("customizedNames", new Class[] { String.class }));
+
+		assertEquals("GET", endpointMethod.httpMethod());
+		assertEquals("http://my.api.com/{customArgumentPath}", endpointMethod.path());
+		assertEquals(Void.TYPE, endpointMethod.returnType().classType());
+
+		Optional<EndpointMethodParameter> pathParameter = endpointMethod.parameters().get(0);
+		assertTrue(pathParameter.isPresent());
+		assertEquals("customArgumentPath", pathParameter.get().name());
+		assertTrue(pathParameter.get().path());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodOfMethodWithHttpMethodMetaAnnotation() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("metaAnnotationOfHttpMethod"));
+
+		assertEquals("POST", endpointMethod.httpMethod());
+		assertEquals("http://my.api.com/some-method", endpointMethod.path());
+		assertEquals(Void.TYPE, endpointMethod.returnType().classType());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodOfMethodWithQueryStringParameter() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("queryString", new Class[] { String.class, int.class }));
+
+		assertEquals("GET", endpointMethod.httpMethod());
+		assertEquals("http://my.api.com/query", endpointMethod.path());
+		assertEquals(void.class, endpointMethod.returnType().classType());
+
+		Optional<EndpointMethodParameter> nameParameter = endpointMethod.parameters().get(0);
+		assertTrue(nameParameter.isPresent());
+		assertEquals("name", nameParameter.get().name());
+		assertTrue(nameParameter.get().query());
+
+		Optional<EndpointMethodParameter> ageParameter = endpointMethod.parameters().get(1);
+		assertTrue(ageParameter.isPresent());
+		assertEquals("age", ageParameter.get().name());
+		assertTrue(ageParameter.get().query());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowExceptionWhenMethodHasMoreThanOneBodyParameter() throws Exception {
+		jaxRsContractReader.read(myApiTypeTarget,
+				MyApiType.class.getMethod("methodWithTwoBodyParameters", new Class[] { Object.class, Object.class }));
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenInterfaceHasAInheritance() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myInheritanceApiTarget,
+				MyInheritanceApiType.class.getMethod("method"));
+
+		assertEquals("http://my.api.com/simple", endpointMethod.path());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenMethodIsInherited() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myInheritanceApiTarget,
+				MyInheritanceApiType.class.getMethod("inheritedMethod"));
+
+		assertEquals("http://my.api.com/inherited", endpointMethod.path());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWithInheritedProducesAnnotation() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myInheritanceApiTarget,
+				MyInheritanceApiType.class.getMethod("getWithHeaders", new Class[] { String.class }));
+
+		assertEquals("http://my.api.com/getWithHeaders", endpointMethod.path());
+
+		EndpointHeader customHeader = endpointMethod.headers().first("X-Custom-Header").orElse(null);
+		assertNotNull(customHeader);
+		assertEquals("{X-Custom-Header}", customHeader.value());
+
+		EndpointHeader acceptHeader = endpointMethod.headers().first("Accept").orElse(null);
+		assertNotNull(acceptHeader);
+		assertEquals("application/json", acceptHeader.value());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenMethodHasAGenericParameter() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
+				MySpecificApi.class.getMethod("create", new Class[] { Object.class }));
+
+		assertEquals("http://my.model.api/create", endpointMethod.path());
+
+		Optional<EndpointMethodParameter> parameter = endpointMethod.parameters().get(0);
+		assertTrue(parameter.isPresent());
+		assertEquals("type", parameter.get().name());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsASimpleGenericType() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
+				MySpecificApi.class.getMethod("find", new Class[] { int.class }));
+
+		assertEquals("http://my.model.api/find", endpointMethod.path());
+		assertEquals(MyModel.class, endpointMethod.returnType().classType());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsACollectionWithGenericType() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
+				MySpecificApi.class.getMethod("allAsList"));
+
+		assertEquals("http://my.model.api/all", endpointMethod.path());
+		assertEquals(new SimpleParameterizedType(List.class, null, MyModel.class), endpointMethod.returnType().unwrap());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsGenericArray() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
+				MySpecificApi.class.getMethod("allAsArray"));
+
+		assertEquals("http://my.model.api/all", endpointMethod.path());
+		assertEquals(new SimpleGenericArrayType(MyModel.class), endpointMethod.returnType().unwrap());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsArray() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
+				MySpecificApi.class.getMethod("myModelArray"));
+
+		assertEquals("http://my.model.api/all", endpointMethod.path());
+		assertEquals(MyModel[].class, endpointMethod.returnType().classType());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsMap() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
+				MySpecificApi.class.getMethod("myModelAsMap"));
+
+		assertEquals("http://my.model.api/all", endpointMethod.path());
+		assertEquals(new SimpleParameterizedType(Map.class, null, String.class, MyModel.class),
+				endpointMethod.returnType().unwrap());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsMapWithGenericValue() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
+				MySpecificApi.class.getMethod("allAsMap"));
+
+		assertEquals("http://my.model.api/all", endpointMethod.path());
+		assertEquals(new SimpleParameterizedType(Map.class, null, String.class, MyModel.class),
+				endpointMethod.returnType().unwrap());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsMapWithGenericKeyAndValue() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
+				MySpecificApi.class.getMethod("anyAsMap"));
+
+		assertEquals("http://my.model.api/any", endpointMethod.path());
+		assertEquals(
+				new SimpleParameterizedType(Map.class, null,
+						new SimpleWildcardType(new Type[] { Number.class }, new Type[0]),
+						new SimpleWildcardType(new Type[] { MyModel.class }, new Type[0])),
+				endpointMethod.returnType().unwrap());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWhenTargetHasEndpointUrl() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myContextApiTarget,
+				MyContextApi.class.getMethod("method"));
+
+		assertEquals("http://my.api.com/context/any", endpointMethod.path());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowExceptionWhenInterfaceTypeIsAnnotatedWithApplicationPathAndPathAnnotations() throws Exception {
+		jaxRsContractReader.read(new EndpointTarget(MyWrongApi.class),
+				MyWrongApi.class.getMethod("wrong"));
+	}
+
+	@ApplicationPath("http://my.api.com")
+	interface MyApiType {
+
+		@Path("/{path}")
+		@GET
+		public String method(@PathParam("path") String path);
+
+		@Path("/{path}")
+		@GET
+		public String method(@PathParam("path") String path, @HeaderParam("Content-Type") String contentType, Object body);
+
+		@Path("path")
+		@GET
+		public String pathWithoutSlash();
+
+		@Path("/{customArgumentPath}")
+		@GET
+		public void customizedNames(@PathParam("customArgumentPath") String path);
+
+		@Path("/some-method")
+		@POST
+		public void metaAnnotationOfHttpMethod();
+
+		@Path("/query")
+		@GET
+		public void queryString(@QueryParam("name") String name, @QueryParam("age") int age);
+
+		@Path("/twoBodyParameters")
+		@GET
+		public String methodWithTwoBodyParameters(Object first, Object second);
+
+		@Path("/headers")
+		@GET
+		public String headers(@HeaderParam("X-Custom-Header") String customHeader, @HeaderParam("X-Other-Custom-Header") String otherCustomHeader);
+
+		@Path("/consumes")
+		@GET
+		@Consumes("application/json")
+		public String consumes(Object body);
+
+		@Path("/produces")
+		@GET
+		@Produces("application/json")
+		public Object produces();
+
+		@Path("/produces")
+		@GET
+		@Produces({"text/plain", "text/html"})
+		public String multipleProduces();
+
+		@Path("/mergeHeaders")
+		@GET
+		@Consumes("application/json")
+		@Produces("application/json")
+		public Object mergeHeaders(Object body, @HeaderParam("X-Custom-Header") String customHeader);
+
+		public void withoutPath();
+
+		@Path("/withoutHttpMethod")
+		public void withoutHttpMethod();
+	}
+
+	@ApplicationPath("http://my.api.com")
+	@Produces("application/json")
+	interface MyBaseApiType {
+
+		@Path("/inherited")
+		@POST
+		public String inheritedMethod();
+	}
+
+	interface MyInheritanceApiType extends MyBaseApiType {
+
+		@Path("/simple")
+		@GET
+		public String method();
+
+		@Path("/getWithHeaders")
+		@GET
+		public Object getWithHeaders(@HeaderParam("X-Custom-Header") String customHeader);
+	}
+
+	interface MyGenericApiType<T> {
+
+		@Path("/create")
+		@POST
+		public void create(T type);
+
+		@Path("/find")
+		@GET
+		public T find(int id);
+
+		@Path("/all")
+		@POST
+		public Collection<T> all();
+
+		@Path("/all")
+		@GET
+		public List<T> allAsList();
+
+		@Path("/all")
+		@GET
+		public T[] allAsArray();
+
+		@Path("/all")
+		@GET
+		public Map<String, T> allAsMap();
+
+		@Path("/any")
+		@GET
+		public Map<? extends Number, ? extends T> anyAsMap();
+	}
+
+	@ApplicationPath("http://my.model.api")
+	interface MySpecificApi extends MyGenericApiType<MyModel> {
+
+		@Path("/update")
+		@PUT
+		public MyModel update(MyModel myModel);
+
+		@Path("/all")
+		@GET
+		public MyModel[] myModelArray();
+
+		@Path("/all")
+		@GET
+		public Map<String, MyModel> myModelAsMap();
+	}
+
+	@Path("/context")
+	interface MyContextApi {
+
+		@Path("/any")
+		@GET
+		public String method();
+	}
+
+	@ApplicationPath("http://wrong")
+	@Path("/path")
+	interface MyWrongApi {
+
+		public void wrong();
+	}
+
+	class MyModel {
+	}
+
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/DynamicParameterMatcher.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/DynamicParameterMatcher.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 
 public class DynamicParameterMatcher {
 
-	private static final Pattern DYNAMIC_PARAMETER_PATTERN = Pattern.compile("\\{([a-zA-Z]+)\\}");
+	private static final Pattern DYNAMIC_PARAMETER_PATTERN = Pattern.compile("\\{([a-zA-Z\\-\\_]+)\\}");
 
 	public static Matcher matches(String source) {
 		return DYNAMIC_PARAMETER_PATTERN.matcher(source);

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointHeaderParameterResolverTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointHeaderParameterResolverTest.java
@@ -33,6 +33,32 @@ public class EndpointHeaderParameterResolverTest {
 	}
 
 	@Test
+	public void shouldResolveDynamicHeaderArgumentWithHyphen() {
+		parameters.put(new EndpointMethodParameter(0, "content-type", String.class, EndpointMethodParameterType.HEADER));
+
+		EndpointHeaderParameterResolver resolver = new EndpointHeaderParameterResolver("{content-type}", parameters);
+
+		Object[] args = new Object[] { "application/json" };
+
+		String value = resolver.resolve(args);
+
+		assertEquals(args[0], value);
+	}
+
+	@Test
+	public void shouldResolveDynamicHeaderArgumentWithUnderline() {
+		parameters.put(new EndpointMethodParameter(0, "content_type", String.class, EndpointMethodParameterType.HEADER));
+
+		EndpointHeaderParameterResolver resolver = new EndpointHeaderParameterResolver("{content_type}", parameters);
+
+		Object[] args = new Object[] { "application/json" };
+
+		String value = resolver.resolve(args);
+
+		assertEquals(args[0], value);
+	}
+
+	@Test
 	public void shouldResolveToEmptyWhenDynamicHeaderArgumentValueIsNull() {
 		parameters.put(new EndpointMethodParameter(0, "contentType", String.class, EndpointMethodParameterType.HEADER));
 

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointPathParameterResolverTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointPathParameterResolverTest.java
@@ -67,4 +67,29 @@ public class EndpointPathParameterResolverTest {
 		assertEquals("/method/static/path", endpoint);
 	}
 
+	@Test
+	public void shouldResolveDynamicArgumentWithHyphen() {
+		parameters.put(new EndpointMethodParameter(0, "first-argument", String.class));
+
+		EndpointPathParameterResolver resolver = new EndpointPathParameterResolver("/method/{first-argument}", parameters);
+
+		Object[] args = { "arg" };
+
+		String endpoint = resolver.resolve(args);
+
+		assertEquals("/method/arg", endpoint);
+	}
+
+	@Test
+	public void shouldResolveDynamicArgumentWithUnderline() {
+		parameters.put(new EndpointMethodParameter(0, "first_argument", String.class));
+
+		EndpointPathParameterResolver resolver = new EndpointPathParameterResolver("/method/{first_argument}", parameters);
+
+		Object[] args = { "arg" };
+
+		String endpoint = resolver.resolve(args);
+
+		assertEquals("/method/arg", endpoint);
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 		<module>java-restify-netflix</module>
 		<module>java-restify-netflix-spring-autoconfigure</module>
 		<module>java-restify-netflix-spring-starter</module>
+		<module>java-restify-jaxrs-contract</module>
 	</modules>
 
 	<dependencies>


### PR DESCRIPTION
## Suporte para anotações do JAX-RS :coffee:

:electric_plug: Criação de novo artefato: *java-restify-jxrs-contract*

### Descrição
Implementa suporte para anotações do JAX-RS para definição de contratos client-side. 

:point_right: As anotações suportadas são: *ApplicationPath*, *Path*, *Consumes*, *Produces*, *PathParam*, *QueryParam*, *HeaderParam* e *HttpMethod* (com todas as sub-anotações: *GET*, *POST*, etc)

### Changelog
- Cria novo projeto *java-restify-jaxrs-contract*
- Cria classe *JaxRsContractReader*, implementando o parser das anotações do JAX-RS