### PR TITLE
[spring-autoconfigure] Auto-configuração do Spring Boot (bugs e melhorias)

### DIFF
--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/autoconfigure/RestifyAutoConfiguration.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/autoconfigure/RestifyAutoConfiguration.java
@@ -85,7 +85,7 @@ public class RestifyAutoConfiguration {
 		private RestTemplateBuilder restTemplateBuilder;
 
 		@Autowired(required = false)
-		private RestTemplate restTemplate;
+		private RestOperations restTemplate;
 
 		@ConditionalOnMissingBean
 		@Bean

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/autoconfigure/RestifyErrorHandler.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/autoconfigure/RestifyErrorHandler.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.spring.autoconfigure;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+
+import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.client.response.BaseHttpResponseMessage;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponseErrorFallback;
+import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
+import com.github.ljtfreitas.restify.http.client.response.StatusCode;
+import com.github.ljtfreitas.restify.http.util.Tryable;
+
+public class RestifyErrorHandler extends DefaultResponseErrorHandler {
+
+	private final EndpointResponseErrorFallback endpointResponseErrorFallback;
+
+	public RestifyErrorHandler(EndpointResponseErrorFallback endpointResponseErrorFallback) {
+		this.endpointResponseErrorFallback = endpointResponseErrorFallback;
+	}
+
+	@Override
+	public void handleError(ClientHttpResponse response) throws IOException {
+		HttpResponseMessage httpResponse = convert(response);
+		endpointResponseErrorFallback.onError(httpResponse);
+	}
+
+	private HttpResponseMessage convert(ClientHttpResponse response) throws IOException {
+		StatusCode statusCode = StatusCode.of(response.getRawStatusCode());
+		Headers headers = headersOf(response.getHeaders());
+		InputStream body = Tryable.or(() -> response.getBody(), new ByteArrayInputStream(new byte[0]));
+
+		return new BaseHttpResponseMessage(statusCode, headers, body, null) {
+			@Override
+			public void close() throws IOException {
+				response.close();
+			}
+		};
+	}
+
+	private Headers headersOf(HttpHeaders httpHeaders) {
+		Headers headers = new Headers();
+		httpHeaders.forEach((k, v) -> headers.put(k, v));
+		return headers;
+	}
+}

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyConfiguration.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyConfiguration.java
@@ -59,9 +59,9 @@ import com.github.ljtfreitas.restify.http.spring.client.call.exec.ListenableFutu
 import com.github.ljtfreitas.restify.http.spring.client.call.exec.ResponseEntityEndpointCallExecutableFactory;
 import com.github.ljtfreitas.restify.http.spring.client.call.exec.WebAsyncTaskEndpointCallExecutableFactory;
 import com.github.ljtfreitas.restify.http.spring.client.request.RestOperationsEndpointRequestExecutor;
+import com.github.ljtfreitas.restify.http.spring.client.request.EndpointResponseErrorHandler;
 import com.github.ljtfreitas.restify.http.spring.contract.SpringWebContractReader;
 import com.github.ljtfreitas.restify.http.spring.contract.metadata.SpelDynamicParameterExpressionResolver;
-import com.github.ljtfreitas.restify.spring.autoconfigure.RestifyErrorHandler;
 
 @Configuration
 class RestifyConfiguration {
@@ -80,13 +80,13 @@ class RestifyConfiguration {
 
 		private RestTemplate buildRestTemplate() {
 			RestTemplate restTemplate = new RestTemplate();
-			restTemplate.setErrorHandler(restifyErrorHandler());
+			restTemplate.setErrorHandler(endpointResponseErrorHandler());
 			return restTemplate;
 		}
 
 		@Bean
-		public RestifyErrorHandler restifyErrorHandler() {
-			return new RestifyErrorHandler(endpointResponseErrorFallback());
+		public EndpointResponseErrorHandler endpointResponseErrorHandler() {
+			return new EndpointResponseErrorHandler(endpointResponseErrorFallback());
 		}
 
 		@Bean

--- a/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/client/request/EndpointResponseErrorHandler.java
+++ b/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/client/request/EndpointResponseErrorHandler.java
@@ -23,7 +23,7 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.spring.autoconfigure;
+package com.github.ljtfreitas.restify.http.spring.client.request;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -35,16 +35,21 @@ import org.springframework.web.client.DefaultResponseErrorHandler;
 
 import com.github.ljtfreitas.restify.http.client.Headers;
 import com.github.ljtfreitas.restify.http.client.response.BaseHttpResponseMessage;
+import com.github.ljtfreitas.restify.http.client.response.DefaultEndpointResponseErrorFallback;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponseErrorFallback;
 import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
 import com.github.ljtfreitas.restify.http.client.response.StatusCode;
 import com.github.ljtfreitas.restify.http.util.Tryable;
 
-public class RestifyErrorHandler extends DefaultResponseErrorHandler {
+public class EndpointResponseErrorHandler extends DefaultResponseErrorHandler {
 
 	private final EndpointResponseErrorFallback endpointResponseErrorFallback;
 
-	public RestifyErrorHandler(EndpointResponseErrorFallback endpointResponseErrorFallback) {
+	public EndpointResponseErrorHandler() {
+		this.endpointResponseErrorFallback = new DefaultEndpointResponseErrorFallback();
+	}
+
+	public EndpointResponseErrorHandler(EndpointResponseErrorFallback endpointResponseErrorFallback) {
 		this.endpointResponseErrorFallback = endpointResponseErrorFallback;
 	}
 

--- a/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/client/request/RestOperationsEndpointRequestExecutor.java
+++ b/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/client/request/RestOperationsEndpointRequestExecutor.java
@@ -30,8 +30,10 @@ import java.lang.reflect.Type;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
 
+import com.github.ljtfreitas.restify.http.RestifyHttpException;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequestExecutor;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
@@ -59,9 +61,14 @@ public class RestOperationsEndpointRequestExecutor implements EndpointRequestExe
 	public <T> EndpointResponse<T> execute(EndpointRequest endpointRequest) {
 		RequestEntity<Object> request = requestEntityConverter.convert(endpointRequest);
 
-		ResponseEntity<Object> response = rest.exchange(request, new JavaTypeReference(endpointRequest.responseType()));
+		try {
+			ResponseEntity<Object> response = rest.exchange(request, new JavaTypeReference(endpointRequest.responseType()));
 
-		return (EndpointResponse<T>) responseEntityConverter.convert(response);
+			return (EndpointResponse<T>) responseEntityConverter.convert(response);
+
+		} catch (RestClientException e) {
+			throw new RestifyHttpException(e);
+		}
 	}
 
 	private class JavaTypeReference extends ParameterizedTypeReference<Object> {

--- a/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/client/request/RestOperationsEndpointRequestExecutor.java
+++ b/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/client/request/RestOperationsEndpointRequestExecutor.java
@@ -37,6 +37,7 @@ import com.github.ljtfreitas.restify.http.RestifyHttpException;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequestExecutor;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
+import com.github.ljtfreitas.restify.http.client.response.RestifyEndpointResponseException;
 import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
 
 public class RestOperationsEndpointRequestExecutor implements EndpointRequestExecutor {
@@ -66,7 +67,13 @@ public class RestOperationsEndpointRequestExecutor implements EndpointRequestExe
 
 			return (EndpointResponse<T>) responseEntityConverter.convert(response);
 
+		} catch (RestifyEndpointResponseException e) {
+			throw e;
+
 		} catch (RestClientException e) {
+			throw new RestifyHttpException("Spring RestTemplate exception", e);
+
+		} catch (Exception e) {
 			throw new RestifyHttpException(e);
 		}
 	}

--- a/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/contract/metadata/reflection/SpringWebRequestMappingMetadata.java
+++ b/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/contract/metadata/reflection/SpringWebRequestMappingMetadata.java
@@ -85,14 +85,14 @@ public class SpringWebRequestMappingMetadata {
 	}
 
 	private Optional<String> consumes() {
-		String[] produces = Optional.ofNullable(mapping)
+		String[] consumes = Optional.ofNullable(mapping)
 			.map(m -> m.consumes())
 				.filter(p -> p.length <= 1)
 					.orElseThrow(() -> new IllegalArgumentException("[consumes] parameter (of @RequestMapping annotation) "
 							+ "must have only single value."));
 
-		return (produces.length == 0) ? Optional.empty()
-				: Optional.ofNullable(produces[0])
+		return (consumes.length == 0) ? Optional.empty()
+				: Optional.ofNullable(consumes[0])
 					.filter(p -> !p.isEmpty())
 						.map(p -> HttpHeaders.CONTENT_TYPE + "=" + p);
 	}

--- a/java-restify-spring/src/test/java/com/github/ljtfreitas/restify/http/spring/client/request/EndpointResponseErrorHandlerTest.java
+++ b/java-restify-spring/src/test/java/com/github/ljtfreitas/restify/http/spring/client/request/EndpointResponseErrorHandlerTest.java
@@ -1,0 +1,56 @@
+package com.github.ljtfreitas.restify.http.spring.client.request;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponseErrorFallback;
+import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
+import com.github.ljtfreitas.restify.http.client.response.StatusCode;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EndpointResponseErrorHandlerTest {
+
+	@Mock
+	private EndpointResponseErrorFallback endpointErrorFallbackMock;
+
+	@InjectMocks
+	private EndpointResponseErrorHandler endpointResponseErrorTranslator;
+
+	@Captor
+	private ArgumentCaptor<HttpResponseMessage> httpResponseMessageCaptor;
+
+	@Test
+	public void shouldTranslateSpringResponseUsingEndpointResponseErrorFallback() throws Exception {
+		ClientHttpResponse response = new MockClientHttpResponse("response body".getBytes(), HttpStatus.BAD_REQUEST);
+		response.getHeaders().add("Content-Type", "text/plain");
+
+		endpointResponseErrorTranslator.handleError(response);
+
+		verify(endpointErrorFallbackMock).onError(httpResponseMessageCaptor.capture());
+
+		HttpResponseMessage httpResponseMessage = httpResponseMessageCaptor.getValue();
+
+		assertEquals(StatusCode.badRequest(), httpResponseMessage.statusCode());
+
+		assertTrue(httpResponseMessage.headers().get("Content-Type").isPresent());
+		assertEquals("text/plain", httpResponseMessage.headers().get("Content-Type").get().value());
+
+		BufferedReader reader = new BufferedReader(new InputStreamReader(httpResponseMessage.body()));
+		assertEquals("response body", reader.readLine());
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequest.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequest.java
@@ -25,6 +25,7 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.client.request.jdk;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -38,6 +39,7 @@ import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
 import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
 import com.github.ljtfreitas.restify.http.client.response.StatusCode;
+import com.github.ljtfreitas.restify.http.util.Tryable;
 
 public class JdkHttpClientRequest implements HttpClientRequest {
 
@@ -74,7 +76,8 @@ public class JdkHttpClientRequest implements HttpClientRequest {
 			.filter(e -> e.getKey() != null && !e.getKey().equals(""))
 				.forEach(e -> headers.put(e.getKey(), e.getValue()));
 
-		InputStream stream = connection.getErrorStream() == null ? connection.getInputStream() : connection.getErrorStream();
+		InputStream stream = Tryable.or(() -> connection.getErrorStream() == null ? connection.getInputStream() : connection.getErrorStream(),
+				new ByteArrayInputStream(new byte[0]));
 
 		return new JdkHttpClientResponse(statusCode, headers, stream, connection, this);
 	}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/response/EndpointResponseExceptionFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/response/EndpointResponseExceptionFactory.java
@@ -35,7 +35,9 @@ class EndpointResponseExceptionFactory {
 	RestifyEndpointResponseException create(HttpResponseMessage response) {
 		String bodyAsString = TEXT_ERROR_RESPONSE_MESSAGE_CONVERTER.read(response, String.class);
 
-		String message = "HTTP Status Code: " + response.statusCode() + "\n" + bodyAsString;
+		String responseBody = (bodyAsString != null && !bodyAsString.isEmpty()) ? "\n" + bodyAsString : "(empty)";
+
+		String message = "HTTP Status Code: " + response.statusCode() + ". Response body: " + responseBody;
 
 		StatusCode statusCode = response.statusCode();
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/util/Tryable.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/util/Tryable.java
@@ -37,6 +37,14 @@ public interface Tryable {
 		}
 	}
 
+	public static <T> T or(TryableSupplier<T> supplier, T onError) {
+		try {
+			return supplier.get();
+		} catch (Exception e) {
+			return onError;
+		}
+	}
+
 	public static <X extends Throwable, T> T of(TryableSupplier<T> supplier, Supplier<? extends X> exception) throws X {
 		try {
 			return supplier.get();


### PR DESCRIPTION
## Auto-configuração do Spring Boot (bugs e melhorias)

## Descrição
- Corrige a utilização do RestOperations/RestTemplate/RestTemplateBuilder caso já existam beans desse tipo no contexto do Spring;
- Corrige verificação da existência de beans do tipo AsyncTaskExecutor, utilizados para requisições assíncronas;
- Implementa novo tratamento de erro usando o ResponseErrorHandler padrão do Spring, para que as respostas de erro HTTP sejam tratadas da mesma forma como é feito no EndpointRequestExecutor padrão

## Changelog
- Passa a utilizar um bean do tipo RestOperations (interface mais abrangente), e não RestTemplate (se existir, será utilizado), se algum bean desse tipo já existir no contexto;
- Corrige verificação do bean do tipo AsyncTaskExecutor, passando a utilizar uma dupla verificação: se já existe um bean deste tipo, e se o nome do bean é *restifyAsyncTaskExecutor*
- Implementa nova classe *EndpointResponseErrorHandler*, que é um ResponseErrorHandler do Spring (utilizado pelo RestTemplate), para que os erros HTTP sejam tratados da mesmo forma que o EndpointRequestExecutor padrão. Essa implementação utiliza uma instância do *EndpointResponseErrorFallback*, que pode ser customizado usando a propriedade *restify.error.emptyOnNotFound=true/false* (padrão é false)
- Passa a encapsular as exceções lançadas pelo RestTemplate em exceções do tipo RestifyHttpException