### PR TITLE
[refactor-zookeeper-service-discovery] Zookeeper service discovery - Refactor e melhorias

### DIFF
--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequestFactory.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonHttpClientRequestFactory.java
@@ -49,11 +49,38 @@ public class RibbonHttpClientRequestFactory implements HttpClientRequestFactory 
 		this(loadBalancer, clientConfig, new JdkHttpClientRequestFactory());
 	}
 
+	public RibbonHttpClientRequestFactory(ILoadBalancer loadBalancer, HttpClientRequestFactory delegate) {
+		this(loadBalancer, new DefaultClientConfigImpl(), delegate);
+	}
+
 	public RibbonHttpClientRequestFactory(ILoadBalancer loadBalancer, IClientConfig clientConfig, HttpClientRequestFactory delegate) {
 		this(loadBalancer, clientConfig, delegate, Encoding.UTF_8.charset());
 	}
 
+	public RibbonHttpClientRequestFactory(ILoadBalancer loadBalancer, RibbonExceptionHandler ribbonExceptionHandler) {
+		this(loadBalancer, new DefaultClientConfigImpl(), ribbonExceptionHandler);
+	}
+
+	public RibbonHttpClientRequestFactory(ILoadBalancer loadBalancer, IClientConfig clientConfig, RibbonExceptionHandler ribbonExceptionHandler) {
+		this(loadBalancer, clientConfig, new JdkHttpClientRequestFactory(), ribbonExceptionHandler);
+	}
+
+	public RibbonHttpClientRequestFactory(ILoadBalancer loadBalancer, IClientConfig clientConfig, HttpClientRequestFactory delegate,
+			RibbonExceptionHandler ribbonExceptionHandler) {
+		this(new RibbonLoadBalancedClient(loadBalancer, clientConfig, delegate, ribbonExceptionHandler), Encoding.UTF_8.charset());
+	}
+
+	public RibbonHttpClientRequestFactory(ILoadBalancer loadBalancer, IClientConfig clientConfig, RibbonExceptionHandler ribbonExceptionHandler,
+			Charset charset) {
+		this(loadBalancer, clientConfig, new JdkHttpClientRequestFactory(), ribbonExceptionHandler, charset);
+	}
+
 	public RibbonHttpClientRequestFactory(ILoadBalancer loadBalancer, IClientConfig clientConfig, HttpClientRequestFactory delegate, Charset charset) {
+		this(new RibbonLoadBalancedClient(loadBalancer, clientConfig, delegate), charset);
+	}
+
+	public RibbonHttpClientRequestFactory(ILoadBalancer loadBalancer, IClientConfig clientConfig, HttpClientRequestFactory delegate,
+			RibbonExceptionHandler ribbonExceptionHandler, Charset charset) {
 		this(new RibbonLoadBalancedClient(loadBalancer, clientConfig, delegate), charset);
 	}
 

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonLoadBalancedClient.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/RibbonLoadBalancedClient.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequestFactory;
+import com.github.ljtfreitas.restify.http.client.request.jdk.JdkHttpClientRequestFactory;
 import com.github.ljtfreitas.restify.http.client.response.HttpResponseMessage;
 import com.netflix.client.AbstractLoadBalancerAwareClient;
 import com.netflix.client.RequestSpecificRetryHandler;
@@ -44,15 +45,36 @@ public class RibbonLoadBalancedClient extends AbstractLoadBalancerAwareClient<Ri
 	private final HttpClientRequestFactory httpClientRequestFactory;
 	private final RibbonExceptionHandler ribbonExceptionHandler;
 
+	public RibbonLoadBalancedClient(ILoadBalancer loadBalancer) {
+		this(loadBalancer, new DefaultClientConfigImpl(), new JdkHttpClientRequestFactory(), new SimpleRibbonExceptionHandler());
+	}
+
+	public RibbonLoadBalancedClient(ILoadBalancer loadBalancer, IClientConfig clientConfig) {
+		this(loadBalancer, clientConfig, new JdkHttpClientRequestFactory(), new SimpleRibbonExceptionHandler());
+	}
+
 	public RibbonLoadBalancedClient(ILoadBalancer loadBalancer, IClientConfig clientConfig, HttpClientRequestFactory httpClientRequestFactory) {
 		this(loadBalancer, clientConfig, httpClientRequestFactory, new SimpleRibbonExceptionHandler());
 	}
 
