### PR TITLE
[endpoint-response-callback-async-exception] Requisições assíncronas - Exception

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/async/DefaultAsyncEndpointCall.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/async/DefaultAsyncEndpointCall.java
@@ -26,6 +26,7 @@
 package com.github.ljtfreitas.restify.http.client.call.async;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 
 import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
@@ -62,7 +63,17 @@ class DefaultAsyncEndpointCall<T> implements AsyncEndpointCall<T> {
 			successCallback.onSuccess(value);
 
 		} else if (throwable != null && failureCallback != null) {
-			failureCallback.onFailure(throwable);
+			Throwable cause = deepCause(throwable);
+
+			failureCallback.onFailure(cause);
+		}
+	}
+
+	private Throwable deepCause(Throwable throwable) {
+		if (throwable instanceof CompletionException) {
+			return deepCause(throwable.getCause());
+		} else {
+			return throwable;
 		}
 	}
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/async/EndpointResponseFailureCallback.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/async/EndpointResponseFailureCallback.java
@@ -38,13 +38,15 @@ public abstract class EndpointResponseFailureCallback implements EndpointCallFai
 			RestifyEndpointResponseException exception = (RestifyEndpointResponseException) throwable;
 			onResponseFailure(exception);
 
-		} else if (throwable instanceof RestifyHttpException) {
-			throw (RestifyHttpException) throwable;
-
 		} else {
-			throw new RestifyHttpException(throwable);
-
+			onException(throwable);
 		}
+	}
+
+	protected void onException(Throwable throwable) {
+		RestifyHttpException newException = (throwable instanceof RestifyHttpException) ?
+				(RestifyHttpException) throwable : new RestifyHttpException(throwable);
+		throw newException;
 	}
 
 	protected void onResponseFailure(RestifyEndpointResponseException exception) {

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/async/DefaultAsyncEndpointCallTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/async/DefaultAsyncEndpointCallTest.java
@@ -51,7 +51,7 @@ public class DefaultAsyncEndpointCallTest {
 
 		verify(callback).onFailure(throwableCaptor.capture());
 
-		assertSame(exception, throwableCaptor.getValue().getCause());
+		assertSame(exception, throwableCaptor.getValue());
 	}
 
 	@Test
@@ -73,7 +73,7 @@ public class DefaultAsyncEndpointCallTest {
 
 		verify(failureCallback).onFailure(throwableCaptor.capture());
 
-		assertSame(exception, throwableCaptor.getValue().getCause());
+		assertSame(exception, throwableCaptor.getValue());
 	}
 
 }


### PR DESCRIPTION
## EndpointResponseCallback - Exception

## Descrição
- Melhora tratamento de exceção para requisições assíncronas

## Changelog
- Extrai do CompletionException a causa da exceção, e propaga para o callback;
- No EndpointResponseFailureCallback, implementa novo método (*onException*) que permite ao usuário implementar um tratamento específico, em caso de erro.

