### PR TITLE
[netty-http-client] Suporte para o Netty (http client)

### DIFF
--- a/java-restify/pom.xml
+++ b/java-restify/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -65,6 +66,34 @@
 			<groupId>javax.json</groupId>
 			<artifactId>javax.json-api</artifactId>
 			<version>1.0</version>
+			<optional>true</optional>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-transport</artifactId>
+			<version>4.0.34.Final</version>
+			<optional>true</optional>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-codec-http</artifactId>
+			<version>4.0.34.Final</version>
+			<optional>true</optional>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-buffer</artifactId>
+			<version>4.0.34.Final</version>
+			<optional>true</optional>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-common</artifactId>
+			<version>4.0.34.Final</version>
 			<optional>true</optional>
 			<scope>provided</scope>
 		</dependency>

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
@@ -27,6 +27,7 @@ package com.github.ljtfreitas.restify.http;
 
 import java.lang.reflect.Proxy;
 import java.nio.charset.Charset;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -481,7 +482,17 @@ public class RestifyProxyBuilder {
 			return this;
 		}
 
+		public HttpClientRequestConfigurationBuilder connectionTimeout(Duration connectionTimeout) {
+			builder.connectionTimeout(connectionTimeout);
+			return this;
+		}
+
 		public HttpClientRequestConfigurationBuilder readTimeout(int readTimeout) {
+			builder.readTimeout(readTimeout);
+			return this;
+		}
+
+		public HttpClientRequestConfigurationBuilder readTimeout(Duration readTimeout) {
 			builder.readTimeout(readTimeout);
 			return this;
 		}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/Headers.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/Headers.java