-	public RibbonLoadBalancedClient(ILoadBalancer loadBalancer, IClientConfig clientConfig, HttpClientRequestFactory httpClientRequestFactory, RibbonExceptionHandler ribbonRequestExceptionObserver) {
+	public RibbonLoadBalancedClient(ILoadBalancer loadBalancer, HttpClientRequestFactory httpClientRequestFactory) {
+		this(loadBalancer, new DefaultClientConfigImpl(), httpClientRequestFactory, new SimpleRibbonExceptionHandler());
+	}
+
+	public RibbonLoadBalancedClient(ILoadBalancer loadBalancer, RibbonExceptionHandler ribbonExceptionHandler) {
+		this(loadBalancer, new DefaultClientConfigImpl(), new JdkHttpClientRequestFactory(), ribbonExceptionHandler);
+	}
+
+	public RibbonLoadBalancedClient(ILoadBalancer loadBalancer, IClientConfig clientConfig, RibbonExceptionHandler ribbonExceptionHandler) {
+		this(loadBalancer, clientConfig, new JdkHttpClientRequestFactory(), ribbonExceptionHandler);
+	}
+
+	public RibbonLoadBalancedClient(ILoadBalancer loadBalancer, IClientConfig clientConfig, HttpClientRequestFactory httpClientRequestFactory,
+			RibbonExceptionHandler ribbonExceptionHandler) {
 		super(loadBalancer, clientConfig);
 		this.clientConfig = clientConfig;
 		this.httpClientRequestFactory = httpClientRequestFactory;
-		this.ribbonExceptionHandler = ribbonRequestExceptionObserver;
+		this.ribbonExceptionHandler = ribbonExceptionHandler;
 	}
 
 	@Override

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperConfiguration.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperConfiguration.java
@@ -25,41 +25,35 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.netflix.client.request.zookeeper;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import static com.github.ljtfreitas.restify.http.util.Preconditions.nonNull;
 
-import com.netflix.client.config.IClientConfig;
-import com.netflix.loadbalancer.AbstractServerList;
-import com.netflix.loadbalancer.Server;
+public class ZookeeperConfiguration {
 
-public class ZookeeperServers extends AbstractServerList<Server> {
+	private final String address;
+	private final Integer port;
+	private final String root;
 
-	private final String serviceName;
-	private final ZookeeperServiceDiscovery zookeeperServiceDiscovery;
-
-	public ZookeeperServers(String serviceName, ZookeeperServiceDiscovery zookeeperServiceDiscovery) {
-		this.serviceName = serviceName;
-		this.zookeeperServiceDiscovery = zookeeperServiceDiscovery;
+	public ZookeeperConfiguration(String root) {
+		this(null, 2181, root);
 	}
 
-	@Override
-	public List<Server> getInitialListOfServers() {
-		return allServers();
+	public ZookeeperConfiguration(String address, int port) {
+		this(address, port, "/");
 	}
 
-	@Override
-	public List<Server> getUpdatedListOfServers() {
-		return allServers();
+	public ZookeeperConfiguration(String address, int port, String root) {
+		this.address = address;
+		this.port = port;
+		this.root = root;
 	}
 
-	private List<Server> allServers() {
-		return zookeeperServiceDiscovery.queryForInstances(serviceName)
-				.stream()
-					.map(instance -> new ZookeeperServer(instance))
-						.collect(Collectors.toList());
+	public String root() {
+		return root;
 	}
 
-	@Override
-	public void initWithNiwsConfig(IClientConfig clientConfig) {
+	public String connectionString() {
+		nonNull(address, "Zookeeper address cannot be null.");
+		nonNull(port, "Zookeeper port cannot be null.");
+		return address + ":" + port;
 	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperInstance.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperInstance.java
@@ -48,9 +48,6 @@ public class ZookeeperInstance {
 	private String address;
 
 	@JsonProperty
-	private boolean secure;
-
-	@JsonProperty
 	private Map<String, String> metadata;
 
 	@Deprecated
@@ -85,11 +82,32 @@ public class ZookeeperInstance {
 		return address;
 	}
 
-	public boolean secure() {
-		return secure;
-	}
-
 	public Map<String, String> metadata() {
 		return Collections.unmodifiableMap(metadata);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder report = new StringBuilder();
+
+		report
+			.append("ZookeeperInstance: [")
+				.append("Id: ")
+					.append(id)
+				.append(", ")
+				.append("Name: ")
+					.append(name)
+				.append(", ")
+				.append("Address: ")
+					.append(address)
+				.append(", ")
+				.append("Port: ")
+					.append(port)
+				.append(", ")
+				.append("Metadata: ")
+					.append(metadata)
+			.append("]");
+
+		return report.toString();
 	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperServiceDiscoveryException.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/zookeeper/ZookeeperServiceDiscoveryException.java
@@ -25,41 +25,19 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.netflix.client.request.zookeeper;
 
-import java.util.List;
-import java.util.stream.Collectors;
+public class ZookeeperServiceDiscoveryException extends RuntimeException {
 
-import com.netflix.client.config.IClientConfig;
-import com.netflix.loadbalancer.AbstractServerList;
-import com.netflix.loadbalancer.Server;
+	private static final long serialVersionUID = 1L;
 
-public class ZookeeperServers extends AbstractServerList<Server> {
-
-	private final String serviceName;
-	private final ZookeeperServiceDiscovery zookeeperServiceDiscovery;
-
-	public ZookeeperServers(String serviceName, ZookeeperServiceDiscovery zookeeperServiceDiscovery) {
-		this.serviceName = serviceName;
-		this.zookeeperServiceDiscovery = zookeeperServiceDiscovery;
+	public ZookeeperServiceDiscoveryException(String message, Throwable cause) {
+		super(message, cause);
 	}
 
-	@Override
-	public List<Server> getInitialListOfServers() {
-		return allServers();
+	public ZookeeperServiceDiscoveryException(String message) {
+		super(message);
 	}
 
-	@Override
-	public List<Server> getUpdatedListOfServers() {
-		return allServers();
-	}
-
-	private List<Server> allServers() {
-		return zookeeperServiceDiscovery.queryForInstances(serviceName)
-				.stream()
-					.map(instance -> new ZookeeperServer(instance))
-						.collect(Collectors.toList());
-	}
-
-	@Override
-	public void initWithNiwsConfig(IClientConfig clientConfig) {
+	public ZookeeperServiceDiscoveryException(Throwable cause) {
+		super(cause);
 	}
 }


### PR DESCRIPTION
## Zookeeper service discovery - Refactor e melhorias

## Descrição
- Refatorações nas classes de service discovery do Zookeeper - modificações da estrutura interna dos objetos e formato dos construtores

## Changelog
- Implementa novos construtores para as classes *RibbonHttpClientRequestFactory*, *RibbonLoadBalancedClient* e *ZookeeperServiceDiscovery*
- Implementa configuração padrão do Curator, caso o usuário não forneça uma instância configurada
- Renomeia e refatora a classe *ZookeeperConfiguration*
- Implementa nova exceção para a classe *ZookeeperServiceDiscoveryException*

