### PR TITLE
[timeout-http-request] Customização da requisição http

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.jdk;
+
+import java.nio.charset.Charset;
+
+import com.github.ljtfreitas.restify.http.client.charset.Encoding;
+
+public class HttpClientRequestConfiguration {
+
+	private int connectionTimeout = 0;
+	private int readTimeout = 0;
+
+	private Charset charset = Encoding.UTF_8.charset();
+
+	private HttpClientRequestConfiguration() {
+	}
+
+	public int connectionTimeout() {
+		return connectionTimeout;
+	}
+
+	public int readTimeout() {
+		return readTimeout;
+	}
+
+	public Charset charset() {
+		return charset;
+	}
+
+	public static HttpClientRequestConfiguration useDefault() {
+		return new HttpClientRequestConfiguration();
+	}
+
+	public static class Builder {
+
+		private HttpClientRequestConfiguration configuration = new HttpClientRequestConfiguration();
+
+		public Builder connectionTimeout(int connectionTimeout) {
+			configuration.connectionTimeout = connectionTimeout;
+			return this;
+		}
+
+		public Builder readTimeout(int readTimeout) {
+			configuration.readTimeout = readTimeout;
+			return this;
+		}
+
+		public Builder charset(Charset charset) {
+			configuration.charset = charset;
+			return this;
+		}
+
+		public HttpClientRequestConfiguration build() {
+			return configuration;
+		}
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestFactory.java
@@ -36,14 +36,24 @@ import com.github.ljtfreitas.restify.http.client.request.HttpClientRequestFactor
 
 public class JdkHttpClientRequestFactory implements HttpClientRequestFactory {
 
+	private final HttpClientRequestConfiguration httpClientRequestConfiguration;
 	private final Charset charset;
 
 	public JdkHttpClientRequestFactory() {
-		this(Encoding.UTF_8.charset());
+		this(Encoding.UTF_8.charset(), HttpClientRequestConfiguration.useDefault());
 	}
 
 	public JdkHttpClientRequestFactory(Charset charset) {
+		this(charset, HttpClientRequestConfiguration.useDefault());
+	}
+
+	public JdkHttpClientRequestFactory(HttpClientRequestConfiguration httpClientRequestConfiguration) {
+		this(httpClientRequestConfiguration.charset(), httpClientRequestConfiguration);
+	}
+
+	public JdkHttpClientRequestFactory(Charset charset, HttpClientRequestConfiguration httpClientRequestConfiguration) {
 		this.charset = charset;
+		this.httpClientRequestConfiguration = httpClientRequestConfiguration;
 	}
 
 	@Override
@@ -51,7 +61,11 @@ public class JdkHttpClientRequestFactory implements HttpClientRequestFactory {
 		try {
 			HttpURLConnection connection = (HttpURLConnection) request.endpoint().toURL().openConnection();
 
+			connection.setConnectTimeout(httpClientRequestConfiguration.connectionTimeout());
+			connection.setReadTimeout(httpClientRequestConfiguration.readTimeout());
+
 			connection.setDoOutput(true);
+			connection.setAllowUserInteraction(false);
 			connection.setRequestMethod(request.method());
 
 			return new JdkHttpClientRequest(connection, charset, request.headers(), request);

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/okhttp/OkHttpClientRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/okhttp/OkHttpClientRequestFactory.java
@@ -46,6 +46,10 @@ public class OkHttpClientRequestFactory implements HttpClientRequestFactory {
 		this(okHttpClient, Encoding.UTF_8.charset());
 	}
 
+	public OkHttpClientRequestFactory(Charset charset) {
+		this(new OkHttpClient(), charset);
+	}
+
 	public OkHttpClientRequestFactory(OkHttpClient okHttpClient, Charset charset) {
 		this.okHttpClient = okHttpClient;
 		this.charset = charset;

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/apache/httpclient/ApacheHttpClientRequestTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/apache/httpclient/ApacheHttpClientRequestTest.java
@@ -1,5 +1,6 @@
 package com.github.ljtfreitas.restify.http.client.request.apache.httpclient;
 
+import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -7,17 +8,23 @@ import static org.mockserver.model.JsonBody.json;
 import static org.mockserver.model.StringBody.exact;
 import static org.mockserver.verify.VerificationTimes.once;
 
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeUnit;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.apache.http.client.config.RequestConfig;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.HttpRequest;
 
+import com.github.ljtfreitas.restify.http.RestifyHttpException;
 import com.github.ljtfreitas.restify.http.RestifyProxyBuilder;
 import com.github.ljtfreitas.restify.http.client.request.apache.httpclient.ApacheHttpClientRequestFactory;
 import com.github.ljtfreitas.restify.http.contract.BodyParameter;
@@ -31,6 +38,9 @@ public class ApacheHttpClientRequestTest {
 	@Rule
 	public MockServerRule mockServerRule = new MockServerRule(this, 7080);
 
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
 	private MyApi myApi;
 
 	private MockServerClient mockServerClient;
@@ -39,8 +49,14 @@ public class ApacheHttpClientRequestTest {
 	public void setup() {
 		mockServerClient = new MockServerClient("localhost", 7080);
 
+		RequestConfig configuration = RequestConfig.custom()
+				.setSocketTimeout(2000)
+					.build();
+
+		ApacheHttpClientRequestFactory apacheHttpClientRequestFactory = new ApacheHttpClientRequestFactory(configuration);
+
 		myApi = new RestifyProxyBuilder()
-				.client(new ApacheHttpClientRequestFactory())
+				.client(apacheHttpClientRequestFactory)
 				.target(MyApi.class, "http://localhost:7080")
 				.build();
 	}
@@ -117,6 +133,21 @@ public class ApacheHttpClientRequestTest {
 		myApi.xml(new MyModel("Tiago de Freitas Lima", 31));
 
 		mockServerClient.verify(httpRequest, once());
+	}
+
+	@Test
+	public void shouldThrowExceptionOnTimeout() {
+		mockServerClient
+			.when(request()
+				.withMethod("GET")
+				.withPath("/json"))
+			.respond(response()
+				.withDelay(TimeUnit.MILLISECONDS, 3000));
+
+		expectedException.expect(isA(RestifyHttpException.class));
+		expectedException.expectCause(isA(SocketTimeoutException.class));
+
+		myApi.json();
 	}
 
 	interface MyApi {


### PR DESCRIPTION
## Customização/configuração da requisição http

## Descrição
- Permite configurar, via builder, timeouts da requisição usando o client http padrão (baseado no HttpUrlConnection)
- Permite mais flexibilidade para configurar o Apache HttpClient, usando os objetos RequestConfig e HttpContext

## Changelog
- Cria nova classe *HttpClientRequestConfiguration* para configuração do request (utilizada apenas pelo client http padrão) Permite configurar *connectionTimeout* e *readTimeout* da requisição.
- Cria novos campos no *RestifyProxyBuilder* para configuração das classe HttpClientRequestConfiguration
- Modifica o *ApacheHttpClientRequestFactory* para configurar a requisição usando os objetos RequestConfig e HttpContext (da api do apache-httpclient). Esses objetos já eram utilizados, mas não era possível configurá-los externamente; esse pull request permite enviar esses objetos através do construtor.
- Implementa testes de unidade para casos de timeout da requisição
