### PR TITLE
[fix-get-parameter-name] Captura de nomes de argumentos de métodos

### DIFF
--- a/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/reflection/JaxRsJavaMethodParameterMetadata.java
+++ b/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/metadata/reflection/JaxRsJavaMethodParameterMetadata.java
@@ -67,7 +67,8 @@ public class JaxRsJavaMethodParameterMetadata {
 							.orElseGet(() -> Optional.ofNullable(queryParameter)
 								.map(QueryParam::value).filter(s -> !s.trim().isEmpty())
 									.orElseGet(() -> Optional.ofNullable(javaMethodParameter.getName())
-											.orElseThrow(() -> new IllegalStateException("Could not get the name of the parameter " + javaMethodParameter)))));
+											.filter(name -> javaMethodParameter.isNamePresent() && !name.isEmpty())
+												.orElseThrow(() -> new IllegalStateException("Could not get the name of the parameter " + javaMethodParameter)))));
 
 		this.serializer = (queryParameter != null) ? new EndpointMethodQueryParameterSerializer()
 				: new SimpleEndpointMethodParameterSerializer();

--- a/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/contract/metadata/reflection/SpringWebJavaMethodParameterMetadata.java
+++ b/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/contract/metadata/reflection/SpringWebJavaMethodParameterMetadata.java
@@ -74,7 +74,8 @@ public class SpringWebJavaMethodParameterMetadata {
 							.orElseGet(() -> Optional.ofNullable(queryParameter)
 								.map(RequestParam::value).filter(s -> !s.trim().isEmpty())
 									.orElseGet(() -> Optional.ofNullable(javaMethodParameter.getName())
-											.orElseThrow(() -> new IllegalStateException("Could not get the name of the parameter " + javaMethodParameter)))));
+											.filter(name -> javaMethodParameter.isNamePresent() && !name.isEmpty())
+												.orElseThrow(() -> new IllegalStateException("Could not get the name of the parameter " + javaMethodParameter)))));
 
 		this.serializerType = SpringWebEndpointMethodParameterSerializer.of(this);
 	}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaMethodParameterMetadata.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaMethodParameterMetadata.java
@@ -72,7 +72,8 @@ public class JavaMethodParameterMetadata {
 							.orElseGet(() -> Optional.ofNullable(queryParameter)
 								.map(QueryParameter::value).filter(s -> !s.trim().isEmpty())
 									.orElseGet(() -> Optional.ofNullable(javaMethodParameter.getName())
-											.orElseThrow(() -> new IllegalStateException("Could not get the name of the parameter " + javaMethodParameter)))));
+											.filter(name -> javaMethodParameter.isNamePresent() && !name.isEmpty())
+												.orElseThrow(() -> new IllegalStateException("Could not get the name of the parameter " + javaMethodParameter)))));
 
 		this.serializerType = pathParameter != null ? pathParameter.serializer()
 				: queryParameter != null ? queryParameter.serializer()


### PR DESCRIPTION
## Captura de nomes de argumentos de métodos ☕️ 

## Descrição
- Corrige verificação da captura de nomes dos argumentos de métodos.

## Changelog
- Corrige verificação da captura de nomes dos argumentos de métodos. Já existia uma checagem que lançava uma exceção se o método "getName" do "java.lang.reflect.Parameter" retornasse nulo ou vazio, mas esse método sempre retorna o nome existente no arquivo .class (por exemplo, "arg0"), mesmo que o código não tenha sido compilado com a flag **-parameters**. Foi incluído na verificação o método "isNamePresent", que confirma que o código foi compilado com as informações dos nomes de argumentos. Essa correção foi feita em todas as implementações do *RestifyContractReader*