### PR TITLE
[collections-executables] Executables para coleções

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
@@ -45,11 +45,17 @@ import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallObjectExe
 import com.github.ljtfreitas.restify.http.client.call.exec.HeadersEndpointCallExecutableFactory;
 import com.github.ljtfreitas.restify.http.client.call.exec.async.AsyncCallbackEndpointCallExecutableFactory;
 import com.github.ljtfreitas.restify.http.client.call.exec.async.AsyncEndpointCallExecutableFactory;
+import com.github.ljtfreitas.restify.http.client.call.exec.jdk.ArrayEndpointCallExecutableFactory;
 import com.github.ljtfreitas.restify.http.client.call.exec.jdk.CallableEndpointCallExecutableFactory;
+import com.github.ljtfreitas.restify.http.client.call.exec.jdk.CollectionEndpointCallExecutableFactory;
 import com.github.ljtfreitas.restify.http.client.call.exec.jdk.CompletableFutureCallbackEndpointCallExecutableFactory;
 import com.github.ljtfreitas.restify.http.client.call.exec.jdk.CompletableFutureEndpointCallExecutableFactory;
+import com.github.ljtfreitas.restify.http.client.call.exec.jdk.EnumerationEndpointCallExecutableFactory;
 import com.github.ljtfreitas.restify.http.client.call.exec.jdk.FutureEndpointCallExecutableFactory;
 import com.github.ljtfreitas.restify.http.client.call.exec.jdk.FutureTaskEndpointCallExecutableFactory;
+import com.github.ljtfreitas.restify.http.client.call.exec.jdk.IterableEndpointCallExecutableFactory;
+import com.github.ljtfreitas.restify.http.client.call.exec.jdk.IteratorEndpointCallExecutableFactory;
+import com.github.ljtfreitas.restify.http.client.call.exec.jdk.ListIteratorEndpointCallExecutableFactory;
 import com.github.ljtfreitas.restify.http.client.call.exec.jdk.OptionalEndpointCallExecutableFactory;
 import com.github.ljtfreitas.restify.http.client.call.exec.jdk.RunnableEndpointCallExecutableFactory;
 import com.github.ljtfreitas.restify.http.client.message.HttpMessageConverter;
@@ -365,6 +371,12 @@ public class RestifyProxyBuilder {
 			this.built.add(new OptionalEndpointCallExecutableFactory<Object>());
 			this.built.add(new CallableEndpointCallExecutableFactory<Object, Object>());
 			this.built.add(new RunnableEndpointCallExecutableFactory());
+			this.built.add(new CollectionEndpointCallExecutableFactory<>());
+			this.built.add(new ArrayEndpointCallExecutableFactory<>());
+			this.built.add(new EnumerationEndpointCallExecutableFactory<>());
+			this.built.add(new IteratorEndpointCallExecutableFactory<>());
+			this.built.add(new ListIteratorEndpointCallExecutableFactory<>());
+			this.built.add(new IterableEndpointCallExecutableFactory<>());
 			this.built.add(new EndpointCallObjectExecutableFactory<Object, Object>());
 			this.built.add(new HeadersEndpointCallExecutableFactory());
 		}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/HeadersEndpointCallExecutableFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/HeadersEndpointCallExecutableFactory.java
@@ -51,7 +51,7 @@ public class HeadersEndpointCallExecutableFactory implements EndpointCallExecuta
 		return new HeadersEndpointCallExecutable(executable);
 	}
 
