### PR TITLE
[fix-hystrix-property-names] Corrige nomes de propriedades do hystrix

### DIFF
--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerCommandPropertiesSetter.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerCommandPropertiesSetter.java
@@ -25,33 +25,34 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
 
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.CIRCUIT_BREAKER_ENABLED;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.CIRCUIT_BREAKER_ERROR_THRESHOLD_PERCENTAGE;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.CIRCUIT_BREAKER_FORCE_CLOSED;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.CIRCUIT_BREAKER_FORCE_OPEN;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.CIRCUIT_BREAKER_REQUEST_VOLUME_THRESHOLD;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.CIRCUIT_BREAKER_SLEEP_WINDOW_IN_MILLISECONDS;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.EXECUTION_ISOLATION_SEMAPHORE_MAX_CONCURRENT_REQUESTS;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.EXECUTION_ISOLATION_STRATEGY;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.EXECUTION_ISOLATION_THREAD_INTERRUPT_ON_TIMEOUT;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.EXECUTION_ISOLATION_THREAD_TIMEOUT_IN_MILLISECONDS;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.EXECUTION_TIMEOUT_ENABLED;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.FALLBACK_ENABLED;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.FALLBACK_ISOLATION_SEMAPHORE_MAX_CONCURRENT_REQUESTS;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.METRICS_HEALTH_SNAPSHOT_INTERVAL_IN_MILLISECONDS;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.METRICS_ROLLING_PERCENTILE_BUCKET_SIZE;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.METRICS_ROLLING_PERCENTILE_ENABLED;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.METRICS_ROLLING_PERCENTILE_NUM_BUCKETS;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.METRICS_ROLLING_PERCENTILE_TIME_IN_MILLISECONDS;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.METRICS_ROLLING_STATS_NUM_BUCKETS;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.METRICS_ROLLING_STATS_TIME_IN_MILLISECONDS;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.CIRCUIT_BREAKER_ENABLED;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.CIRCUIT_BREAKER_ERROR_THRESHOLD_PERCENTAGE;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.CIRCUIT_BREAKER_FORCE_CLOSED;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.CIRCUIT_BREAKER_FORCE_OPEN;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.CIRCUIT_BREAKER_REQUEST_VOLUME_THRESHOLD;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.CIRCUIT_BREAKER_SLEEP_WINDOW_IN_MILLISECONDS;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.EXECUTION_ISOLATION_SEMAPHORE_MAX_CONCURRENT_REQUESTS;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.EXECUTION_ISOLATION_STRATEGY;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.EXECUTION_ISOLATION_THREAD_INTERRUPT_ON_CANCEL;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.EXECUTION_ISOLATION_THREAD_INTERRUPT_ON_TIMEOUT;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.EXECUTION_ISOLATION_THREAD_TIMEOUT_IN_MILLISECONDS;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.EXECUTION_TIMEOUT_ENABLED;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.FALLBACK_ENABLED;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.FALLBACK_ISOLATION_SEMAPHORE_MAX_CONCURRENT_REQUESTS;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.METRICS_HEALTH_SNAPSHOT_INTERVAL_IN_MILLISECONDS;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.METRICS_ROLLING_PERCENTILE_BUCKET_SIZE;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.METRICS_ROLLING_PERCENTILE_ENABLED;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.METRICS_ROLLING_PERCENTILE_NUM_BUCKETS;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.METRICS_ROLLING_PERCENTILE_TIME_IN_MILLISECONDS;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.METRICS_ROLLING_STATS_NUM_BUCKETS;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.METRICS_ROLLING_STATS_TIME_IN_MILLISECONDS;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties;
+import com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty;
 import com.netflix.hystrix.HystrixCommandProperties;
 import com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStrategy;
 
