### PR TITLE
[path-annotation-on-method-refactor] Path dos métodos opcionais

### DIFF
--- a/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/reflection/JaxRsJavaMethodMetadata.java
+++ b/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/reflection/JaxRsJavaMethodMetadata.java
@@ -55,8 +55,7 @@ public class JaxRsJavaMethodMetadata {
 	public JaxRsJavaMethodMetadata(java.lang.reflect.Method javaMethod) {
 		this.javaMethod = javaMethod;
 
-		this.path = Optional.ofNullable(javaMethod.getAnnotation(Path.class))
-				.orElseThrow(() -> new IllegalArgumentException("Method " + javaMethod + " does not have a @Path annotation"));
+		this.path = javaMethod.getAnnotation(Path.class);
 
 		this.httpMethod = Optional.ofNullable(new JavaAnnotationScanner(javaMethod).scan(HttpMethod.class))
 				.orElseThrow(() -> new IllegalArgumentException("Method " + javaMethod + " does not have a @HttpMethod annotation"));
@@ -65,8 +64,8 @@ public class JaxRsJavaMethodMetadata {
 		this.produces = javaMethod.getAnnotation(Produces.class);
 	}
 
-	public Path path() {
-		return path;
+	public Optional<Path> path() {
+		return Optional.ofNullable(path);
 	}
 
 	public HttpMethod httpMethod() {

--- a/java-restify-jaxrs-contract/src/test/java/com/github/ljtfreitas/restify/http/jaxrs/contract/JaxRsContractReaderTest.java
+++ b/java-restify-jaxrs-contract/src/test/java/com/github/ljtfreitas/restify/http/jaxrs/contract/JaxRsContractReaderTest.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
@@ -43,6 +44,8 @@ public class JaxRsContractReaderTest {
 
 	private EndpointTarget myContextApiTarget;
 
+	private EndpointTarget mySimpleCrudApiTarget;
+
 	private JaxRsContractReader jaxRsContractReader;
 
 	@Before
@@ -54,6 +57,8 @@ public class JaxRsContractReaderTest {
 		myGenericSpecificApiTarget = new EndpointTarget(MySpecificApi.class);
 
 		myContextApiTarget = new EndpointTarget(MyContextApi.class, "http://my.api.com");
+
+		mySimpleCrudApiTarget = new EndpointTarget(MySimpleCrudApi.class, "http://my.api.com");
 
 		jaxRsContractReader = new JaxRsContractReader();
 	}
@@ -389,6 +394,14 @@ public class JaxRsContractReaderTest {
 		assertEquals("http://my.api.com/context/any", endpointMethod.path());
 	}
 
+	@Test
+	public void shouldCreateEndpointMethodWhenJavaMethodHasNotPathAnnotation() throws Exception {
+		EndpointMethod endpointMethod = jaxRsContractReader.read(mySimpleCrudApiTarget, MySimpleCrudApi.class.getMethod("post", MyModel.class));
+
+		assertEquals("http://my.api.com/context", endpointMethod.path());
+		assertEquals("POST", endpointMethod.httpMethod());
+	}
+
 	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowExceptionWhenInterfaceTypeIsAnnotatedWithApplicationPathAndPathAnnotations() throws Exception {
 		jaxRsContractReader.read(new EndpointTarget(MyWrongApi.class),
@@ -530,6 +543,22 @@ public class JaxRsContractReaderTest {
 		@Path("/any")
 		@GET
 		public String method();
+	}
+
+	@Path("/context")
+	interface MySimpleCrudApi {
+
+		@POST
+		public void post(MyModel myModel);
+
+		@GET
+		public MyModel get();
+
+		@PUT
+		public void put(MyModel myModel);
+
+		@DELETE
+		public void delete();
 	}
 
 	@ApplicationPath("http://wrong")

--- a/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/contract/SpringWebContractReader.java
+++ b/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/contract/SpringWebContractReader.java
@@ -30,6 +30,7 @@ import static com.github.ljtfreitas.restify.http.util.Preconditions.nonNull;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -50,6 +51,7 @@ import com.github.ljtfreitas.restify.http.contract.metadata.SimpleRestifyContrac
 import com.github.ljtfreitas.restify.http.spring.contract.metadata.reflection.SpringWebJavaMethodMetadata;
 import com.github.ljtfreitas.restify.http.spring.contract.metadata.reflection.SpringWebJavaMethodParameterMetadata;
 import com.github.ljtfreitas.restify.http.spring.contract.metadata.reflection.SpringWebJavaTypeMetadata;
+import com.github.ljtfreitas.restify.http.util.Tryable;
 
 public class SpringWebContractReader implements RestifyContractReader {
 
@@ -69,8 +71,7 @@ public class SpringWebContractReader implements RestifyContractReader {
 
 		SpringWebJavaMethodMetadata javaMethodMetadata = new SpringWebJavaMethodMetadata(javaMethod);
 
-		String endpointPath = expressionsolver.resolve(endpointTarget(target) + endpointTypePath(javaTypeMetadata)
-				+ endpointMethodPath(javaMethodMetadata));
+		String endpointPath = endpointPath(target, javaTypeMetadata, javaMethodMetadata);
 
 		String endpointHttpMethod = javaMethodMetadata.httpMethod().name();
 
@@ -81,6 +82,13 @@ public class SpringWebContractReader implements RestifyContractReader {
 		Type returnType = javaMethodMetadata.returnType(target.type());
 
 		return new EndpointMethod(javaMethod, endpointPath, endpointHttpMethod, parameters, headers, returnType);
+	}
+
+	private String endpointPath(EndpointTarget target, SpringWebJavaTypeMetadata javaTypeMetadata, SpringWebJavaMethodMetadata javaMethodMetadata) {
+		String endpoint = expressionsolver.resolve(endpointTarget(target) + endpointTypePath(javaTypeMetadata) + 
+				endpointMethodPath(javaMethodMetadata));
+
+		return Tryable.of(() -> new URL(endpoint)).toString();
 	}
 
 	private String endpointTarget(EndpointTarget target) {

--- a/java-restify-spring/src/test/java/com/github/ljtfreitas/restify/http/spring/contract/SpringWebContractReaderTest.java
+++ b/java-restify-spring/src/test/java/com/github/ljtfreitas/restify/http/spring/contract/SpringWebContractReaderTest.java
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,6 +51,8 @@ public class SpringWebContractReaderTest {
 
 	private EndpointTarget myContextApiTarget;
 
+	private EndpointTarget mySimpleCrudApiTarget;
+
 	@Mock
 	private RestifyContractExpressionResolver expressionResolverMock;
 
@@ -65,6 +68,8 @@ public class SpringWebContractReaderTest {
 		myGenericSpecificApiTarget = new EndpointTarget(MySpecificApi.class);
 
 		myContextApiTarget = new EndpointTarget(MyContextApi.class, "http://my.api.com");
+
+		mySimpleCrudApiTarget = new EndpointTarget(MySimpleCrudApi.class, "http://my.api.com");
 
 		when(expressionResolverMock.resolve(anyString()))
 			.then(returnsFirstArg());
@@ -321,6 +326,15 @@ public class SpringWebContractReaderTest {
 		assertEquals("http://my.api.com/context/any", endpointMethod.path());
 	}
 
+	@Test
+	public void shouldCreateEndpointMethodWhenJavaMethodHasNoPathOnRequestMappingAnnotation() throws Exception {
+		EndpointMethod endpointMethod = springMvcContractReader.read(mySimpleCrudApiTarget,
+				MySimpleCrudApi.class.getMethod("post", MyModel.class));
+
+		assertEquals("http://my.api.com/context", endpointMethod.path());
+		assertEquals("POST", endpointMethod.httpMethod());
+	}
+
 	@RequestMapping(path = "http://my.api.com", headers = "X-My-Type=MyApiType")
 	interface MyApiType {
 
@@ -411,6 +425,22 @@ public class SpringWebContractReaderTest {
 
 		@GetMapping("/any")
 		public String method();
+	}
+
+	@RequestMapping("/context")
+	interface MySimpleCrudApi {
+
+		@PostMapping
+		public void post(@RequestBody MyModel myModel);
+
+		@GetMapping
+		public MyModel get();
+
+		@PutMapping
+		public void put(@RequestBody MyModel myModel);
+
+		@DeleteMapping
+		public void delete();
 	}
 
 	class MyModel {

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReader.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReader.java
@@ -30,6 +30,7 @@ import static com.github.ljtfreitas.restify.http.util.Preconditions.isTrue;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -40,6 +41,7 @@ import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParame
 import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaMethodMetadata;
 import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaMethodParameterMetadata;
 import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaTypeMetadata;
+import com.github.ljtfreitas.restify.http.util.Tryable;
 
 public class DefaultRestifyContractReader implements RestifyContractReader {
 
@@ -73,7 +75,9 @@ public class DefaultRestifyContractReader implements RestifyContractReader {
 	}
 
 	private String endpointPath(EndpointTarget target, JavaTypeMetadata javaTypeMetadata, JavaMethodMetadata javaMethodMetadata) {
-		return endpointTarget(target) + endpointTypePath(javaTypeMetadata) + endpointMethodPath(javaMethodMetadata);
+		String endpoint = endpointTarget(target) + endpointTypePath(javaTypeMetadata) + endpointMethodPath(javaMethodMetadata);
+
+		return Tryable.of(() -> new URL(endpoint)).toString();
 	}
 
 	private String endpointTarget(EndpointTarget target) {
@@ -90,8 +94,8 @@ public class DefaultRestifyContractReader implements RestifyContractReader {
 	}
 
 	private String endpointMethodPath(JavaMethodMetadata javaMethodMetadata) {
-		String endpointMethodPath = javaMethodMetadata.path().value();
-		return (endpointMethodPath.startsWith("/") ? endpointMethodPath : "/" + endpointMethodPath);
+		String endpointMethodPath = javaMethodMetadata.path().map(Path::value).orElse("");
+		return (endpointMethodPath.startsWith("/") || endpointMethodPath.isEmpty() ? endpointMethodPath : "/" + endpointMethodPath);
 	}
 
 	private EndpointMethodParameters endpointMethodParameters(Method javaMethod, EndpointTarget target) {

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaMethodMetadata.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaMethodMetadata.java
@@ -43,8 +43,7 @@ public class JavaMethodMetadata {
 	public JavaMethodMetadata(java.lang.reflect.Method javaMethod) {
 		this.javaMethod = javaMethod;
 
-		this.path = Optional.ofNullable(javaMethod.getAnnotation(Path.class))
-				.orElseThrow(() -> new IllegalArgumentException("Method " + javaMethod + " does not have a @Path annotation"));
+		this.path = javaMethod.getAnnotation(Path.class);
 
 		this.httpMethod = Optional.ofNullable(new JavaAnnotationScanner(javaMethod).scan(Method.class))
 				.orElseThrow(() -> new IllegalArgumentException("Method " + javaMethod + " does not have a @Method annotation"));
@@ -54,8 +53,8 @@ public class JavaMethodMetadata {
 					.orElseGet(() -> new JavaAnnotationScanner(javaMethod).scanAll(Header.class));
 	}
 
-	public Path path() {
-		return path;
+	public Optional<Path> path() {
+		return Optional.ofNullable(path);
 	}
 
 	public Method httpMethod() {

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReaderTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReaderTest.java
@@ -22,6 +22,7 @@ import com.github.ljtfreitas.restify.http.client.request.async.EndpointCallSucce
 import com.github.ljtfreitas.restify.http.contract.AcceptJson;
 import com.github.ljtfreitas.restify.http.contract.BodyParameter;
 import com.github.ljtfreitas.restify.http.contract.CallbackParameter;
+import com.github.ljtfreitas.restify.http.contract.Delete;
 import com.github.ljtfreitas.restify.http.contract.Get;
 import com.github.ljtfreitas.restify.http.contract.Header;
 import com.github.ljtfreitas.restify.http.contract.HeaderParameter;
@@ -47,6 +48,8 @@ public class DefaultRestifyContractReaderTest {
 
 	private EndpointTarget myContextApiTarget;
 
+	private EndpointTarget mySimpleCrudApiTarget;
+
 	private DefaultRestifyContractReader restifyContractReader;
 
 	@Before
@@ -58,6 +61,8 @@ public class DefaultRestifyContractReaderTest {
 		myGenericSpecificApiTarget = new EndpointTarget(MySpecificApi.class);
 
 		myContextApiTarget = new EndpointTarget(MyContextApi.class, "http://my.api.com");
+
+		mySimpleCrudApiTarget = new EndpointTarget(MySimpleCrudApi.class, "http://my.api.com");
 
 		restifyContractReader = new DefaultRestifyContractReader();
 	}
@@ -383,6 +388,13 @@ public class DefaultRestifyContractReaderTest {
 	}
 
 	@Test
+	public void shouldCreateEndpointMethodWhenJavaMethodHasNotPathAnnotation() throws Exception {
+		EndpointMethod endpointMethod = restifyContractReader.read(mySimpleCrudApiTarget, MySimpleCrudApi.class.getMethod("post", MyModel.class));
+
+		assertEquals("http://my.api.com/context", endpointMethod.path());
+	}
+
+	@Test
 	public void shouldCreateEndpointMethodWhenInterfaceHasDynamicPath() throws Exception {
 		restifyContractReader = new DefaultRestifyContractReader(new DynamicExpressionResolver());
 
@@ -538,6 +550,22 @@ public class DefaultRestifyContractReaderTest {
 		@Path("/any")
 		@Method("GET")
 		public String method();
+	}
+
+	@Path("/context")
+	interface MySimpleCrudApi {
+
+		@Post
+		public void post(MyModel model);
+
+		@Get
+		public MyModel get();
+
+		@Put
+		public void put(MyModel model);
+
+		@Delete
+		public void delete();
 	}
 
 	@Path("@{api.endpoint}")

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaMethodMetadataTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaMethodMetadataTest.java
@@ -1,15 +1,16 @@
 package com.github.ljtfreitas.restify.http.contract.metadata.reflection;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 
+import com.github.ljtfreitas.restify.http.contract.Get;
 import com.github.ljtfreitas.restify.http.contract.Header;
 import com.github.ljtfreitas.restify.http.contract.Headers;
 import com.github.ljtfreitas.restify.http.contract.Method;
 import com.github.ljtfreitas.restify.http.contract.Path;
 import com.github.ljtfreitas.restify.http.contract.Post;
-import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaMethodMetadata;
 
 public class JavaMethodMetadataTest {
 
@@ -19,7 +20,7 @@ public class JavaMethodMetadataTest {
 
 		JavaMethodMetadata javaMethodMetadata = new JavaMethodMetadata(javaMethod);
 
-		assertEquals("/path", javaMethodMetadata.path().value());
+		assertEquals("/path", javaMethodMetadata.path().get().value());
 		assertEquals("GET", javaMethodMetadata.httpMethod().value());
 
 		assertEquals(1, javaMethodMetadata.headers().length);
@@ -33,7 +34,7 @@ public class JavaMethodMetadataTest {
 
 		JavaMethodMetadata javaMethodMetadata = new JavaMethodMetadata(javaMethod);
 
-		assertEquals("/path", javaMethodMetadata.path().value());
+		assertEquals("/path", javaMethodMetadata.path().get().value());
 		assertEquals("POST", javaMethodMetadata.httpMethod().value());
 
 		assertEquals(0, javaMethodMetadata.headers().length);
@@ -45,7 +46,7 @@ public class JavaMethodMetadataTest {
 
 		JavaMethodMetadata javaMethodMetadata = new JavaMethodMetadata(javaMethod);
 
-		assertEquals("/path", javaMethodMetadata.path().value());
+		assertEquals("/path", javaMethodMetadata.path().get().value());
 		assertEquals("GET", javaMethodMetadata.httpMethod().value());
 
 		assertEquals(2, javaMethodMetadata.headers().length);
@@ -57,11 +58,14 @@ public class JavaMethodMetadataTest {
 		assertEquals("MyHeader2", javaMethodMetadata.headers()[1].value());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void shouldThrowExceptionWhenMethodHasNoPathAnnotation() throws Exception {
+	@Test
+	public void shouldReturnEmptyPathWhenMethodHasNoPathAnnotation() throws Exception {
 		java.lang.reflect.Method javaMethod = MyApiType.class.getMethod("methodWithoutPathAnnotation");
 
-		new JavaMethodMetadata(javaMethod);
+		JavaMethodMetadata javaMethodMetadata = new JavaMethodMetadata(javaMethod);
+
+		assertFalse(javaMethodMetadata.path().isPresent());
+		assertEquals("GET", javaMethodMetadata.httpMethod().value());
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -89,6 +93,7 @@ public class JavaMethodMetadataTest {
 			@Header(name = "X-My-Header-2", value = "MyHeader2")})
 		public String methodWithArrayOfHeaders();
 
+		@Get
 		public String methodWithoutPathAnnotation();
 
 		@Path("/path")


### PR DESCRIPTION
## Path dos métodos opcionais

### Descrição
- Torna a anotação *Path* opcional/não obrigatória no nível do método. Caso o método não esteja anotado, o endpoint será construído a partir do endpoint target + conteúdo da anotação Path do topo da interface (se existir). Essa modificação também foi implementada no contrato com as anotações do Spring (torna o atributo *path* da anotação RequestMapping opcional) e JAX-RS.

### Changelog
- Modifica a implementação do DefaultRestifyContractReader para tornar a anotação Path não obrigatória.
- Modifica a implementação do SpringWebContractReader para tornar o atributo path da anotação RequestMapping não obrigatório.
- Modifica a implementação do JaxRsContractReader para tornar a anotação Path não obrigatória.
