### PR TITLE
[add-more-status-code] Adiciona status codes e metodos na classe StatusCode

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/response/StatusCode.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/response/StatusCode.java
@@ -29,10 +29,16 @@ public class StatusCode {
 
 	// Informational 1xx
 	public static final int HTTP_STATUS_CODE_CONTINUE = 100;
+	public static final int HTTP_STATUS_CODE_SWITCHING_PROTOCOLS = 101;
 
 	// Successful 2xx
 	public static final int HTTP_STATUS_CODE_OK = 200;
+	public static final int HTTP_STATUS_CODE_CREATED = 201;
+	public static final int HTTP_STATUS_CODE_ACCEPTED = 202;
+	public static final int HTTP_STATUS_CODE_NON_AUTHORITATIVE_INFORMATION = 203;
 	public static final int HTTP_STATUS_CODE_NO_CONTENT = 204;
+	public static final int HTTP_STATUS_CODE_RESET_CONTENT = 205;
+	public static final int HTTP_STATUS_CODE_PARTIAL_CONTENT = 206;
 
 	// Redirection 3xx
 	public static final int HTTP_STATUS_CODE_NOT_MODIFIED = 304;
@@ -98,8 +104,40 @@ public class StatusCode {
 		return isClientError() || isServerError();
 	}
 
+	public boolean isContinue() {
+		return code == HTTP_STATUS_CODE_CONTINUE;
+	}
+
+	public boolean isSwitchingProtocols() {
+		return code == HTTP_STATUS_CODE_SWITCHING_PROTOCOLS;
+	}
+
+	public boolean isOK() {
+		return code == HTTP_STATUS_CODE_OK;
+	}
+
+	public boolean isCreated() {
+		return code == HTTP_STATUS_CODE_CREATED;
+	}
+
+	public boolean isAccepted() {
+		return code == HTTP_STATUS_CODE_ACCEPTED;
+	}
+
+	public boolean isNonAuthoritativeInformation() {
+		return code == HTTP_STATUS_CODE_NON_AUTHORITATIVE_INFORMATION;
+	}
+
 	public boolean isNoContent() {
 		return code == HTTP_STATUS_CODE_NO_CONTENT;
+	}
+
+	public boolean isResetContent() {
+		return code == HTTP_STATUS_CODE_RESET_CONTENT;
+	}
+
+	public boolean isPartialContent() {
+		return code == HTTP_STATUS_CODE_PARTIAL_CONTENT;
 	}
 
 	public boolean isNotModified() {


### PR DESCRIPTION
## Status code HTTP e métodos de verificação (StatusCode) 

## Descrição
- Adiciona mais status codes e metodos de verificação na classe StatusCode; todos os status code oficiais da especificação HTTP estão suportados e contemplados.

## Changelog
- Adiciona constantes e métodos de verificação na classe StatusCode para os códigos: 
```java
HTTP_STATUS_CODE_SWITCHING_PROTOCOLS = 101;
HTTP_STATUS_CODE_CREATED = 201;
HTTP_STATUS_CODE_ACCEPTED = 202;
NON_AUTHORITATIVE_INFORMATION = 203;
HTTP_STATUS_CODE_RESET_CONTENT = 205;
HTTP_STATUS_CODE_PARTIAL_CONTENT = 206;
```