@@ -60,9 +61,9 @@ class HystrixCircuitBreakerCommandPropertiesSetter {
 	private static final Map<String, HystrixCircuitBreakerPropertiesSetter<HystrixCommandProperties.Setter>> HYSTRIX_COMMAND_PROPERTIES_SETTERS
 		= new LinkedHashMap<>();
 
-	private final CircuitBreakerProperties[] properties;
+	private final CircuitBreakerProperty[] properties;
 
-	public HystrixCircuitBreakerCommandPropertiesSetter(CircuitBreakerProperties[] properties) {
+	public HystrixCircuitBreakerCommandPropertiesSetter(CircuitBreakerProperty[] properties) {
 		this.properties = properties;
 	}
 
@@ -73,6 +74,7 @@ class HystrixCircuitBreakerCommandPropertiesSetter {
 	}
 
 	static {
+		// Execution
 		HYSTRIX_COMMAND_PROPERTIES_SETTERS.put(EXECUTION_ISOLATION_STRATEGY,
 				(s, v) -> s.withExecutionIsolationStrategy(ExecutionIsolationStrategy.valueOf(v)));
 
@@ -85,15 +87,20 @@ class HystrixCircuitBreakerCommandPropertiesSetter {
 		HYSTRIX_COMMAND_PROPERTIES_SETTERS.put(EXECUTION_ISOLATION_THREAD_INTERRUPT_ON_TIMEOUT,
 				(s, v) -> s.withExecutionIsolationThreadInterruptOnTimeout(Boolean.valueOf(v)));
 
+		HYSTRIX_COMMAND_PROPERTIES_SETTERS.put(EXECUTION_ISOLATION_THREAD_INTERRUPT_ON_CANCEL,
+				(s, v) -> s.withExecutionIsolationThreadInterruptOnFutureCancel(Boolean.valueOf(v)));
+
 		HYSTRIX_COMMAND_PROPERTIES_SETTERS.put(EXECUTION_ISOLATION_SEMAPHORE_MAX_CONCURRENT_REQUESTS,
 				(s, v) -> s.withExecutionIsolationSemaphoreMaxConcurrentRequests(Integer.valueOf(v)));
 
+		// Fallback
 		HYSTRIX_COMMAND_PROPERTIES_SETTERS.put(FALLBACK_ISOLATION_SEMAPHORE_MAX_CONCURRENT_REQUESTS,
 				(s, v) -> s.withFallbackIsolationSemaphoreMaxConcurrentRequests(Integer.valueOf(v)));
 
 		HYSTRIX_COMMAND_PROPERTIES_SETTERS.put(FALLBACK_ENABLED,
 				(s, v) -> s.withFallbackEnabled(Boolean.valueOf(v)));
 
+		// Circuit breaker
 		HYSTRIX_COMMAND_PROPERTIES_SETTERS.put(CIRCUIT_BREAKER_ENABLED,
 				(s, v) -> s.withCircuitBreakerEnabled(Boolean.valueOf(v)));
 
@@ -112,6 +119,7 @@ class HystrixCircuitBreakerCommandPropertiesSetter {
 		HYSTRIX_COMMAND_PROPERTIES_SETTERS.put(CIRCUIT_BREAKER_FORCE_CLOSED,
 				(s, v) -> s.withCircuitBreakerForceClosed(Boolean.valueOf(v)));
 
+		// Metrics
 		HYSTRIX_COMMAND_PROPERTIES_SETTERS.put(METRICS_ROLLING_STATS_TIME_IN_MILLISECONDS,
 				(s, v) -> s.withMetricsRollingStatisticalWindowInMilliseconds(Integer.valueOf(v)));
 

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerThreadPoolPropertiesSetter.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerThreadPoolPropertiesSetter.java
@@ -25,19 +25,20 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
 
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.CORE_SIZE;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.KEEP_ALIVE_TIME_MINUTES;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.MAX_QUEUE_SIZE;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.METRICS_ROLLING_STATS_NUM_BUCKETS;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.METRICS_ROLLING_STATS_TIME_IN_MILLISECONDS;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.QUEUE_SIZE_REJECTION_THRESHOLD;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.THREAD_POOL_ALLOW_MAXIMUM_SIZE_TO_DIVERGE_FROM_CORE_SIZE;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.THREAD_POOL_CORE_SIZE;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.THREAD_POOL_KEEP_ALIVE_TIME_MINUTES;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.THREAD_POOL_MAX_QUEUE_SIZE;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.THREAD_POOL_METRICS_ROLLING_STATS_NUM_BUCKETS;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.THREAD_POOL_METRICS_ROLLING_STATS_TIME_IN_MILLISECONDS;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.THREAD_POOL_QUEUE_SIZE_REJECTION_THRESHOLD;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties;
+import com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty;
 import com.netflix.hystrix.HystrixThreadPoolProperties;
 
 class HystrixCircuitBreakerThreadPoolPropertiesSetter {
@@ -45,9 +46,9 @@ class HystrixCircuitBreakerThreadPoolPropertiesSetter {
 	private static final Map<String, HystrixCircuitBreakerPropertiesSetter<HystrixThreadPoolProperties.Setter>> HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS
 		= new LinkedHashMap<>();
 
-	private final CircuitBreakerProperties[] properties;
+	private final CircuitBreakerProperty[] properties;
 
-	public HystrixCircuitBreakerThreadPoolPropertiesSetter(CircuitBreakerProperties[] properties) {
+	public HystrixCircuitBreakerThreadPoolPropertiesSetter(CircuitBreakerProperty[] properties) {
 		this.properties = properties;
 	}
 
@@ -58,22 +59,25 @@ class HystrixCircuitBreakerThreadPoolPropertiesSetter {
 	}
 
 	static {
-		HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS.put(MAX_QUEUE_SIZE,
+		HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS.put(THREAD_POOL_MAX_QUEUE_SIZE,
 				(s, v) -> s.withMaxQueueSize(Integer.valueOf(v)));
 
-		HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS.put(CORE_SIZE,
+		HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS.put(THREAD_POOL_CORE_SIZE,
 				(s, v) -> s.withCoreSize(Integer.valueOf(v)));
 
-		HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS.put(KEEP_ALIVE_TIME_MINUTES,
+		HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS.put(THREAD_POOL_KEEP_ALIVE_TIME_MINUTES,
 				(s, v) -> s.withKeepAliveTimeMinutes(Integer.valueOf(v)));
 
-		HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS.put(QUEUE_SIZE_REJECTION_THRESHOLD,
+		HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS.put(THREAD_POOL_QUEUE_SIZE_REJECTION_THRESHOLD,
 				(s, v) -> s.withQueueSizeRejectionThreshold(Integer.valueOf(v)));
 
-		HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS.put(METRICS_ROLLING_STATS_NUM_BUCKETS,
+		HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS.put(THREAD_POOL_ALLOW_MAXIMUM_SIZE_TO_DIVERGE_FROM_CORE_SIZE,
+				(s, v) -> s.withAllowMaximumSizeToDivergeFromCoreSize(Boolean.valueOf(v)));
+
+		HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS.put(THREAD_POOL_METRICS_ROLLING_STATS_NUM_BUCKETS,
 				(s, v) -> s.withMetricsRollingStatisticalWindowBuckets(Integer.valueOf(v)));
 
-		HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS.put(METRICS_ROLLING_STATS_TIME_IN_MILLISECONDS,
+		HYSTRIX_THREAD_POOL_PROPERTIES_SETTERS.put(THREAD_POOL_METRICS_ROLLING_STATS_TIME_IN_MILLISECONDS,
 				(s, v) -> s.withMetricsRollingStatisticalWindowInMilliseconds(Integer.valueOf(v)));
 	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandMetadataFactory.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandMetadataFactory.java
@@ -28,7 +28,7 @@ package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
 import java.util.Optional;
 
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
-import com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties;
+import com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty;
 import com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.OnCircuitBreaker;
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
@@ -84,8 +84,8 @@ class HystrixCommandMetadataFactory {
 	}
 
 	private HystrixCommandProperties.Setter commandProperties() {
-		CircuitBreakerProperties[] properties = onCircuitBreaker.map(a -> a.properties())
-				.orElseGet(() -> new CircuitBreakerProperties[0]);
+		CircuitBreakerProperty[] properties = onCircuitBreaker.map(a -> a.properties())
+				.orElseGet(() -> new CircuitBreakerProperty[0]);
 
 		HystrixCommandProperties.Setter hystrixCommandProperties = HystrixCommandProperties.defaultSetter();
 
@@ -96,8 +96,8 @@ class HystrixCommandMetadataFactory {
 	}
 
 	private HystrixThreadPoolProperties.Setter threadPoolProperties() {
-		CircuitBreakerProperties[] properties = onCircuitBreaker.map(a -> a.properties())
-				.orElseGet(() -> new CircuitBreakerProperties[0]);
+		CircuitBreakerProperty[] properties = onCircuitBreaker.map(a -> a.properties())
+				.orElseGet(() -> new CircuitBreakerProperty[0]);
 
 		HystrixThreadPoolProperties.Setter hystrixThreadPoolProperties = HystrixThreadPoolProperties.defaultSetter();
 

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/circuitbreaker/CircuitBreakerProperty.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/circuitbreaker/CircuitBreakerProperty.java
@@ -34,21 +34,25 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-public @interface CircuitBreakerProperties {
+public @interface CircuitBreakerProperty {
 
 	String name();
 
 	String value();
 
+	// Execution
 	public static final String EXECUTION_ISOLATION_STRATEGY = "execution.isolation.strategy";
 	public static final String EXECUTION_ISOLATION_THREAD_TIMEOUT_IN_MILLISECONDS = "execution.isolation.thread.timeoutInMilliseconds";
 	public static final String EXECUTION_TIMEOUT_ENABLED = "execution.timeout.enabled";
 	public static final String EXECUTION_ISOLATION_THREAD_INTERRUPT_ON_TIMEOUT = "execution.isolation.thread.interruptOnTimeout";
+	public static final String EXECUTION_ISOLATION_THREAD_INTERRUPT_ON_CANCEL = "execution.isolation.thread.interruptOnCancel";
 	public static final String EXECUTION_ISOLATION_SEMAPHORE_MAX_CONCURRENT_REQUESTS = "execution.isolation.semaphore.maxConcurrentRequests";
 
+	// Fallback
 	public static final String FALLBACK_ISOLATION_SEMAPHORE_MAX_CONCURRENT_REQUESTS = "fallback.isolation.semaphore.maxConcurrentRequests";
 	public static final String FALLBACK_ENABLED = "fallback.enabled";
 
+	// Circuit breaker
 	public static final String CIRCUIT_BREAKER_ENABLED = "circuitBreaker.enabled";
 	public static final String CIRCUIT_BREAKER_REQUEST_VOLUME_THRESHOLD = "circuitBreaker.requestVolumeThreshold";
 	public static final String CIRCUIT_BREAKER_SLEEP_WINDOW_IN_MILLISECONDS = "circuitBreaker.sleepWindowInMilliseconds";
@@ -56,16 +60,21 @@ public @interface CircuitBreakerProperties {
 	public static final String CIRCUIT_BREAKER_FORCE_OPEN = "circuitBreaker.forceOpen";
 	public static final String CIRCUIT_BREAKER_FORCE_CLOSED = "circuitBreaker.forceClosed";
 
+	// Metrics
+	public static final String METRICS_ROLLING_STATS_TIME_IN_MILLISECONDS = "metrics.rollingStats.timeInMilliseconds";
+	public static final String METRICS_ROLLING_STATS_NUM_BUCKETS = "metrics.rollingStats.numBuckets";
 	public static final String METRICS_ROLLING_PERCENTILE_ENABLED = "metrics.rollingPercentile.enabled";
 	public static final String METRICS_ROLLING_PERCENTILE_TIME_IN_MILLISECONDS = "metrics.rollingPercentile.timeInMilliseconds";
 	public static final String METRICS_ROLLING_PERCENTILE_NUM_BUCKETS = "metrics.rollingPercentile.numBuckets";
 	public static final String METRICS_ROLLING_PERCENTILE_BUCKET_SIZE = "metrics.rollingPercentile.bucketSize";
 	public static final String METRICS_HEALTH_SNAPSHOT_INTERVAL_IN_MILLISECONDS = "metrics.healthSnapshot.intervalInMilliseconds";
 
-	public static final String MAX_QUEUE_SIZE = "maxQueueSize";
-	public static final String CORE_SIZE = "coreSize";
-	public static final String KEEP_ALIVE_TIME_MINUTES = "keepAliveTimeMinutes";
-	public static final String QUEUE_SIZE_REJECTION_THRESHOLD = "queueSizeRejectionThreshold";
-	public static final String METRICS_ROLLING_STATS_NUM_BUCKETS = "metrics.rollingStats.numBuckets";
-	public static final String METRICS_ROLLING_STATS_TIME_IN_MILLISECONDS = "metrics.rollingStats.timeInMilliseconds";
+	// Thread pool
+	public static final String THREAD_POOL_MAX_QUEUE_SIZE = "threadpool.default.maxQueueSize";
+	public static final String THREAD_POOL_CORE_SIZE = "threadpool.default.coreSize";
+	public static final String THREAD_POOL_KEEP_ALIVE_TIME_MINUTES = "threadpool.default.keepAliveTimeMinutes";
+	public static final String THREAD_POOL_QUEUE_SIZE_REJECTION_THRESHOLD = "threadpool.default.queueSizeRejectionThreshold";
+	public static final String THREAD_POOL_ALLOW_MAXIMUM_SIZE_TO_DIVERGE_FROM_CORE_SIZE = "threadpool.default.allowMaximumSizeToDivergeFromCoreSize";
+	public static final String THREAD_POOL_METRICS_ROLLING_STATS_TIME_IN_MILLISECONDS = "threadpool.default.metrics.rollingStats.timeInMilliseconds";
+	public static final String THREAD_POOL_METRICS_ROLLING_STATS_NUM_BUCKETS = "threadpool.default.metrics.rollingStats.numBuckets";
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/circuitbreaker/OnCircuitBreaker.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/circuitbreaker/OnCircuitBreaker.java
@@ -42,5 +42,5 @@ public @interface OnCircuitBreaker {
 
 	String threadPoolKey() default "";
 
-	CircuitBreakerProperties[] properties() default {};
+	CircuitBreakerProperty[] properties() default {};
 }

--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandMetadataFactoryTest.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandMetadataFactoryTest.java
@@ -1,13 +1,13 @@
 package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
 
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.CORE_SIZE;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.EXECUTION_ISOLATION_STRATEGY;
-import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties.EXECUTION_ISOLATION_THREAD_TIMEOUT_IN_MILLISECONDS;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.THREAD_POOL_CORE_SIZE;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.EXECUTION_ISOLATION_STRATEGY;
+import static com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty.EXECUTION_ISOLATION_THREAD_TIMEOUT_IN_MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperties;
+import com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.CircuitBreakerProperty;
 import com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.OnCircuitBreaker;
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStrategy;
@@ -79,9 +79,9 @@ public class HystrixCommandMetadataFactoryTest {
 		String customizedKeys();
 
 		@OnCircuitBreaker(properties = {
-				@CircuitBreakerProperties(name = EXECUTION_ISOLATION_STRATEGY, value = "SEMAPHORE"),
-				@CircuitBreakerProperties(name = EXECUTION_ISOLATION_THREAD_TIMEOUT_IN_MILLISECONDS, value = "2500"),
-				@CircuitBreakerProperties(name = CORE_SIZE, value = "50")})
+				@CircuitBreakerProperty(name = EXECUTION_ISOLATION_STRATEGY, value = "SEMAPHORE"),
+				@CircuitBreakerProperty(name = EXECUTION_ISOLATION_THREAD_TIMEOUT_IN_MILLISECONDS, value = "2500"),
+				@CircuitBreakerProperty(name = THREAD_POOL_CORE_SIZE, value = "50")})
 		String customizedProperties();
 	}
 }


### PR DESCRIPTION
## Hystrix - Nomes de propriedades

## Descrição
- Corrige nomes de propriedades do Hystrix, para estarem compatíveis com a documentação oficial do framework: https://github.com/Netflix/Hystrix/wiki/Configuration

## Changelog
- Renomeia a anotação CircuitBreakerProperties para *CircuitBreakerProperty*
- Corrige nomes de propriedades do Hystrix