-	public class HeadersEndpointCallExecutable implements EndpointCallExecutable<Headers, Void> {
+	private class HeadersEndpointCallExecutable implements EndpointCallExecutable<Headers, Void> {
 
 		private final EndpointCallExecutable<EndpointResponse<Void>, Void> delegate;
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/ArrayEndpointCallExecutableFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/ArrayEndpointCallExecutableFactory.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.exec.jdk;
+
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutableFactory;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+
+public class ArrayEndpointCallExecutableFactory<T> implements EndpointCallExecutableFactory<T[], T[]> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().arrayType();
+	}
+
+	@Override
+	public EndpointCallExecutable<T[], T[]> create(EndpointMethod endpointMethod) {
+		return new ArrayEndpointCallExecutable(endpointMethod.returnType());
+	}
+
+	private class ArrayEndpointCallExecutable implements EndpointCallExecutable<T[], T[]> {
+
+		private final JavaType returnType;
+
+		public ArrayEndpointCallExecutable(JavaType returnType) {
+			this.returnType = returnType;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return returnType;
+		}
+
+		@Override
+		public T[] execute(EndpointCall<T[]> call, Object[] args) {
+			return Optional.ofNullable(call.execute()).orElseGet(() -> empty());
+		}
+
+		@SuppressWarnings("unchecked")
+		private T[] empty() {
+			return (T[]) new Object[0];
+		}
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/CollectionEndpointCallExecutableFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/CollectionEndpointCallExecutableFactory.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.exec.jdk;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutableFactory;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+
+public class CollectionEndpointCallExecutableFactory<T> implements EndpointCallExecutableFactory<Collection<T>, Collection<T>> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		Class<?> classType = endpointMethod.returnType().classType();
+		return List.class.isAssignableFrom(classType)
+			|| Set.class.isAssignableFrom(classType)
+			|| Collection.class.equals(classType);
+	}
+
+	@Override
+	public EndpointCallExecutable<Collection<T>, Collection<T>> create(EndpointMethod endpointMethod) {
+		return new CollectionEndpointCallExecutable(endpointMethod.returnType());
+	}
+
+	private class CollectionEndpointCallExecutable implements EndpointCallExecutable<Collection<T>, Collection<T>> {
+
+		private final JavaType returnType;
+
+		public CollectionEndpointCallExecutable(JavaType returnType) {
+			this.returnType = returnType;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return returnType;
+		}
+
+		@Override
+		public Collection<T> execute(EndpointCall<Collection<T>> call, Object[] args) {
+			return Optional.ofNullable(call.execute()).orElseGet(() -> empty());
+		}
+
+		private Collection<T> empty() {
+			Class<?> classType = returnType.classType();
+
+			if (classType.equals(NavigableSet.class)) {
+				return Collections.emptyNavigableSet();
+
+			} else if (classType.equals(SortedSet.class)) {
+				return Collections.emptySortedSet();
+
+			} else if (Set.class.isAssignableFrom(classType)) {
+				return Collections.emptySet();
+
+			} else {
+				return Collections.emptyList();
+			}
+		}
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/EnumerationEndpointCallExecutableFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/EnumerationEndpointCallExecutableFactory.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.exec.jdk;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutableDecoratorFactory;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleParameterizedType;
+
+public class EnumerationEndpointCallExecutableFactory<T> implements EndpointCallExecutableDecoratorFactory<Enumeration<T>, Collection<T>, Collection<T>> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Enumeration.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return collectionTypeOf(endpointMethod.returnType());
+	}
+
+	private JavaType collectionTypeOf(JavaType type) {
+		Type responseType = type.parameterized() ? type.as(ParameterizedType.class).getActualTypeArguments()[0] : Object.class;
+		return JavaType.of(new SimpleParameterizedType(Collection.class, null, responseType));
+	}
+
+	@Override
+	public EndpointCallExecutable<Enumeration<T>, Collection<T>> create(EndpointMethod endpointMethod, EndpointCallExecutable<Collection<T>, Collection<T>> delegate) {
+		return new EnumerationEndpointCallExecutable(delegate);
+	}
+
+	private class EnumerationEndpointCallExecutable implements EndpointCallExecutable<Enumeration<T>, Collection<T>> {
+
+		private final EndpointCallExecutable<Collection<T>, Collection<T>> delegate;
+
+		public EnumerationEndpointCallExecutable(EndpointCallExecutable<Collection<T>, Collection<T>> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Enumeration<T> execute(EndpointCall<Collection<T>> call, Object[] args) {
+			return Collections.enumeration(delegate.execute(call, args));
+		}
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/IterableEndpointCallExecutableFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/IterableEndpointCallExecutableFactory.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.exec.jdk;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutableDecoratorFactory;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleParameterizedType;
+
+public class IterableEndpointCallExecutableFactory<T> implements EndpointCallExecutableDecoratorFactory<Iterable<T>, Collection<T>, Collection<T>> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Iterable.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return collectionTypeOf(endpointMethod.returnType());
+	}
+
+	private JavaType collectionTypeOf(JavaType type) {
+		Type responseType = type.parameterized() ? type.as(ParameterizedType.class).getActualTypeArguments()[0] : Object.class;
+		return JavaType.of(new SimpleParameterizedType(Collection.class, null, responseType));
+	}
+
+	@Override
+	public EndpointCallExecutable<Iterable<T>, Collection<T>> create(EndpointMethod endpointMethod, EndpointCallExecutable<Collection<T>, Collection<T>> delegate) {
+		return new IterableEndpointCallExecutable(delegate);
+	}
+
+	private class IterableEndpointCallExecutable implements EndpointCallExecutable<Iterable<T>, Collection<T>> {
+
+		private final EndpointCallExecutable<Collection<T>, Collection<T>> delegate;
+
+		public IterableEndpointCallExecutable(EndpointCallExecutable<Collection<T>, Collection<T>> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Iterable<T> execute(EndpointCall<Collection<T>> call, Object[] args) {
+			return Optional.ofNullable(delegate.execute(call, args))
+				.orElseGet(Collections::emptyList);
+		}
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/IteratorEndpointCallExecutableFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/IteratorEndpointCallExecutableFactory.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.exec.jdk;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Iterator;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutableDecoratorFactory;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleParameterizedType;
+
+public class IteratorEndpointCallExecutableFactory<T> implements EndpointCallExecutableDecoratorFactory<Iterator<T>, Collection<T>, Collection<T>> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Iterator.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return collectionTypeOf(endpointMethod.returnType());
+	}
+
+	private JavaType collectionTypeOf(JavaType type) {
+		Type responseType = type.parameterized() ? type.as(ParameterizedType.class).getActualTypeArguments()[0] : Object.class;
+		return JavaType.of(new SimpleParameterizedType(Collection.class, null, responseType));
+	}
+
+	@Override
+	public EndpointCallExecutable<Iterator<T>, Collection<T>> create(EndpointMethod endpointMethod, EndpointCallExecutable<Collection<T>, Collection<T>> delegate) {
+		return new IteratorEndpointCallExecutable(delegate);
+	}
+
+	private class IteratorEndpointCallExecutable implements EndpointCallExecutable<Iterator<T>, Collection<T>> {
+
+		private final EndpointCallExecutable<Collection<T>, Collection<T>> delegate;
+
+		public IteratorEndpointCallExecutable(EndpointCallExecutable<Collection<T>, Collection<T>> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Iterator<T> execute(EndpointCall<Collection<T>> call, Object[] args) {
+			Collection<T> collection = delegate.execute(call, args);
+			return collection.iterator();
+		}
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/IteratorEndpointCallExecutableFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/IteratorEndpointCallExecutableFactory.java
@@ -28,7 +28,9 @@ package com.github.ljtfreitas.restify.http.client.call.exec.jdk;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.Optional;
 
 import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
 import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
@@ -74,8 +76,9 @@ public class IteratorEndpointCallExecutableFactory<T> implements EndpointCallExe
 
 		@Override
 		public Iterator<T> execute(EndpointCall<Collection<T>> call, Object[] args) {
-			Collection<T> collection = delegate.execute(call, args);
-			return collection.iterator();
+			return Optional.ofNullable(delegate.execute(call, args))
+				.map(c -> c.iterator())
+					.orElseGet(Collections::emptyIterator);
 		}
 	}
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/ListIteratorEndpointCallExecutableFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/ListIteratorEndpointCallExecutableFactory.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.exec.jdk;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutableDecoratorFactory;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleParameterizedType;
+
+public class ListIteratorEndpointCallExecutableFactory<T> implements EndpointCallExecutableDecoratorFactory<ListIterator<T>, List<T>, List<T>> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(ListIterator.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return listTypeOf(endpointMethod.returnType());
+	}
+
+	private JavaType listTypeOf(JavaType type) {
+		Type responseType = type.parameterized() ? type.as(ParameterizedType.class).getActualTypeArguments()[0] : Object.class;
+		return JavaType.of(new SimpleParameterizedType(List.class, null, responseType));
+	}
+
+	@Override
+	public EndpointCallExecutable<ListIterator<T>, List<T>> create(EndpointMethod endpointMethod, EndpointCallExecutable<List<T>, List<T>> delegate) {
+		return new ListIteratorEndpointCallExecutable(delegate);
+	}
+
+	private class ListIteratorEndpointCallExecutable implements EndpointCallExecutable<ListIterator<T>, List<T>> {
+
+		private final EndpointCallExecutable<List<T>, List<T>> delegate;
+
+		public ListIteratorEndpointCallExecutable(EndpointCallExecutable<List<T>, List<T>> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public ListIterator<T> execute(EndpointCall<List<T>> call, Object[] args) {
+			return Optional.ofNullable(delegate.execute(call, args))
+				.map(c -> c.listIterator())
+					.orElseGet(Collections::emptyListIterator);
+		}
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaType.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaType.java
@@ -53,6 +53,11 @@ public class JavaType {
 		return rawClassType.equals(Void.class) || rawClassType.equals(Void.TYPE);
 	}
 
+	public boolean arrayType() {
+		Class<?> rawClassType = rawClassType();
+		return rawClassType.isArray();
+	}
+
 	public boolean is(Class<?> classType) {
 		return rawClassType().equals(classType);
 	}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/ArrayEndpointCallExecutableFactoryTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/ArrayEndpointCallExecutableFactoryTest.java
@@ -1,0 +1,65 @@
+package com.github.ljtfreitas.restify.http.client.call.exec.jdk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.contract.metadata.SimpleEndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ArrayEndpointCallExecutableFactoryTest {
+
+	@Mock
+	private EndpointCall<String[]> endpointCall;
+
+	private ArrayEndpointCallExecutableFactory<String> factory;
+
+	@Before
+	public void setup() {
+		factory = new ArrayEndpointCallExecutableFactory<>();
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsCollection() throws Exception {
+		assertTrue(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("array"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotArray() throws Exception {
+		assertFalse(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldCreateExecutableFromEndpointMethodWithArrayReturnType() throws Exception {
+		EndpointCallExecutable<String[], String[]> executable = factory.create(new SimpleEndpointMethod(SomeType.class.getMethod("array")));
+
+		String[] result = {"result"};
+
+		when(endpointCall.execute())
+			.thenReturn(result);
+
+		String[] array = executable.execute(endpointCall, null);
+
+		assertSame(result, array);
+		assertEquals(JavaType.of(result.getClass()), executable.returnType());
+	}
+
+	interface SomeType {
+
+		String[] array();
+
+		String string();
+	}
+
+}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/CallableEndpointCallExecutableFactoryTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/CallableEndpointCallExecutableFactoryTest.java
@@ -51,7 +51,6 @@ public class CallableEndpointCallExecutableFactoryTest {
 		assertFalse(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
 	}
 
-
 	@Test
 	public void shouldReturnArgumentTypeOfCallable() throws Exception {
 		assertEquals(JavaType.of(String.class), factory.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("callable"))));

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/CollectionEndpointCallExecutableFactoryTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/CollectionEndpointCallExecutableFactoryTest.java
@@ -1,0 +1,115 @@
+package com.github.ljtfreitas.restify.http.client.call.exec.jdk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.contract.metadata.SimpleEndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleParameterizedType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CollectionEndpointCallExecutableFactoryTest {
+
+	@Mock
+	private EndpointCall<Collection<String>> endpointCall;
+
+	private CollectionEndpointCallExecutableFactory<String> factory;
+
+	@Before
+	public void setup() {
+		factory = new CollectionEndpointCallExecutableFactory<>();
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsCollection() throws Exception {
+		assertTrue(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("collection"))));
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsList() throws Exception {
+		assertTrue(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("list"))));
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsSet() throws Exception {
+		assertTrue(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("set"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotCollection() throws Exception {
+		assertFalse(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldCreateExecutableFromEndpointMethodWithCollectionReturnType() throws Exception {
+		EndpointCallExecutable<Collection<String>, Collection<String>> executable = factory.create(new SimpleEndpointMethod(SomeType.class.getMethod("collection")));
+
+		Collection<String> result = Arrays.asList("result");
+
+		when(endpointCall.execute())
+			.thenReturn(result);
+
+		Collection<String> collection = executable.execute(endpointCall, null);
+
+		assertSame(result, collection);
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)), executable.returnType());
+	}
+
+	@Test
+	public void shouldCreateExecutableFromEndpointMethodWithSetReturnType() throws Exception {
+		EndpointCallExecutable<Collection<String>, Collection<String>> executable = factory.create(new SimpleEndpointMethod(SomeType.class.getMethod("set")));
+
+		Set<String> result = Collections.singleton("result");
+
+		when(endpointCall.execute())
+			.thenReturn(result);
+
+		Collection<String> collection = executable.execute(endpointCall, null);
+
+		assertSame(result, collection);
+		assertEquals(JavaType.of(new SimpleParameterizedType(Set.class, null, String.class)), executable.returnType());
+	}
+
+	@Test
+	public void shouldCreateExecutableFromEndpointMethodWithListReturnType() throws Exception {
+		EndpointCallExecutable<Collection<String>, Collection<String>> executable = factory.create(new SimpleEndpointMethod(SomeType.class.getMethod("list")));
+
+		Collection<String> result = Arrays.asList("result");
+
+		when(endpointCall.execute())
+			.thenReturn(result);
+
+		Collection<String> collection = executable.execute(endpointCall, null);
+
+		assertSame(result, collection);
+		assertEquals(JavaType.of(new SimpleParameterizedType(List.class, null, String.class)), executable.returnType());
+	}
+
+	interface SomeType {
+
+		Collection<String> collection();
+
+		List<String> list();
+
+		Set<String> set();
+
+		String string();
+	}
+}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/EnumerationEndpointCallExecutableFactoryTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/EnumerationEndpointCallExecutableFactoryTest.java
@@ -1,0 +1,88 @@
+package com.github.ljtfreitas.restify.http.client.call.exec.jdk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Enumeration;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.contract.metadata.SimpleEndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleParameterizedType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EnumerationEndpointCallExecutableFactoryTest {
+
+	@Mock
+	private EndpointCallExecutable<Collection<String>, Collection<String>> delegate;
+
+	private EnumerationEndpointCallExecutableFactory<String> factory;
+
+	@Before
+	public void setup() {
+		factory = new EnumerationEndpointCallExecutableFactory<>();
+
+		when(delegate.execute(any(), anyVararg()))
+			.then(invocation -> invocation.getArgumentAt(0, EndpointCall.class).execute());
+
+		when(delegate.returnType())
+			.thenReturn(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)));
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsEnumeration() throws Exception {
+		assertTrue(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("enumeration"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotEnumeration() throws Exception {
+		assertFalse(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionParameterizedWithArgumentTypeOfEnumeration() throws Exception {
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)), factory.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("enumeration"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionParameterizedWithObjectWhenEnumerationIsNotParameterized() throws Exception {
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, Object.class)), factory.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbEnumeration"))));
+	}
+
+	@Test
+	public void shouldCreateExecutableFromEndpointMethodWithEnumerationReturnType() throws Exception {
+		EndpointCallExecutable<Enumeration<String>, Collection<String>> executable = factory.create(new SimpleEndpointMethod(SomeType.class.getMethod("enumeration")), delegate);
+
+		Collection<String> result = Arrays.asList("result");
+
+		Enumeration<String> enumeration = executable.execute(() -> result, null);
+
+		assertTrue(enumeration.hasMoreElements());
+		assertEquals("result", enumeration.nextElement());
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)), executable.returnType());
+	}
+
+	private interface SomeType {
+
+		Enumeration<String> enumeration();
+
+		@SuppressWarnings("rawtypes")
+		Enumeration dumbEnumeration();
+
+		String string();
+	}
+
+}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/IterableEndpointCallExecutableFactoryTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/IterableEndpointCallExecutableFactoryTest.java
@@ -1,0 +1,92 @@
+package com.github.ljtfreitas.restify.http.client.call.exec.jdk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.contract.metadata.SimpleEndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleParameterizedType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IterableEndpointCallExecutableFactoryTest {
+
+	@Mock
+	private EndpointCallExecutable<Collection<String>, Collection<String>> delegate;
+
+	private IterableEndpointCallExecutableFactory<String> factory;
+
+	@Before
+	public void setup() {
+		factory = new IterableEndpointCallExecutableFactory<>();
+
+		when(delegate.execute(any(), anyVararg()))
+			.then(invocation -> invocation.getArgumentAt(0, EndpointCall.class).execute());
+
+		when(delegate.returnType())
+			.thenReturn(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)));
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsIterable() throws Exception {
+		assertTrue(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("iterable"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotIterable() throws Exception {
+		assertFalse(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionParameterizedWithArgumentTypeOfIterable() throws Exception {
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)),
+				factory.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("iterable"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionParameterizedWithObjectWhenIterableIsNotParameterized() throws Exception {
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, Object.class)),
+				factory.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbIterable"))));
+	}
+
+	@Test
+	public void shouldCreateExecutableFromEndpointMethodWithIteratorReturnType() throws Exception {
+		EndpointCallExecutable<Iterable<String>, Collection<String>> executable = factory.create(new SimpleEndpointMethod(SomeType.class.getMethod("iterable")), delegate);
+
+		Collection<String> result = Arrays.asList("result");
+
+		Iterable<String> iterable = executable.execute(() -> result, null);
+
+		Iterator<String> iterator = iterable.iterator();
+
+		assertTrue(iterator.hasNext());
+		assertEquals("result", iterator.next());
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)), executable.returnType());
+	}
+
+	private interface SomeType {
+
+		Iterable<String> iterable();
+
+		@SuppressWarnings("rawtypes")
+		Iterable dumbIterable();
+
+		String string();
+	}
+
+}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/IteratorEndpointCallExecutableFactoryTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/IteratorEndpointCallExecutableFactoryTest.java
@@ -1,0 +1,90 @@
+package com.github.ljtfreitas.restify.http.client.call.exec.jdk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.contract.metadata.SimpleEndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleParameterizedType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IteratorEndpointCallExecutableFactoryTest {
+
+	@Mock
+	private EndpointCallExecutable<Collection<String>, Collection<String>> delegate;
+
+	private IteratorEndpointCallExecutableFactory<String> factory;
+
+	@Before
+	public void setup() {
+		factory = new IteratorEndpointCallExecutableFactory<>();
+
+		when(delegate.execute(any(), anyVararg()))
+			.then(invocation -> invocation.getArgumentAt(0, EndpointCall.class).execute());
+
+		when(delegate.returnType())
+			.thenReturn(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)));
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsIterator() throws Exception {
+		assertTrue(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("iterator"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotIterator() throws Exception {
+		assertFalse(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionParameterizedWithArgumentTypeOfIterator() throws Exception {
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)),
+				factory.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("iterator"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionParameterizedWithObjectWhenIteratorIsNotParameterized() throws Exception {
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, Object.class)),
+				factory.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbIterator"))));
+	}
+
+	@Test
+	public void shouldCreateExecutableFromEndpointMethodWithIteratorReturnType() throws Exception {
+		EndpointCallExecutable<Iterator<String>, Collection<String>> executable = factory.create(new SimpleEndpointMethod(SomeType.class.getMethod("iterator")), delegate);
+
+		Collection<String> result = Arrays.asList("result");
+
+		Iterator<String> iterator = executable.execute(() -> result, null);
+
+		assertTrue(iterator.hasNext());
+		assertEquals("result", iterator.next());
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)), executable.returnType());
+	}
+
+	private interface SomeType {
+
+		Iterator<String> iterator();
+
+		@SuppressWarnings("rawtypes")
+		Iterator dumbIterator();
+
+		String string();
+	}
+
+}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/ListIteratorEndpointCallExecutableFactoryTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/ListIteratorEndpointCallExecutableFactoryTest.java
@@ -1,0 +1,90 @@
+package com.github.ljtfreitas.restify.http.client.call.exec.jdk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.ListIterator;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.exec.EndpointCallExecutable;
+import com.github.ljtfreitas.restify.http.contract.metadata.SimpleEndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleParameterizedType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ListIteratorEndpointCallExecutableFactoryTest {
+
+	@Mock
+	private EndpointCallExecutable<List<String>, List<String>> delegate;
+
+	private ListIteratorEndpointCallExecutableFactory<String> factory;
+
+	@Before
+	public void setup() {
+		factory = new ListIteratorEndpointCallExecutableFactory<>();
+
+		when(delegate.execute(any(), anyVararg()))
+			.then(invocation -> invocation.getArgumentAt(0, EndpointCall.class).execute());
+
+		when(delegate.returnType())
+			.thenReturn(JavaType.of(new SimpleParameterizedType(List.class, null, String.class)));
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsListIterator() throws Exception {
+		assertTrue(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("listIterator"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotListIterator() throws Exception {
+		assertFalse(factory.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnListParameterizedWithArgumentTypeOfListIterator() throws Exception {
+		assertEquals(JavaType.of(new SimpleParameterizedType(List.class, null, String.class)),
+				factory.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("listIterator"))));
+	}
+
+	@Test
+	public void shouldReturnListParameterizedWithObjectWhenListIteratorIsNotParameterized() throws Exception {
+		assertEquals(JavaType.of(new SimpleParameterizedType(List.class, null, Object.class)),
+				factory.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbListIterator"))));
+	}
+
+	@Test
+	public void shouldCreateExecutableFromEndpointMethodWithListIteratorReturnType() throws Exception {
+		EndpointCallExecutable<ListIterator<String>, List<String>> executable = factory.create(new SimpleEndpointMethod(SomeType.class.getMethod("listIterator")), delegate);
+
+		List<String> result = Arrays.asList("result");
+
+		ListIterator<String> ListIterator = executable.execute(() -> result, null);
+
+		assertTrue(ListIterator.hasNext());
+		assertEquals("result", ListIterator.next());
+		assertEquals(JavaType.of(new SimpleParameterizedType(List.class, null, String.class)), executable.returnType());
+	}
+
+	private interface SomeType {
+
+		ListIterator<String> listIterator();
+
+		@SuppressWarnings("rawtypes")
+		ListIterator dumbListIterator();
+
+		String string();
+	}
+
+}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/OptionalEndpointCallExecutableFactoryTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/exec/jdk/OptionalEndpointCallExecutableFactoryTest.java
@@ -51,9 +51,9 @@ public class OptionalEndpointCallExecutableFactoryTest {
 		when(endpointCall.execute())
 			.thenReturn(result);
 
-		Optional<String> future = executable.execute(endpointCall, null);
+		Optional<String> optional = executable.execute(endpointCall, null);
 
-		assertEquals(result, future.get());
+		assertEquals(result, optional.get());
 		assertEquals(JavaType.of(String.class), executable.returnType());
 	}
 
@@ -63,7 +63,7 @@ public class OptionalEndpointCallExecutableFactoryTest {
 		assertEquals(JavaType.of(Object.class), executable.returnType());
 	}
 
-	interface SomeType {
+	private interface SomeType {
 
 		Optional<String> optional();
 


### PR DESCRIPTION
## Executables para coleções

## Descrição
- Implementa novos executables para alguns tipos de Collection e outros tipos iteráveis, para realizar um tratamento *null safe* específico para cada caso (se a resposta da requisição for nula, a saída do método será uma coleção/array/iterável vazio)

## Changelog
- Implementa novos executables para *Collection*, *Set*, *List*, *Array*, *Iterator*, *Iterable*, *ListIterator* e *Enumeration*. Esses executables serão carregados por padrão, e passam a fazer parte da configuração padrão do java-restify
