### PR TITLE
[content-type-interceptor] Content-Type interceptor

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
@@ -71,6 +71,7 @@ import com.github.ljtfreitas.restify.http.client.request.EndpointRequestWriter;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequestFactory;
 import com.github.ljtfreitas.restify.http.client.request.RestifyEndpointRequestExecutor;
 import com.github.ljtfreitas.restify.http.client.request.interceptor.AcceptHeaderEndpointRequestInterceptor;
+import com.github.ljtfreitas.restify.http.client.request.interceptor.ContentTypeHeaderEndpointRequestInterceptor;
 import com.github.ljtfreitas.restify.http.client.request.interceptor.EndpointRequestInterceptor;
 import com.github.ljtfreitas.restify.http.client.request.interceptor.EndpointRequestInterceptorStack;
 import com.github.ljtfreitas.restify.http.client.request.interceptor.authentication.AuthenticationEndpoinRequestInterceptor;
@@ -323,6 +324,16 @@ public class RestifyProxyBuilder {
 
 		public EndpointRequestInterceptorsBuilder accept(ContentType... contentTypes) {
 			interceptors.add(new AcceptHeaderEndpointRequestInterceptor(contentTypes));
+			return this;
+		}
+
+		public EndpointRequestInterceptorsBuilder contentType(String contentType) {
+			interceptors.add(new ContentTypeHeaderEndpointRequestInterceptor(contentType));
+			return this;
+		}
+
+		public EndpointRequestInterceptorsBuilder contentType(ContentType contentType) {
+			interceptors.add(new ContentTypeHeaderEndpointRequestInterceptor(contentType));
 			return this;
 		}
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequest.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequest.java
@@ -54,6 +54,10 @@ public class EndpointRequest {
 		this(endpoint, method, headers, null, responseType);
 	}
 
+	public EndpointRequest(URI endpoint, String method, Headers headers, Object body) {
+		this(endpoint, method, headers, body, void.class);
+	}
+
 	public EndpointRequest(URI endpoint, String method, Headers headers, Object body, Type responseType) {
 		this(endpoint, method, headers, body, JavaType.of(responseType));
 	}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/ContentTypeHeaderEndpointRequestInterceptor.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/ContentTypeHeaderEndpointRequestInterceptor.java
@@ -25,41 +25,33 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.client.request.interceptor;
 
-import static com.github.ljtfreitas.restify.http.client.Headers.ACCEPT;
+import static com.github.ljtfreitas.restify.http.client.Headers.CONTENT_TYPE;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import com.github.ljtfreitas.restify.http.client.Header;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
 import com.github.ljtfreitas.restify.http.contract.ContentType;
 
-public class AcceptHeaderEndpointRequestInterceptor implements EndpointRequestInterceptor {
+public class ContentTypeHeaderEndpointRequestInterceptor implements EndpointRequestInterceptor {
 
-	private final Collection<ContentType> contentTypes;
+	private final ContentType contentType;
 
-	public AcceptHeaderEndpointRequestInterceptor(String... contentTypes) {
-		this(Arrays.stream(contentTypes).map(ContentType::of).collect(Collectors.toSet()));
+	public ContentTypeHeaderEndpointRequestInterceptor(String contentType) {
+		this.contentType = ContentType.of(contentType);
 	}
 
-	public AcceptHeaderEndpointRequestInterceptor(ContentType... contentTypes) {
-		this(Arrays.stream(contentTypes).collect(Collectors.toSet()));
-	}
-
-	public AcceptHeaderEndpointRequestInterceptor(Collection<ContentType> contentTypes) {
-		this.contentTypes = new LinkedHashSet<>(contentTypes);
+	public ContentTypeHeaderEndpointRequestInterceptor(ContentType contentType) {
+		this.contentType = contentType;
 	}
 
 	@Override
 	public EndpointRequest intercepts(EndpointRequest endpointRequest) {
-		Optional<Header> accept = endpointRequest.headers().get(ACCEPT);
+		Optional<Header> contentType = endpointRequest.headers().get(CONTENT_TYPE);
+		boolean hasBody = endpointRequest.body().isPresent();
 
-		if (!accept.isPresent()) {
-			String acceptTypes = contentTypes.stream().map(ContentType::name).collect(Collectors.joining(", "));
-			endpointRequest.headers().add(new Header(ACCEPT, acceptTypes));
+		if (!contentType.isPresent() && hasBody) {
+			endpointRequest.headers().add(new Header(CONTENT_TYPE, this.contentType.toString()));
 		}
 
 		return endpointRequest;

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/interceptor/ContentTypeHeaderEndpointRequestInterceptorTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/interceptor/ContentTypeHeaderEndpointRequestInterceptorTest.java
@@ -1,0 +1,74 @@
+package com.github.ljtfreitas.restify.http.client.request.interceptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.Header;
+import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContentTypeHeaderEndpointRequestInterceptorTest {
+
+	private ContentTypeHeaderEndpointRequestInterceptor contentTypeHeaderEndpointRequestInterceptor;
+
+	private Headers headers;
+
+	@Before
+	public void setup() throws Exception {
+		contentTypeHeaderEndpointRequestInterceptor = new ContentTypeHeaderEndpointRequestInterceptor("application/json");
+
+		headers = new Headers();
+	}
+
+	@Test
+	public void shouldAddContentTypeHeaderWhenRequestHasBodyButContentTypeIsNotPresent() throws Exception {
+		String body = "{\"field\":\"value\"}";
+
+		EndpointRequest endpointRequest = new EndpointRequest(new URI("http://my.api.com/object"), "GET", headers, body);
+
+		EndpointRequest endpointRequestExpected = contentTypeHeaderEndpointRequestInterceptor
+				.intercepts(endpointRequest);
+
+		Optional<Header> contentType = endpointRequestExpected.headers().get("Content-Type");
+
+		assertTrue(contentType.isPresent());
+		assertEquals("application/json", contentType.get().value());
+	}
+
+	@Test
+	public void shouldNotAddContentTypeHeaderWhenRequestHasNoBody() throws Exception {
+		EndpointRequest endpointRequest = new EndpointRequest(new URI("http://my.api.com/object"), "GET");
+
+		EndpointRequest endpointRequestExpected = contentTypeHeaderEndpointRequestInterceptor.intercepts(endpointRequest);
+
+		Optional<Header> contentType = endpointRequestExpected.headers().get("Content-Type");
+
+		assertFalse(contentType.isPresent());
+	}
+
+	@Test
+	public void shouldNotAddContentTypeHeaderWhenRequestHasBodyAndContentTypeAlreadyIsPresent() throws Exception {
+		String body = "<field>value</field>";
+
+		headers.put(Headers.CONTENT_TYPE, "application/xml");
+
+		EndpointRequest endpointRequest = new EndpointRequest(new URI("http://my.api.com/object"), "GET", headers, body);
+
+		EndpointRequest endpointRequestExpected = contentTypeHeaderEndpointRequestInterceptor.intercepts(endpointRequest);
+
+		Optional<Header> contentType = endpointRequestExpected.headers().get("Content-Type");
+
+		assertTrue(contentType.isPresent());
+		assertEquals("application/xml", contentType.get().value());
+	}
+}


### PR DESCRIPTION
## Content-Type interceptor

## Descrição
- Implementa novo interceptor, *ContentTypeHeaderEndpointRequestInterceptor*, para geração automática do cabeçalho Content-Type das requisições, caso não tenha sido definida pela interface ou método. Essa funcionalidade tem a mesma semântica do *AcceptHeaderEndpointRequestInterceptor*, sendo útil para clientes de APIs que funcionam com apenas um Content-Type (tornando repetitiva a definição do cabeçalho para cada método)

## Changelog
- Cria nova classe *ContentTypeHeaderEndpointRequestInterceptor* para geração automática do cabeçalho Content-Type da requisição. Esse interceptor altera o request **apenas** se a requisição possuir um corpo, e se o cabeçalho Content-Type não estiver definido para o request (dessa forma, os cabeçalhos definidos no nível do método ou da interface tem precedência)