### PR TITLE
[jsonp-support-jsr-353] Suporte para JSR 353 - Java API for Json Processing

### DIFF
--- a/java-restify/pom.xml
+++ b/java-restify/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -55,11 +56,24 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-		    <groupId>io.reactivex.rxjava2</groupId>
-		    <artifactId>rxjava</artifactId>
-		    <version>2.0.2</version>
-		    <optional>true</optional>
-		    <scope>provided</scope>
+			<groupId>io.reactivex.rxjava2</groupId>
+			<artifactId>rxjava</artifactId>
+			<version>2.0.2</version>
+			<optional>true</optional>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.json</groupId>
+			<artifactId>javax.json-api</artifactId>
+			<version>1.0</version>
+			<optional>true</optional>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.json</artifactId>
+			<version>1.0.4</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonMessageConverter.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonMessageConverter.java
@@ -38,9 +38,10 @@ public abstract class JsonMessageConverter<T> implements HttpMessageReader<T>, H
 		return APPLICATION_JSON;
 	}
 
-	public static JsonMessageConverter<Object> available() {
-		return JavaClassDiscovery.present("com.fasterxml.jackson.databind.ObjectMapper") ? new JacksonMessageConverter<>()
-			: JavaClassDiscovery.present("com.google.gson.Gson") ? new GsonMessageConverter<>()
-				:  new FallbackJsonMessageConverter<>();
+	public static JsonMessageConverter<?> available() {
+		return  JavaClassDiscovery.present("com.google.gson.Gson") ? new GsonMessageConverter<>()
+					: JavaClassDiscovery.present("com.fasterxml.jackson.databind.ObjectMapper") ? new JacksonMessageConverter<>()
+						: JavaClassDiscovery.present("javax.json.Json") ? new JsonpMessageConverter()
+								:  new FallbackJsonMessageConverter<>();
 	}
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonpMessageConverter.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonpMessageConverter.java
@@ -1,11 +1,15 @@
 package com.github.ljtfreitas.restify.http.client.message.converter.json;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.Map;
 
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
+import javax.json.JsonReaderFactory;
 import javax.json.JsonStructure;
+import javax.json.JsonWriterFactory;
 
 import com.github.ljtfreitas.restify.http.client.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.request.RestifyHttpMessageWriteException;
@@ -13,6 +17,18 @@ import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
 import com.github.ljtfreitas.restify.http.client.response.RestifyHttpMessageReadException;
 
 public class JsonpMessageConverter extends JsonMessageConverter<JsonStructure> {
+
+	private final JsonReaderFactory jsonReaderFactory;
+	private final JsonWriterFactory jsonWriterFactory;
+
+	public JsonpMessageConverter() {
+		this(Collections.emptyMap());
+	}
+
+	public JsonpMessageConverter(Map<String, ?> configuration) {
+		this.jsonReaderFactory = Json.createReaderFactory(configuration);
+		this.jsonWriterFactory = Json.createWriterFactory(configuration);
+	}
 
 	@Override
 	public boolean canRead(Type type) {
@@ -22,10 +38,10 @@ public class JsonpMessageConverter extends JsonMessageConverter<JsonStructure> {
 	@Override
 	public JsonStructure read(HttpResponseMessage httpResponseMessage, Type expectedType) throws RestifyHttpMessageReadException {
 		if (JsonArray.class.equals(expectedType)) {
-			return Json.createReader(httpResponseMessage.body()).readArray();
+			return jsonReaderFactory.createReader(httpResponseMessage.body()).readArray();
 
 		} else if (JsonObject.class.equals(expectedType)) {
-			return Json.createReader(httpResponseMessage.body()).readObject();
+			return jsonReaderFactory.createReader(httpResponseMessage.body()).readObject();
 
 		} else {
 			throw new RestifyHttpMessageReadException("Unsupported type: [" + expectedType + "]. Only JsonArray and JsonObject are supported.");
@@ -40,10 +56,10 @@ public class JsonpMessageConverter extends JsonMessageConverter<JsonStructure> {
 	@Override
 	public void write(JsonStructure json, HttpRequestMessage httpRequestMessage) throws RestifyHttpMessageWriteException {
 		if (json instanceof JsonArray) {
-			Json.createWriter(httpRequestMessage.output()).writeArray((JsonArray) json);
+			jsonWriterFactory.createWriter(httpRequestMessage.output()).writeArray((JsonArray) json);
 
 		} else if (json instanceof JsonObject) {
-			Json.createWriter(httpRequestMessage.output()).writeObject((JsonObject) json);
+			jsonWriterFactory.createWriter(httpRequestMessage.output()).writeObject((JsonObject) json);
 
 		} else {
 			throw new RestifyHttpMessageReadException("Unsupported type: [" + json.getClass() + "]. Only JsonArray and JsonObject are supported.");

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonpMessageConverter.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonpMessageConverter.java
@@ -1,0 +1,52 @@
+package com.github.ljtfreitas.restify.http.client.message.converter.json;
+
+import java.lang.reflect.Type;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonStructure;
+
+import com.github.ljtfreitas.restify.http.client.request.HttpRequestMessage;
+import com.github.ljtfreitas.restify.http.client.request.RestifyHttpMessageWriteException;
+import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
+import com.github.ljtfreitas.restify.http.client.response.RestifyHttpMessageReadException;
+
+public class JsonpMessageConverter extends JsonMessageConverter<JsonStructure> {
+
+	@Override
+	public boolean canRead(Type type) {
+		return type instanceof Class && JsonStructure.class.isAssignableFrom((Class<?>) type);
+	}
+
+	@Override
+	public JsonStructure read(HttpResponseMessage httpResponseMessage, Type expectedType) throws RestifyHttpMessageReadException {
+		if (JsonArray.class.equals(expectedType)) {
+			return Json.createReader(httpResponseMessage.body()).readArray();
+
+		} else if (JsonObject.class.equals(expectedType)) {
+			return Json.createReader(httpResponseMessage.body()).readObject();
+
+		} else {
+			throw new RestifyHttpMessageReadException("Unsupported type: [" + expectedType + "]. Only JsonArray and JsonObject are supported.");
+		}
+	}
+
+	@Override
+	public boolean canWrite(Class<?> type) {
+		return JsonStructure.class.isAssignableFrom((Class<?>) type);
+	}
+
+	@Override
+	public void write(JsonStructure json, HttpRequestMessage httpRequestMessage) throws RestifyHttpMessageWriteException {
+		if (json instanceof JsonArray) {
+			Json.createWriter(httpRequestMessage.output()).writeArray((JsonArray) json);
+
+		} else if (json instanceof JsonObject) {
+			Json.createWriter(httpRequestMessage.output()).writeObject((JsonObject) json);
+
+		} else {
+			throw new RestifyHttpMessageReadException("Unsupported type: [" + json.getClass() + "]. Only JsonArray and JsonObject are supported.");
+		}
+	}
+}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonpMessageConverterTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonpMessageConverterTest.java
@@ -1,6 +1,8 @@
 package com.github.ljtfreitas.restify.http.client.message.converter.json;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -43,12 +45,22 @@ public class JsonpMessageConverterTest {
 	}
 
 	@Test
+	public void shouldCanWriteJsonObject() {
+		assertTrue(converter.canWrite(JsonObject.class));
+	}
+
+	@Test
 	public void shouldWriteJsonObject() {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 
 		converter.write(jsonObject, new SimpleHttpRequestMessage(output));
 
 		assertEquals(jsonObject.toString(), output.toString());
+	}
+
+	@Test
+	public void shouldCanReadJsonObject() {
+		assertTrue(converter.canRead(JsonObject.class));
 	}
 
 	@Test
@@ -62,12 +74,22 @@ public class JsonpMessageConverterTest {
 	}
 
 	@Test
+	public void shouldCanWriteJsonArray() {
+		assertTrue(converter.canWrite(JsonArray.class));
+	}
+
+	@Test
 	public void shouldWriteJsonArray() {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 
 		converter.write(jsonArray, new SimpleHttpRequestMessage(output));
 
 		assertEquals(jsonArray.toString(), output.toString());
+	}
+
+	@Test
+	public void shouldCanReadJsonArray() {
+		assertTrue(converter.canRead(JsonArray.class));
 	}
 
 	@Test
@@ -85,5 +107,15 @@ public class JsonpMessageConverterTest {
 		jsonArrayElement = response.getJsonObject(1);
 		assertEquals("Tiago de Freitas Lima 2", jsonArrayElement.getString("name"));
 		assertEquals(32, jsonArrayElement.getInt("age"));
+	}
+
+	@Test
+	public void shouldNotCanWriteWhenTypeIsNotJsonObjectOrJsonArray() {
+		assertFalse(converter.canWrite(String.class));
+	}
+
+	@Test
+	public void shouldNotCanReadWhenTypeIsNotJsonObjectOrJsonArray() {
+		assertFalse(converter.canRead(String.class));
 	}
 }

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonpMessageConverterTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonpMessageConverterTest.java
@@ -1,0 +1,89 @@
+package com.github.ljtfreitas.restify.http.client.message.converter.json;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.ljtfreitas.restify.http.client.request.SimpleHttpRequestMessage;
+import com.github.ljtfreitas.restify.http.client.response.SimpleHttpResponseMessage;
+
+public class JsonpMessageConverterTest {
+
+	private JsonpMessageConverter converter = new JsonpMessageConverter();
+
+	private JsonObject jsonObject;
+
+	private JsonArray jsonArray;
+
+	@Before
+	public void setup() {
+		jsonObject = Json.createObjectBuilder()
+			.add("name", "Tiago de Freitas Lima")
+			.add("age", 31)
+			.build();
+
+		jsonArray = Json.createArrayBuilder()
+			.add(Json.createObjectBuilder()
+					.add("name", "Tiago de Freitas Lima 1")
+					.add("age", 31)
+					.build())
+			.add(Json.createObjectBuilder()
+				.add("name", "Tiago de Freitas Lima 2")
+				.add("age", 32)
+				.build())
+			.build();
+	}
+
+	@Test
+	public void shouldWriteJsonObject() {
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+		converter.write(jsonObject, new SimpleHttpRequestMessage(output));
+
+		assertEquals(jsonObject.toString(), output.toString());
+	}
+
+	@Test
+	public void shouldReadJsonObject() {
+		ByteArrayInputStream input = new ByteArrayInputStream(jsonObject.toString().getBytes());
+
+		JsonObject response = (JsonObject) converter.read(new SimpleHttpResponseMessage(input), JsonObject.class);
+
+		assertEquals("Tiago de Freitas Lima", response.getString("name"));
+		assertEquals(31, response.getInt("age"));
+	}
+
+	@Test
+	public void shouldWriteJsonArray() {
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+		converter.write(jsonArray, new SimpleHttpRequestMessage(output));
+
+		assertEquals(jsonArray.toString(), output.toString());
+	}
+
+	@Test
+	public void shouldReadJsonArray() throws Exception {
+		ByteArrayInputStream input = new ByteArrayInputStream(jsonArray.toString().getBytes());
+
+		JsonArray response = (JsonArray) converter.read(new SimpleHttpResponseMessage(input), JsonArray.class);
+
+		assertEquals(2, response.size());
+
+		JsonObject jsonArrayElement = response.getJsonObject(0);
+		assertEquals("Tiago de Freitas Lima 1", jsonArrayElement.getString("name"));
+		assertEquals(31, jsonArrayElement.getInt("age"));
+
+		jsonArrayElement = response.getJsonObject(1);
+		assertEquals("Tiago de Freitas Lima 2", jsonArrayElement.getString("name"));
+		assertEquals(32, jsonArrayElement.getInt("age"));
+	}
+}


### PR DESCRIPTION
## Suporte para JSR 353 - Java API for Json Processing :coffee:

### Descrição
Implementa suporte para [JSR 353 - Java API for Json Processing](https://jsonp.java.net/) para requisições/respostas no formato application/json

## Changelog
- Cria nova classe *JsonpMessageConverter*, implementa leitura/escrita de json utilizando a JSR-353. Essa classe serializa/deserializa json a partir/para objetos do tipo *JsonObject* (objeto json simples) e *JsonArray* (array de objetos json)
- Adiciona a nova implementação na resolução automática do provider json disponível no classpath, e altera a ordem de resolução: a prioridade passa a ser o Gson (se estiver disponivel no classpath), depois o Jackson (se estiver disponivel no classpath), e depois o JsonP (se estiver disponivel no classpath).