@@ -34,8 +34,10 @@ import java.util.Optional;
 public class Headers {
 
 	public static final String ACCEPT = "Accept";
-	public static final String CONTENT_TYPE = "Content-Type";
+	public static final String CONNECTION = "Connection";
 	public static final String CONTENT_LENGTH = "Content-Length";
+	public static final String CONTENT_TYPE = "Content-Type";
+	public static final String HOST = "Host";
 
 	private final Collection<Header> headers;
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/apache/httpclient/ApacheHttpClientRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/apache/httpclient/ApacheHttpClientRequestFactory.java
@@ -25,6 +25,8 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.client.request.apache.httpclient;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Optional;
@@ -48,7 +50,7 @@ import com.github.ljtfreitas.restify.http.client.charset.Encoding;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequestFactory;
 
-public class ApacheHttpClientRequestFactory implements HttpClientRequestFactory {
+public class ApacheHttpClientRequestFactory implements HttpClientRequestFactory, Closeable {
 
 	private final HttpClient httpClient;
 	private final RequestConfig requestConfig;
@@ -167,6 +169,13 @@ public class ApacheHttpClientRequestFactory implements HttpClientRequestFactory 
 					.filter(m -> m.name().equals(method))
 						.findFirst()
 							.orElseThrow(() -> new IllegalArgumentException("Unsupported http method: " + method));
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (httpClient instanceof Closeable) {
+			((Closeable) this.httpClient).close();
 		}
 	}
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
@@ -26,6 +26,7 @@
 package com.github.ljtfreitas.restify.http.client.request.jdk;
 
 import java.nio.charset.Charset;
+import java.time.Duration;
 
 import com.github.ljtfreitas.restify.http.client.charset.Encoding;
 
@@ -64,8 +65,18 @@ public class HttpClientRequestConfiguration {
 			return this;
 		}
 
+		public Builder connectionTimeout(Duration duration) {
+			configuration.connectionTimeout = (int) duration.toMillis();
+			return this;
+		}
+
 		public Builder readTimeout(int readTimeout) {
 			configuration.readTimeout = readTimeout;
+			return this;
+		}
+
+		public Builder readTimeout(Duration duration) {
+			configuration.readTimeout = (int) duration.toMillis();
 			return this;
 		}
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyBootstrapFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyBootstrapFactory.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.netty;
+
+import java.util.concurrent.TimeUnit;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.SocketChannelConfig;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+
+class NettyBootstrapFactory {
+
+	private final EventLoopGroup eventLoopGroup;
+	private final NettyHttpClientRequestConfiguration nettyHttpClientRequestConfiguration;
+
+	public NettyBootstrapFactory(EventLoopGroup eventLoopGroup, NettyHttpClientRequestConfiguration nettyHttpClientRequestConfiguration) {
+		this.eventLoopGroup = eventLoopGroup;
+		this.nettyHttpClientRequestConfiguration = nettyHttpClientRequestConfiguration;
+	}
+
+	public Bootstrap create() {
+		Bootstrap bootstrap = new Bootstrap();
+
+		bootstrap.group(this.eventLoopGroup)
+			.channel(NioSocketChannel.class)
+				.handler(new NettyChannelInitializer());
+
+		return bootstrap;
+	}
+
+	private class NettyChannelInitializer extends ChannelInitializer<SocketChannel> {
+
+		@Override
+		protected void initChannel(SocketChannel channel) throws Exception {
+			configure(channel.config());
+			ChannelPipeline pipeline = channel.pipeline();
+
+			nettyHttpClientRequestConfiguration.sslContext().ifPresent(sslContext -> pipeline.addLast(sslContext.newHandler(channel.alloc())));
+
+			pipeline.addLast(new HttpClientCodec());
+			pipeline.addLast(new HttpObjectAggregator(nettyHttpClientRequestConfiguration.maxResponseSize()));
+			pipeline.addLast(new ReadTimeoutHandler(nettyHttpClientRequestConfiguration.readTimeout(), TimeUnit.MILLISECONDS));
+		}
+
+		private void configure(SocketChannelConfig channelConfiguration) {
+			channelConfiguration.setConnectTimeoutMillis(nettyHttpClientRequestConfiguration.connectionTimeout());
+		}
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyChannelFutureListener.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyChannelFutureListener.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.netty;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.handler.codec.http.HttpRequest;
+
+class NettyChannelFutureListener implements ChannelFutureListener {
+
+	private final HttpRequest nettyHttpRequest;
+	private final NettyRequestExecuteHandler nettyRequestExecuteHandler;
+
+	public NettyChannelFutureListener(HttpRequest nettyHttpRequest, NettyRequestExecuteHandler nettyRequestExecuteHandler) {
+		this.nettyHttpRequest = nettyHttpRequest;
+		this.nettyRequestExecuteHandler = nettyRequestExecuteHandler;
+	}
+
+	@Override
+	public void operationComplete(ChannelFuture channelFuture) throws Exception {
+		if (channelFuture.isSuccess()) {
+			Channel channel = channelFuture.channel();
+			channel.pipeline().addLast(nettyRequestExecuteHandler);
+
+			channel.writeAndFlush(nettyHttpRequest);
+
+		} else {
+			nettyRequestExecuteHandler.exceptionCaught(null, channelFuture.cause());
+		}
+	}
+
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyEventLoopGroupFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyEventLoopGroupFactory.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.netty;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+
+class NettyEventLoopGroupFactory {
+
+	public EventLoopGroup create() {
+		return new NioEventLoopGroup(availableProcessors());
+	}
+
+	private int availableProcessors() {
+		return Runtime.getRuntime().availableProcessors() * 2;
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequest.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequest.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.netty;
+
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import com.github.ljtfreitas.restify.http.RestifyHttpException;
+import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
+import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+
+class NettyHttpClientRequest implements HttpClientRequest {
+
+	private static final String HTTP_SCHEME = "http";
+	private static final String HTTPS_SCHEME = "https";
+
+	private static final int HTTP_SCHEME_PORT = 80;
+	private static final int HTTPS_SCHEME_PORT = 443;
+	
+	private final Bootstrap bootstrap;
+	private final EndpointRequest endpointRequest;
+	private final Charset charset;
+	private final ByteBufOutputStream body;
+
+	public NettyHttpClientRequest(Bootstrap bootstrap, EndpointRequest endpointRequest, Charset charset) {
+		this.bootstrap = bootstrap;
+		this.endpointRequest = endpointRequest;
+		this.charset = charset;
+		this.body = new ByteBufOutputStream(Unpooled.buffer());
+	}
+
+	@Override
+	public OutputStream output() {
+		return body;
+	}
+
+	@Override
+	public Headers headers() {
+		return endpointRequest.headers();
+	}
+
+	@Override
+	public Charset charset() {
+		return charset;
+	}
+
+	@Override
+	public EndpointRequest source() {
+		return endpointRequest;
+	}
+
+	@Override
+	public HttpResponseMessage execute() throws RestifyHttpException {
+		final CompletableFuture<NettyHttpClientResponse> responseOnFuture = new CompletableFuture<>();
+
+		NettyRequestExecuteHandler nettyRequestExecuteHandler = new NettyRequestExecuteHandler(responseOnFuture, this);
+
+		ChannelFutureListener connectionListener = new NettyChannelFutureListener(nettyHttpRequest(), nettyRequestExecuteHandler);
+
+		bootstrap.connect(endpointRequest.endpoint().getHost(), port(endpointRequest.endpoint()))
+				.addListener(connectionListener);
+
+		try {
+			return responseOnFuture.get();
+
+		} catch (InterruptedException | ExecutionException e) {
+			throw new RestifyHttpException("Error on Netty HTTP request to endpoint [" + endpointRequest.endpoint() + "]", e);
+		}
+	}
+
+	private int port(URI endpoint) {
+		int port = endpoint.getPort();
+
+		if (port == -1) {
+			if (HTTP_SCHEME.equalsIgnoreCase(endpoint.getScheme())) {
+				port = HTTP_SCHEME_PORT;
+
+			} else if (HTTPS_SCHEME.equalsIgnoreCase(endpoint.getScheme())) {
+				port = HTTPS_SCHEME_PORT;
+			}
+		}
+
+		return port;
+	}
+
+	private HttpRequest nettyHttpRequest() {
+		HttpMethod nettyMethod = HttpMethod.valueOf(endpointRequest.method());
+
+		ByteBuf bodyBuffer = body.buffer();
+
+		FullHttpRequest nettyRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, nettyMethod,
+				endpointRequest.endpoint().toString(), bodyBuffer);
+
+		nettyRequest.headers().set(Headers.HOST, endpointRequest.endpoint().getHost());
+		nettyRequest.headers().set(Headers.CONNECTION, "close");
+
+		if (bodyBuffer.readableBytes() != 0) {
+			nettyRequest.headers().set(Headers.CONTENT_LENGTH, bodyBuffer.readableBytes());
+		}
+
+		endpointRequest.headers().all().forEach(header -> nettyRequest.headers().add(header.name(), header.value()));
+
+		return nettyRequest;
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequestConfiguration.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequestConfiguration.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.netty;
+
+import java.nio.charset.Charset;
+import java.time.Duration;
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.charset.Encoding;
+
+import io.netty.handler.ssl.SslContext;
+
+public class NettyHttpClientRequestConfiguration {
+
+	private static final int DEFAULT_MAX_RESPONSE_SIZE = 1024 * 1024 * 10;
+
+	private int connectionTimeout = 0;
+	private int readTimeout = 0;
+	private int maxResponseSize = DEFAULT_MAX_RESPONSE_SIZE;
+
+	private SslContext sslContext = null;
+	private Charset charset = Encoding.UTF_8.charset();
+
+	private NettyHttpClientRequestConfiguration() {
+	}
+
+	public int connectionTimeout() {
+		return connectionTimeout;
+	}
+
+	public long readTimeout() {
+		return readTimeout;
+	}
+
+	public int maxResponseSize() {
+		return maxResponseSize;
+	}
+
+	public Optional<SslContext> sslContext() {
+		return Optional.ofNullable(sslContext);
+	}
+
+	public Charset charset() {
+		return charset;
+	}
+
+	public static NettyHttpClientRequestConfiguration useDefault() {
+		return new NettyHttpClientRequestConfiguration();
+	}
+
+	public static class Builder {
+
+		private NettyHttpClientRequestConfiguration configuration = new NettyHttpClientRequestConfiguration();
+
+		public Builder connectionTimeout(int connectionTimeout) {
+			configuration.connectionTimeout = connectionTimeout;
+			return this;
+		}
+
+		public Builder connectionTimeout(Duration duration) {
+			configuration.connectionTimeout = (int) duration.toMillis();
+			return this;
+		}
+
+		public Builder readTimeout(int readTimeout) {
+			configuration.readTimeout = readTimeout;
+			return this;
+		}
+
+		public Builder readTimeout(Duration duration) {
+			configuration.readTimeout = (int) duration.toMillis();
+			return this;
+		}
+
+		public Builder maxResponseSize(int maxResponseSize) {
+			configuration.maxResponseSize = maxResponseSize;
+			return this;
+		}
+
+		public Builder sslContext(SslContext sslContext) {
+			configuration.sslContext = sslContext;
+			return this;
+		}
+
+		public Builder charset(Charset charset) {
+			configuration.charset = charset;
+			return this;
+		}
+
+		public NettyHttpClientRequestConfiguration build() {
+			return configuration;
+		}
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequestFactory.java
@@ -61,7 +61,8 @@ public class NettyHttpClientRequestFactory implements HttpClientRequestFactory, 
 
 	@Override
 	public HttpClientRequest createOf(EndpointRequest endpointRequest) {
-		return new NettyHttpClientRequest(bootstrap, endpointRequest, nettyHttpClientRequestConfiguration.charset());
+		return new NettyHttpClientRequest(bootstrap, endpointRequest.endpoint(), endpointRequest.headers(), endpointRequest.method(),
+				nettyHttpClientRequestConfiguration.charset());
 	}
 
 	@Override

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequestFactory.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.netty;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequestFactory;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.EventLoopGroup;
+
+public class NettyHttpClientRequestFactory implements HttpClientRequestFactory, Closeable {
+
+	private final Bootstrap bootstrap;
+	private final EventLoopGroup eventLoopGroup;
+	private NettyHttpClientRequestConfiguration nettyHttpClientRequestConfiguration;
+
+	public NettyHttpClientRequestFactory() {
+		this(new NettyEventLoopGroupFactory().create());
+	}
+
+	public NettyHttpClientRequestFactory(EventLoopGroup eventLoopGroup) {
+		this(eventLoopGroup, NettyHttpClientRequestConfiguration.useDefault());
+	}
+
+	public NettyHttpClientRequestFactory(NettyHttpClientRequestConfiguration nettyHttpClientRequestConfiguration) {
+		this(new NettyEventLoopGroupFactory().create(), nettyHttpClientRequestConfiguration);
+	}
+
+	public NettyHttpClientRequestFactory(EventLoopGroup eventLoopGroup, NettyHttpClientRequestConfiguration nettyHttpClientRequestConfiguration) {
+		this.eventLoopGroup = eventLoopGroup;
+		this.nettyHttpClientRequestConfiguration = nettyHttpClientRequestConfiguration;
+		this.bootstrap = new NettyBootstrapFactory(eventLoopGroup, nettyHttpClientRequestConfiguration).create();
+	}
+
+	@Override
+	public HttpClientRequest createOf(EndpointRequest endpointRequest) {
+		return new NettyHttpClientRequest(bootstrap, endpointRequest, nettyHttpClientRequestConfiguration.charset());
+	}
+
+	@Override
+	public void close() throws IOException {
+		eventLoopGroup.shutdownGracefully().syncUninterruptibly();
+	}
+
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientResponse.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientResponse.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.netty;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.client.request.HttpRequestMessage;
+import com.github.ljtfreitas.restify.http.client.response.BaseHttpResponseMessage;
+import com.github.ljtfreitas.restify.http.client.response.StatusCode;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpResponse;
+
+class NettyHttpClientResponse extends BaseHttpResponseMessage {
+
+	private final ChannelHandlerContext context;
+	private final FullHttpResponse nettyResponse;
+
+	public NettyHttpClientResponse(StatusCode statusCode, Headers headers, InputStream body, HttpRequestMessage httpRequest, 
+			ChannelHandlerContext context, FullHttpResponse nettyResponse) {
+		super(statusCode, headers, body, httpRequest);
+		this.context = context;
+		this.nettyResponse = nettyResponse;
+	}
+
+	@Override
+	public void close() throws IOException {
+		context.close();
+		nettyResponse.release();
+	}
+
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyRequestExecuteHandler.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyRequestExecuteHandler.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.netty;
+
+import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
+
+import com.github.ljtfreitas.restify.http.client.Header;
+import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.client.request.HttpRequestMessage;
+import com.github.ljtfreitas.restify.http.client.response.StatusCode;
+
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.FullHttpResponse;
+
+class NettyRequestExecuteHandler extends SimpleChannelInboundHandler<FullHttpResponse> {
+
+	private final CompletableFuture<NettyHttpClientResponse> future;
+	private final HttpRequestMessage source;
+
+	public NettyRequestExecuteHandler(CompletableFuture<NettyHttpClientResponse> future, NettyHttpClientRequest source) {
+		this.future = future;
+		this.source = source;
+	}
+
+	@Override
+	protected void channelRead0(ChannelHandlerContext context, FullHttpResponse nettyResponse) throws Exception {
+		NettyHttpClientResponse nettyHttpClientResponse = convert(context, nettyResponse);
+
+		future.complete(nettyHttpClientResponse);
+	}
+
+	private NettyHttpClientResponse convert(ChannelHandlerContext context, FullHttpResponse nettyResponse) {
+		nettyResponse.retain();
+
+		StatusCode statusCode = StatusCode.of(nettyResponse.getStatus().code());
+
+		Headers headers = headersOf(nettyResponse);
+
+		InputStream body = new ByteBufInputStream(nettyResponse.content());
+
+		NettyHttpClientResponse nettyHttpClientResponse = new NettyHttpClientResponse(statusCode, headers, body, source,
+				context, nettyResponse);
+
+		return nettyHttpClientResponse;
+	}
+
+	private Headers headersOf(FullHttpResponse nettyResponse) {
+		Headers headers = new Headers();
+
+		nettyResponse.headers().entries().stream()
+			.map(header -> new Header(header.getKey(), header.getValue()))
+				.forEach(headers::add);
+
+		return headers;
+	}
+
+	@Override
+	public void exceptionCaught(ChannelHandlerContext context, Throwable cause) throws Exception {
+		future.completeExceptionally(cause);
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/okhttp/OkHttpClientRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/okhttp/OkHttpClientRequestFactory.java
@@ -25,6 +25,8 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.client.request.okhttp;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.nio.charset.Charset;
 
 import com.github.ljtfreitas.restify.http.client.charset.Encoding;
@@ -33,7 +35,7 @@ import com.github.ljtfreitas.restify.http.client.request.HttpClientRequestFactor
 
 import okhttp3.OkHttpClient;
 
-public class OkHttpClientRequestFactory implements HttpClientRequestFactory {
+public class OkHttpClientRequestFactory implements HttpClientRequestFactory, Closeable {
 
 	private final OkHttpClient okHttpClient;
 	private final Charset charset;
@@ -60,4 +62,12 @@ public class OkHttpClientRequestFactory implements HttpClientRequestFactory {
 		return new OkHttpClientRequest(okHttpClient, endpointRequest, charset);
 	}
 
+	@Override
+	public void close() throws IOException {
+		if (okHttpClient.cache() != null) {
+			okHttpClient.cache().close();
+		}
+
+		okHttpClient.dispatcher().executorService().shutdown();
+	}
 }

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequestTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequestTest.java
@@ -1,0 +1,164 @@
+package com.github.ljtfreitas.restify.http.client.request.netty;
+
+import static org.hamcrest.Matchers.isA;
+import static org.junit.Assert.assertEquals;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+import static org.mockserver.model.StringBody.exact;
+import static org.mockserver.verify.VerificationTimes.once;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockserver.client.server.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.HttpRequest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.ljtfreitas.restify.http.RestifyHttpException;
+import com.github.ljtfreitas.restify.http.RestifyProxyBuilder;
+import com.github.ljtfreitas.restify.http.contract.BodyParameter;
+import com.github.ljtfreitas.restify.http.contract.Get;
+import com.github.ljtfreitas.restify.http.contract.Header;
+import com.github.ljtfreitas.restify.http.contract.Path;
+import com.github.ljtfreitas.restify.http.contract.Post;
+
+import io.netty.handler.timeout.ReadTimeoutException;
+
+public class NettyHttpClientRequestTest {
+
+	@Rule
+	public MockServerRule mockServerRule = new MockServerRule(this, 7080);
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	private MyApi myApi;
+
+	private MockServerClient mockServerClient;
+
+	@Before
+	public void setup() {
+		mockServerClient = new MockServerClient("localhost", 7080);
+
+		NettyHttpClientRequestConfiguration nettyHttpClientRequestConfiguration = new NettyHttpClientRequestConfiguration.Builder()
+				.readTimeout(Duration.ofMillis(2000))
+					.build();
+
+		NettyHttpClientRequestFactory nettyHttpClientRequestFactory = new NettyHttpClientRequestFactory(nettyHttpClientRequestConfiguration);
+
+		myApi = new RestifyProxyBuilder()
+				.client(nettyHttpClientRequestFactory)
+				.target(MyApi.class, "http://localhost:7080")
+				.build();
+	}
+
+	@Test
+	public void shouldSendGetRequestOnJsonFormat() {
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/json"))
+			.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "application/json")
+					.withBody(json("{\"name\": \"Tiago de Freitas Lima\",\"age\":31}")));
+
+		MyModel myModel = myApi.json();
+
+		assertEquals("Tiago de Freitas Lima", myModel.name);
+		assertEquals(31, myModel.age);
+	}
+
+	@Test
+	public void shouldSendPostRequestOnJsonFormat() {
+		HttpRequest httpRequest = request()
+			.withMethod("POST")
+			.withPath("/json")
+			.withHeader("Content-Type", "application/json; charset=UTF-8")
+			.withBody(json("{\"name\":\"Tiago de Freitas Lima\",\"age\":31}"));
+
+		mockServerClient
+			.when(httpRequest)
+			.respond(response()
+				.withStatusCode(201)
+				.withHeader("Content-Type", "text/plain")
+				.withBody(exact("OK")));
+
+		myApi.json(new MyModel("Tiago de Freitas Lima", 31));
+
+		mockServerClient.verify(httpRequest, once());
+	}
+
+	@Test
+	public void shouldThrowExceptionOnTimeout() {
+		mockServerClient
+			.when(request()
+				.withMethod("GET")
+				.withPath("/json"))
+			.respond(response()
+				.withDelay(TimeUnit.MILLISECONDS, 3000));
+
+		expectedException.expect(isA(RestifyHttpException.class));
+		expectedException.expectCause(deeply(ReadTimeoutException.class));
+
+		myApi.json();
+	}
+
+	private Matcher<? extends Throwable> deeply(Class<? extends Throwable> expectedCause) {
+		return new BaseMatcher<Throwable>() {
+			@Override
+			public boolean matches(Object argument) {
+				Throwable exception = (Throwable) argument;
+				Throwable cause = exception.getCause();
+
+				while (cause != null) {
+					if (expectedCause.isInstance(cause)) return true;
+					cause = cause.getCause();
+				}
+
+				return false;
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText(expectedCause.getName());
+			}
+		};
+	}
+
+	interface MyApi {
+
+		@Path("/json") @Get
+		public MyModel json();
+
+		@Path("/json") @Post
+		@Header(name = "Content-Type", value = "application/json")
+		public void json(@BodyParameter MyModel myModel);
+	}
+
+	public static class MyModel {
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		int age;
+
+		public MyModel() {
+		}
+
+		public MyModel(String name, int age) {
+			this.name = name;
+			this.age = age;
+		}
+	}
+}


### PR DESCRIPTION
## Suporte para o Netty (http client) ☕️ 

## Descrição
- Implementa suporte para utilizar o Netty como http client

## Changelog
- Implementa nova classe *NettyHttpClientRequestFactory*, que utiliza o Netty como client http
- A interface HttpClientRequestFactory passa a extender Closeable