### PR TITLE
[fix-json-converter] Modifica ordem de resolução do JsonConverter

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonMessageConverter.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonMessageConverter.java
@@ -39,8 +39,8 @@ public abstract class JsonMessageConverter<T> implements HttpMessageReader<T>, H
 	}
 
 	public static JsonMessageConverter<?> available() {
-		return  JavaClassDiscovery.present("com.google.gson.Gson") ? new GsonMessageConverter<>()
-					: JavaClassDiscovery.present("com.fasterxml.jackson.databind.ObjectMapper") ? new JacksonMessageConverter<>()
+		return  JavaClassDiscovery.present("com.fasterxml.jackson.databind.ObjectMapper") ? new JacksonMessageConverter<>()
+					: JavaClassDiscovery.present("com.google.gson.Gson") ? new GsonMessageConverter<>()
 						: JavaClassDiscovery.present("javax.json.Json") ? new JsonpMessageConverter()
 								:  new FallbackJsonMessageConverter<>();
 	}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/apache/httpclient/ApacheHttpClientRequestTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/apache/httpclient/ApacheHttpClientRequestTest.java
@@ -24,6 +24,7 @@ import org.mockserver.client.server.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.HttpRequest;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.ljtfreitas.restify.http.RestifyHttpException;
 import com.github.ljtfreitas.restify.http.RestifyProxyBuilder;
 import com.github.ljtfreitas.restify.http.client.request.apache.httpclient.ApacheHttpClientRequestFactory;
@@ -171,13 +172,16 @@ public class ApacheHttpClientRequestTest {
 	@XmlAccessorType(XmlAccessType.FIELD)
 	public static class MyModel {
 
+		@JsonProperty
 		String name;
+
+		@JsonProperty
 		int age;
 
 		public MyModel() {
 		}
 
-		public MyModel(String name, int age) {
+		public MyModel(@JsonProperty String name, @JsonProperty int age) {
 			this.name = name;
 			this.age = age;
 		}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestTest.java
@@ -24,6 +24,7 @@ import org.mockserver.client.server.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.HttpRequest;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.ljtfreitas.restify.http.RestifyHttpException;
 import com.github.ljtfreitas.restify.http.RestifyProxyBuilder;
 import com.github.ljtfreitas.restify.http.contract.BodyParameter;
@@ -209,13 +210,16 @@ public class JdkHttpClientRequestTest {
 	@XmlAccessorType(XmlAccessType.FIELD)
 	public static class MyModel {
 
+		@JsonProperty
 		String name;
+
+		@JsonProperty
 		int age;
 
 		public MyModel() {
 		}
 
-		public MyModel(String name, int age) {
+		public MyModel(@JsonProperty String name, @JsonProperty int age) {
 			this.name = name;
 			this.age = age;
 		}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/okhttp/OkHttpClientRequestTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/okhttp/OkHttpClientRequestTest.java
@@ -23,6 +23,7 @@ import org.mockserver.client.server.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.HttpRequest;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.ljtfreitas.restify.http.RestifyHttpException;
 import com.github.ljtfreitas.restify.http.RestifyProxyBuilder;
 import com.github.ljtfreitas.restify.http.contract.BodyParameter;
@@ -171,13 +172,16 @@ public class OkHttpClientRequestTest {
 	@XmlAccessorType(XmlAccessType.FIELD)
 	public static class MyModel {
 
+		@JsonProperty
 		String name;
+
+		@JsonProperty
 		int age;
 
 		public MyModel() {
 		}
 
-		public MyModel(String name, int age) {
+		public MyModel(@JsonProperty String name, @JsonProperty int age) {
 			this.name = name;
 			this.age = age;
 		}


### PR DESCRIPTION
## Modifica ordem de resolução do JsonConverter :coffee:

### Descrição
- Altera a ordem da resolução do JsonConverter disponível no classpath:o Jackson volta a ter maior prioridade

## Changelog
- Altera a ordem da resolução do JsonConverter disponível no classpath:o Jackson volta a ter maior prioridade (modifica a alteração realizada no pull request https://github.com/ljtfreitas/java-restify/pull/12)