### PR TITLE
[refactor-jackson-configuration] Refatora configuração padrão do Jackson

### DIFF
--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequestFactoryTest.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequestFactoryTest.java
@@ -20,6 +20,7 @@ import org.mockserver.client.server.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.HttpRequest;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.ljtfreitas.restify.http.RestifyProxyBuilder;
 import com.github.ljtfreitas.restify.http.contract.BodyParameter;
 import com.github.ljtfreitas.restify.http.contract.Get;
@@ -161,7 +162,10 @@ public class RibbonHttpClientRequestFactoryTest {
 	@XmlAccessorType(XmlAccessType.FIELD)
 	public static class MyModel {
 
+		@JsonProperty
 		String name;
+
+		@JsonProperty
 		int age;
 
 		public MyModel() {

--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperServiceDiscoveryTest.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperServiceDiscoveryTest.java
@@ -23,6 +23,7 @@ import org.mockserver.client.server.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.HttpRequest;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.ljtfreitas.restify.http.RestifyProxyBuilder;
 import com.github.ljtfreitas.restify.http.client.request.jdk.JdkHttpClientRequestFactory;
 import com.github.ljtfreitas.restify.http.contract.BodyParameter;
@@ -169,7 +170,10 @@ public class ZookeeperServiceDiscoveryTest {
 
 	public static class MyModel {
 
+		@JsonProperty
 		String name;
+
+		@JsonProperty
 		int age;
 
 		public MyModel() {

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JacksonMessageConverter.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JacksonMessageConverter.java
@@ -29,13 +29,9 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.github.ljtfreitas.restify.http.client.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.request.RestifyHttpMessageWriteException;
@@ -47,12 +43,7 @@ public class JacksonMessageConverter<T> extends JsonMessageConverter<T> {
 	private final ObjectMapper objectMapper;
 
 	public JacksonMessageConverter() {
-		this(new ObjectMapper()
-				.setSerializationInclusion(Include.NON_NULL)
-				.configure(SerializationFeature.INDENT_OUTPUT, false));
-
-		this.objectMapper.setVisibility(PropertyAccessor.ALL, Visibility.NONE);
-		this.objectMapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
+		this(new ObjectMapper());
 	}
 
 	public JacksonMessageConverter(ObjectMapper objectMapper) {

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/MyJsonModel.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/MyJsonModel.java
@@ -1,5 +1,9 @@
 package com.github.ljtfreitas.restify.http.client.message.converter.json;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
 class MyJsonModel {
 
 	String name;


### PR DESCRIPTION
## Refatoração da configuração padrão do Jackson

## Descrição
- Refatoração da configuração padrão do Jackson (serialização/deserialização de json), para utilizar as configurações padrões do framework. 

## Changelog
- Remove as customizações do ObjectMapper utilizadas na classe JacksonJsonConverter (o java-restify tornava visíveis os campos da classe, ao invés das *propriedades* que é o padrão do Jackson). Continua sendo possível ao usuario do java-restify configurar o ObjectMapper como lhe for melhor e fornecer a instância para o JacksonJsonConverter atráves do construtor.
