### PR TITLE
[version-annotation] Versionamento de endpoint

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
@@ -75,9 +75,11 @@ import com.github.ljtfreitas.restify.http.client.message.form.multipart.Multipar
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequestExecutor;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequestFactory;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequestWriter;
+import com.github.ljtfreitas.restify.http.client.request.EndpointVersion;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequestFactory;
 import com.github.ljtfreitas.restify.http.client.request.RestifyEndpointRequestExecutor;
 import com.github.ljtfreitas.restify.http.client.request.interceptor.AcceptHeaderEndpointRequestInterceptor;
+import com.github.ljtfreitas.restify.http.client.request.interceptor.AcceptVersionHeaderEndpointRequestInterceptor;
 import com.github.ljtfreitas.restify.http.client.request.interceptor.ContentTypeHeaderEndpointRequestInterceptor;
 import com.github.ljtfreitas.restify.http.client.request.interceptor.EndpointRequestInterceptor;
 import com.github.ljtfreitas.restify.http.client.request.interceptor.EndpointRequestInterceptorStack;
@@ -341,6 +343,21 @@ public class RestifyProxyBuilder {
 
 		public EndpointRequestInterceptorsBuilder contentType(ContentType contentType) {
 			interceptors.add(new ContentTypeHeaderEndpointRequestInterceptor(contentType));
+			return this;
+		}
+
+		public EndpointRequestInterceptorsBuilder acceptVersion() {
+			interceptors.add(new AcceptVersionHeaderEndpointRequestInterceptor());
+			return this;
+		}
+
+		public EndpointRequestInterceptorsBuilder acceptVersion(String version) {
+			interceptors.add(new AcceptVersionHeaderEndpointRequestInterceptor(EndpointVersion.of(version)));
+			return this;
+		}
+
+		public EndpointRequestInterceptorsBuilder acceptVersion(EndpointVersion version) {
+			interceptors.add(new AcceptVersionHeaderEndpointRequestInterceptor(version));
 			return this;
 		}
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequest.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequest.java
@@ -41,33 +41,59 @@ public class EndpointRequest {
 	private final Headers headers;
 	private final Object body;
 	private final JavaType responseType;
+	private final EndpointVersion version;
 
 	public EndpointRequest(URI endpoint, String method) {
-		this(endpoint, method, new Headers(), null, void.class);
+		this(endpoint, method, (EndpointVersion) null);
+	}
+
+	public EndpointRequest(URI endpoint, String method, EndpointVersion version) {
+		this(endpoint, method, new Headers(), null, void.class, version);
 	}
 
 	public EndpointRequest(URI endpoint, String method, Type responseType) {
-		this(endpoint, method, new Headers(), responseType);
+		this(endpoint, method, responseType, null);
+	}
+
+	public EndpointRequest(URI endpoint, String method, Type responseType, EndpointVersion version) {
+		this(endpoint, method, new Headers(), responseType, version);
 	}
 
 	public EndpointRequest(URI endpoint, String method, Headers headers, Type responseType) {
-		this(endpoint, method, headers, null, responseType);
+		this(endpoint, method, headers, null, (EndpointVersion) null);
+	}
+
+	public EndpointRequest(URI endpoint, String method, Headers headers, Type responseType, EndpointVersion version) {
+		this(endpoint, method, headers, null, responseType, version);
 	}
 
 	public EndpointRequest(URI endpoint, String method, Headers headers, Object body) {
-		this(endpoint, method, headers, body, void.class);
+		this(endpoint, method, headers, body, (EndpointVersion) null);
+	}
+
+	public EndpointRequest(URI endpoint, String method, Headers headers, Object body, EndpointVersion version) {
+		this(endpoint, method, headers, body, void.class, version);
 	}
 
 	public EndpointRequest(URI endpoint, String method, Headers headers, Object body, Type responseType) {
-		this(endpoint, method, headers, body, JavaType.of(responseType));
+		this(endpoint, method, headers, body, responseType, null);
+	}
+
+	public EndpointRequest(URI endpoint, String method, Headers headers, Object body, Type responseType, EndpointVersion version) {
+		this(endpoint, method, headers, body, JavaType.of(responseType), version);
 	}
 
 	public EndpointRequest(URI endpoint, String method, Headers headers, Object body, JavaType responseType) {
+		this(endpoint, method, headers, body, responseType, null);
+	}
+
+	public EndpointRequest(URI endpoint, String method, Headers headers, Object body, JavaType responseType, EndpointVersion version) {
 		this.endpoint = endpoint;
 		this.method = method;
 		this.headers = headers;
 		this.body = body;
 		this.responseType = responseType;
+		this.version = version;
 	}
 
 	public URI endpoint() {
@@ -90,6 +116,10 @@ public class EndpointRequest {
 		return responseType;
 	}
 
+	public Optional<EndpointVersion> version() {
+		return Optional.ofNullable(version);
+	}
+
 	public EndpointRequest appendParameter(String name, String value) {
 		String appender = endpoint.getQuery() == null ? "" : "&";
 
@@ -102,14 +132,14 @@ public class EndpointRequest {
 			URI newURI = new URI(endpoint.getScheme(), endpoint.getRawAuthority(), endpoint.getRawPath(),
 					newQuery, endpoint.getRawFragment());
 
-			return new EndpointRequest(newURI, method, headers, body, responseType);
+			return new EndpointRequest(newURI, method, headers, body, responseType, version);
 		} catch (URISyntaxException e) {
 			throw new RestifyHttpException(e);
 		}
 	}
 
 	public EndpointRequest replace(URI endpoint) {
-		return new EndpointRequest(endpoint, method, headers, body, responseType);
+		return new EndpointRequest(endpoint, method, headers, body, responseType, version);
 	}
 
 	@Override

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestFactory.java
@@ -65,7 +65,9 @@ public class EndpointRequestFactory {
 				.forEach(h -> headers.add(new Header(h.name(), new EndpointHeaderParameterResolver(h.value(), endpointMethod.parameters())
 						.resolve(args))));
 
-			return new EndpointRequest(endpoint, endpointMethod.httpMethod(), headers, body, responseType);
+			EndpointVersion version = endpointMethod.version().map(EndpointVersion::of).orElse(null);
+
+			return new EndpointRequest(endpoint, endpointMethod.httpMethod(), headers, body, responseType, version);
 
 		} catch (URISyntaxException e) {
 			throw new RestifyHttpException(e);

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointVersion.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointVersion.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request;
+
+import java.util.Objects;
+
+import com.github.ljtfreitas.restify.http.util.Preconditions;
+
+public class EndpointVersion {
+
+	private final String version;
+
+	public EndpointVersion(String version) {
+		this.version = Preconditions.nonNull(version, "Endpoint version cannot be null");
+	}
+
+	public String get() {
+		return version;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(version);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof EndpointVersion) {
+			return version.equals(((EndpointVersion) obj).version);
+		} else {
+			return false;
+		}
+	}
+
+	public static EndpointVersion of(String version) {
+		return new EndpointVersion(version);
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/AcceptVersionHeaderEndpointRequestInterceptor.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/AcceptVersionHeaderEndpointRequestInterceptor.java
@@ -23,39 +23,36 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.client.request;
+package com.github.ljtfreitas.restify.http.client.request.interceptor;
 
-import static com.github.ljtfreitas.restify.http.util.Preconditions.nonNull;
+import java.util.Optional;
 
-import java.util.Objects;
+import com.github.ljtfreitas.restify.http.client.Header;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.EndpointVersion;
 
-public class EndpointVersion {
+public class AcceptVersionHeaderEndpointRequestInterceptor implements EndpointRequestInterceptor {
 
-	private final String version;
+	private final EndpointVersion version;
 
-	public EndpointVersion(String version) {
-		this.version = nonNull(version, "Endpoint version cannot be null");
+	public AcceptVersionHeaderEndpointRequestInterceptor() {
+		this.version = null;
 	}
 
-	public String get() {
-		return version;
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(version);
+	public AcceptVersionHeaderEndpointRequestInterceptor(EndpointVersion version) {
+		this.version = version;
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if (obj instanceof EndpointVersion) {
-			return version.equals(((EndpointVersion) obj).version);
-		} else {
-			return false;
+	public EndpointRequest intercepts(EndpointRequest request) {
+		EndpointVersion version = Optional.ofNullable(this.version)
+				.orElseGet(() -> request.version().orElse(null));
+
+		if (version != null) {
+			request.headers().add(new Header("Accept-Version", version.get()));
 		}
+
+		return request;
 	}
 
-	public static EndpointVersion of(String version) {
-		return new EndpointVersion(version);
-	}
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/Version.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/Version.java
@@ -6,8 +6,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE, ElementType.METHOD })
+@Target({ElementType.TYPE, ElementType.METHOD})
 public @interface Version {
 
 	public String value();
+
+	public boolean uri() default true;
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/Version.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/Version.java
@@ -1,0 +1,13 @@
+package com.github.ljtfreitas.restify.http.contract;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface Version {
+
+	public String value();
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReader.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReader.java
@@ -72,7 +72,9 @@ public class DefaultRestifyContractReader implements RestifyContractReader {
 
 		Type returnType = javaMethodMetadata.returnType(target.type());
 
-		return new EndpointMethod(javaMethod, endpointPath, endpointHttpMethod, parameters, headers, returnType);
+		String version = endpointMethodVersion(endpointVersion(javaTypeMetadata, javaMethodMetadata));
+
+		return new EndpointMethod(javaMethod, endpointPath, endpointHttpMethod, parameters, headers, returnType, version);
 	}
 
 	private String endpointPath(EndpointTarget target, JavaTypeMetadata javaTypeMetadata, JavaMethodMetadata javaMethodMetadata) {
@@ -108,6 +110,13 @@ public class DefaultRestifyContractReader implements RestifyContractReader {
 				.map(v -> v.endsWith("/") ? v.substring(0, v.length() - 1) : v)
 					.map(v -> v.startsWith("/") || v.isEmpty() ? v : "/" + v)
 						.orElse("");
+	}
+
+	private String endpointMethodVersion(String version) {
+		 return Optional.ofNullable(version)
+			.filter(v -> !v.trim().isEmpty())
+				.map(v -> v.substring(1))
+					.orElse(null);
 	}
 
 	private String endpointMethodPath(JavaMethodMetadata javaMethodMetadata) {

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReader.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReader.java
@@ -72,7 +72,7 @@ public class DefaultRestifyContractReader implements RestifyContractReader {
 
 		Type returnType = javaMethodMetadata.returnType(target.type());
 
-		String version = endpointMethodVersion(endpointVersion(javaTypeMetadata, javaMethodMetadata));
+		String version = endpointMethodVersion(endpointVersion(javaTypeMetadata, javaMethodMetadata, true));
 
 		return new EndpointMethod(javaMethod, endpointPath, endpointHttpMethod, parameters, headers, returnType, version);
 	}
@@ -102,8 +102,15 @@ public class DefaultRestifyContractReader implements RestifyContractReader {
 	}
 
 	private String endpointVersion(JavaTypeMetadata javaTypeMetadata, JavaMethodMetadata javaMethodMetadata) {
+		return endpointVersion(javaTypeMetadata, javaMethodMetadata, false);
+	}
+
+	private String endpointVersion(JavaTypeMetadata javaTypeMetadata, JavaMethodMetadata javaMethodMetadata, boolean force) {
 		Version version = javaMethodMetadata.version()
-			.orElseGet(() -> javaTypeMetadata.version().orElse(null));
+			.filter(v -> v.uri() || force)
+				.orElseGet(() -> javaTypeMetadata.version()
+						.filter(v -> v.uri() || force)
+							.orElse(null));
 
 		return Optional.ofNullable(version)
 			.map(Version::value)

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethod.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethod.java
@@ -44,27 +44,52 @@ public class EndpointMethod {
 	private final EndpointHeaders headers;
 	private final JavaType returnType;
 	private final JavaMethodAnnotations annotations;
+	private final String version;
 
 	public EndpointMethod(Method javaMethod, String path, String httpMethod) {
-		this(javaMethod, path, httpMethod, new EndpointMethodParameters());
+		this(javaMethod, path, httpMethod, (String) null);
+	}
+
+	public EndpointMethod(Method javaMethod, String path, String httpMethod, String version) {
+		this(javaMethod, path, httpMethod, new EndpointMethodParameters(), version);
 	}
 
 	public EndpointMethod(Method javaMethod, String path, String httpMethod, EndpointMethodParameters parameters) {
-		this(javaMethod, path, httpMethod, parameters, new EndpointHeaders());
+		this(javaMethod, path, httpMethod, parameters, new EndpointHeaders(), (String) null);
+	}
+
+	public EndpointMethod(Method javaMethod, String path, String httpMethod, EndpointMethodParameters parameters, String version) {
+		this(javaMethod, path, httpMethod, parameters, new EndpointHeaders(), version);
 	}
 
 	public EndpointMethod(Method javaMethod, String path, String httpMethod, EndpointMethodParameters parameters,
 			EndpointHeaders headers) {
-		this(javaMethod, path, httpMethod, parameters, headers, (Type) null);
+		this(javaMethod, path, httpMethod, parameters, headers, (Type) null, (String) null);
+	}
+
+	public EndpointMethod(Method javaMethod, String path, String httpMethod, EndpointMethodParameters parameters,
+			EndpointHeaders headers, String version) {
+		this(javaMethod, path, httpMethod, parameters, headers, (Type) null, version);
 	}
 
 	public EndpointMethod(Method javaMethod, String path, String httpMethod, EndpointMethodParameters parameters,
 			EndpointHeaders headers, Type returnType) {
-		this(javaMethod, path, httpMethod, parameters, headers, JavaType.of(Optional.ofNullable(returnType).orElseGet(() -> javaMethod.getGenericReturnType())));
+		this(javaMethod, path, httpMethod, parameters, headers, returnType, (String) null);
+	}
+
+	public EndpointMethod(Method javaMethod, String path, String httpMethod, EndpointMethodParameters parameters,
+			EndpointHeaders headers, Type returnType, String version) {
+		this(javaMethod, path, httpMethod, parameters, headers, JavaType.of(Optional.ofNullable(returnType).orElseGet(() -> javaMethod.getGenericReturnType())),
+				version);
 	}
 
 	private EndpointMethod(Method javaMethod, String path, String httpMethod, EndpointMethodParameters parameters,
 			EndpointHeaders headers, JavaType returnType) {
+		this(javaMethod, path, httpMethod, parameters, headers, returnType, null);
+	}
+
+	private EndpointMethod(Method javaMethod, String path, String httpMethod, EndpointMethodParameters parameters,
+			EndpointHeaders headers, JavaType returnType, String version) {
 		this.javaMethod = nonNull(javaMethod, "EndpointMethod needs a Java method.");
 		this.path = nonNull(path, "EndpointMethod needs a endpoint path.");
 		this.httpMethod = nonNull(httpMethod, "EndpointMethod needs a HTTP method.");
@@ -72,6 +97,7 @@ public class EndpointMethod {
 		this.headers = nonNull(headers, "EndpointMethod needs a HTTP headers collection.");
 		this.returnType = returnType;
 		this.annotations = new JavaMethodAnnotations(javaMethod);
+		this.version = version;
 	}
 
 	public String path() {
@@ -104,6 +130,10 @@ public class EndpointMethod {
 
 	public JavaMethodAnnotations annotations() {
 		return annotations;
+	}
+
+	public Optional<String> version() {
+		return Optional.ofNullable(version);
 	}
 
 	public String expand(final Object[] args) {

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaMethodMetadata.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaMethodMetadata.java
@@ -32,6 +32,7 @@ import com.github.ljtfreitas.restify.http.contract.Header;
 import com.github.ljtfreitas.restify.http.contract.Headers;
 import com.github.ljtfreitas.restify.http.contract.Method;
 import com.github.ljtfreitas.restify.http.contract.Path;
+import com.github.ljtfreitas.restify.http.contract.Version;
 
 public class JavaMethodMetadata {
 
@@ -39,6 +40,7 @@ public class JavaMethodMetadata {
 	private final Path path;
 	private final Method httpMethod;
 	private final Header[] headers;
+	private final Version version;
 
 	public JavaMethodMetadata(java.lang.reflect.Method javaMethod) {
 		this.javaMethod = javaMethod;
@@ -51,6 +53,8 @@ public class JavaMethodMetadata {
 		this.headers = Optional.ofNullable(javaMethod.getAnnotation(Headers.class))
 				.map(Headers::value)
 					.orElseGet(() -> new JavaAnnotationScanner(javaMethod).scanAll(Header.class));
+
+		this.version = javaMethod.getAnnotation(Version.class);
 	}
 
 	public Optional<Path> path() {
@@ -71,5 +75,9 @@ public class JavaMethodMetadata {
 
 	public Type returnType(Class<?> rawType) {
 		return new JavaTypeResolver(rawType).returnTypeOf(javaMethod);
+	}
+
+	public Optional<Version> version() {
+		return Optional.ofNullable(version);
 	}
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaTypeMetadata.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaTypeMetadata.java
@@ -34,12 +34,14 @@ import java.util.Optional;
 import com.github.ljtfreitas.restify.http.contract.Header;
 import com.github.ljtfreitas.restify.http.contract.Headers;
 import com.github.ljtfreitas.restify.http.contract.Path;
+import com.github.ljtfreitas.restify.http.contract.Version;
 
 public class JavaTypeMetadata {
 
 	private final Class<?> javaType;
 	private final Path path;
 	private final Header[] headers;
+	private final Version version;
 	private final JavaTypeMetadata parent;
 
 	public JavaTypeMetadata(Class<?> javaType) {
@@ -54,6 +56,8 @@ public class JavaTypeMetadata {
 		this.headers = Optional.ofNullable(javaType.getAnnotation(Headers.class))
 				.map(Headers::value)
 					.orElseGet(() -> new JavaAnnotationScanner(javaType).scanAll(Header.class));
+
+		this.version = javaType.getAnnotation(Version.class);
 	}
 
 	public Optional<Path> path() {
@@ -91,5 +95,9 @@ public class JavaTypeMetadata {
 
 	public Optional<JavaTypeMetadata> parent() {
 		return Optional.ofNullable(parent);
+	}
+
+	public Optional<Version> version() {
+		return version == null ? Optional.ofNullable(parent).flatMap(JavaTypeMetadata::version) : Optional.of(version);
 	}
 }

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestFactoryTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestFactoryTest.java
@@ -308,6 +308,19 @@ public class EndpointRequestFactoryTest {
 		assertEquals(JavaType.of(String.class), endpointRequest.responseType());
 	}
 
+	@Test
+	public void shouldCreateEndpointRequestWithVersion() throws Exception {
+		EndpointMethod endpointMethod = new EndpointMethod(TargetType.class.getMethod("simple"), "http://my.api.com/some",
+				"GET", "v1");
+
+		EndpointRequest endpointRequest = endpointRequestFactory.createWith(endpointMethod, new Object[0], JavaType.of(String.class));
+
+		assertTrue(endpointRequest.version().isPresent());
+
+		EndpointVersion version = endpointRequest.version().get();
+		assertEquals("v1", version.get());
+	}
+
 	interface TargetType {
 
 		public String simple();

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/interceptor/AcceptVersionHeaderEndpointRequestInterceptorTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/interceptor/AcceptVersionHeaderEndpointRequestInterceptorTest.java
@@ -1,0 +1,60 @@
+package com.github.ljtfreitas.restify.http.client.request.interceptor;
+
+import static org.junit.Assert.*;
+
+import java.net.URI;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.ljtfreitas.restify.http.client.Header;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.EndpointVersion;
+
+public class AcceptVersionHeaderEndpointRequestInterceptorTest {
+
+	private AcceptVersionHeaderEndpointRequestInterceptor interceptor;
+
+	@Before
+	public void setup() {
+		interceptor = new AcceptVersionHeaderEndpointRequestInterceptor();
+	}
+
+	@Test
+	public void shouldAddAcceptVersionHeaderWhenVersionIsPresentOnRequest() {
+		EndpointRequest request = new EndpointRequest(URI.create("http://my.api.com"), "GET", EndpointVersion.of("v1"));
+
+		EndpointRequest newRequest = interceptor.intercepts(request);
+
+		Optional<Header> acceptVersion = newRequest.headers().get("Accept-Version");
+
+		assertTrue(acceptVersion.isPresent());
+		assertEquals("v1", acceptVersion.get().value());
+	}
+
+	@Test
+	public void shouldNotAddAcceptVersionHeaderWhenVersionIsNotPresentOnRequest() {
+		EndpointRequest request = new EndpointRequest(URI.create("http://my.api.com"), "GET");
+
+		EndpointRequest newRequest = interceptor.intercepts(request);
+
+		Optional<Header> acceptVersion = newRequest.headers().get("Accept-Version");
+
+		assertFalse(acceptVersion.isPresent());
+	}
+
+	@Test
+	public void shouldOverrideRequestVersionWhenAcceptHeaderVersionIsConfigured() {
+		EndpointRequest request = new EndpointRequest(URI.create("http://my.api.com"), "GET", EndpointVersion.of("v1"));
+
+		interceptor = new AcceptVersionHeaderEndpointRequestInterceptor(EndpointVersion.of("v2"));
+
+		EndpointRequest newRequest = interceptor.intercepts(request);
+
+		Optional<Header> acceptVersion = newRequest.headers().get("Accept-Version");
+
+		assertTrue(acceptVersion.isPresent());
+		assertEquals("v2", acceptVersion.get().value());
+	}
+}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReaderTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReaderTest.java
@@ -427,6 +427,9 @@ public class DefaultRestifyContractReaderTest {
 				MyVersionedApi.class.getMethod("versionOne"));
 
 		assertEquals("http://my.api.com/v1/model", endpointMethod.path());
+
+		assertTrue(endpointMethod.version().isPresent());
+		assertEquals("v1", endpointMethod.version().get());
 	}
 
 	@Test
@@ -435,6 +438,9 @@ public class DefaultRestifyContractReaderTest {
 				MyVersionedApi.class.getMethod("versionTwo"));
 
 		assertEquals("http://my.api.com/v2/model", endpointMethod.path());
+
+		assertTrue(endpointMethod.version().isPresent());
+		assertEquals("v2", endpointMethod.version().get());
 	}
 
 	@Path("http://my.api.com")

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReaderTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReaderTest.java
@@ -34,6 +34,7 @@ import com.github.ljtfreitas.restify.http.contract.PathParameter;
 import com.github.ljtfreitas.restify.http.contract.Post;
 import com.github.ljtfreitas.restify.http.contract.Put;
 import com.github.ljtfreitas.restify.http.contract.QueryParameters;
+import com.github.ljtfreitas.restify.http.contract.Version;
 import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleGenericArrayType;
 import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleParameterizedType;
 import com.github.ljtfreitas.restify.http.contract.metadata.reflection.SimpleWildcardType;
@@ -50,6 +51,8 @@ public class DefaultRestifyContractReaderTest {
 
 	private EndpointTarget mySimpleCrudApiTarget;
 
+	private EndpointTarget myVersionedApiTarget;
+
 	private DefaultRestifyContractReader restifyContractReader;
 
 	@Before
@@ -63,6 +66,8 @@ public class DefaultRestifyContractReaderTest {
 		myContextApiTarget = new EndpointTarget(MyContextApi.class, "http://my.api.com");
 
 		mySimpleCrudApiTarget = new EndpointTarget(MySimpleCrudApi.class, "http://my.api.com");
+
+		myVersionedApiTarget = new EndpointTarget(MyVersionedApi.class);
 
 		restifyContractReader = new DefaultRestifyContractReader();
 	}
@@ -416,6 +421,22 @@ public class DefaultRestifyContractReaderTest {
 		assertEquals("http://localhost:8080/context/any", endpointMethod.path());
 	}
 
+	@Test
+	public void shouldCreateEndpointMethodWithVersionWhenTypeIsVersioned() throws Exception {
+		EndpointMethod endpointMethod = restifyContractReader.read(myVersionedApiTarget,
+				MyVersionedApi.class.getMethod("versionOne"));
+
+		assertEquals("http://my.api.com/v1/model", endpointMethod.path());
+	}
+
+	@Test
+	public void shouldCreateEndpointMethodWithMethodVersionWhenVersionAnnotationIsPresentOnMethod() throws Exception {
+		EndpointMethod endpointMethod = restifyContractReader.read(myVersionedApiTarget,
+				MyVersionedApi.class.getMethod("versionTwo"));
+
+		assertEquals("http://my.api.com/v2/model", endpointMethod.path());
+	}
+
 	@Path("http://my.api.com")
 	@Header(name = "X-My-Type", value = "MyApiType")
 	interface MyApiType {
@@ -582,6 +603,20 @@ public class DefaultRestifyContractReaderTest {
 		@Path("/any")
 		@Get
 		public String method();
+	}
+
+	@Path("http://my.api.com")
+	@Version("v1")
+	interface MyVersionedApi {
+
+		@Path("/model")
+		@Get
+		public MyModel versionOne();
+
+		@Path("/model")
+		@Get
+		@Version("v2")
+		public MyModel versionTwo();
 	}
 
 	class MyModel {


### PR DESCRIPTION
## Versionamento de endpoint 🎶 

### Descrição
- Implementa anotação *Version*, para permitir informar declarativamente a versão da api consumida no cliente. A versão informada é concatenada ao path gerado para o método da interface. Exemplo:

```java
public interface Service {
   @Path("/user") @Version("v1")
   public User get(String id); //path -> /v1/user/{id}
}
```
- A informação da versão estará disponível no objeto EndpointRequest (método *version()*)
- A nova anotação também possui o parâmetro *uri* (*boolean*, default *true*) para permitir ao usuário customizar quando a versão deve ser concatenada ao path. Se o valor do parâmetro for *false* a versão não será incluída no path, mas estará disponível da mesma forma no objeto EndpointRequest (e poderá ser adicionada à requisiçao de alguma forma customizada, por exemplo, em um interceptor)
- Cria novo interceptor *AcceptVersionHeaderEndpointRequestInterceptor* para adicionar o cabeçalho "Accept-Version" à requisição. A versão pode ser definida explicitamente (usando o construtor) ou 
a anotação Version pode ser utilizada. Esse interceptor pode ser configurado pelo RestifyProxyBuilder, usando o novo método *interceptors().acceptVersion()*
- Cria objeto *EndpointVersion*, para representar a versão de um endpoint

### Changelog
- Implementa nova anotação *Version*, disponível apenas para o contrato padrão do java-restify. A nova anotação pode ser utiliza em métodos e no topo da interface (neste caso, aplicada para todos os métodos)
