### PR TITLE
[http-request-configuration] Configuração de requisições http (follow redirects e use caches)

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
@@ -514,6 +514,24 @@ public class RestifyProxyBuilder {
 			return this;
 		}
 
+		public HttpClientRequestFollowRedirectsConfigurationBuilder followRedirects() {
+			return new HttpClientRequestFollowRedirectsConfigurationBuilder();
+		}
+
+		public HttpClientRequestConfigurationBuilder followRedirects(boolean enabled) {
+			builder.followRedirects(enabled);
+			return this;
+		}
+
+		public HttpClientRequestUseCachesConfigurationBuilder useCaches() {
+			return new HttpClientRequestUseCachesConfigurationBuilder();
+		}
+
+		public HttpClientRequestConfigurationBuilder useCaches(boolean enabled) {
+			builder.useCaches(enabled);
+			return this;
+		}
+
 		public RestifyProxyBuilder using(HttpClientRequestConfiguration httpClientRequestConfiguration) {
 			this.httpClientRequestConfiguration = httpClientRequestConfiguration;
 			return context;
@@ -525,6 +543,32 @@ public class RestifyProxyBuilder {
 
 		private HttpClientRequestConfiguration build() {
 			return Optional.ofNullable(httpClientRequestConfiguration).orElseGet(() -> builder.build());
+		}
+
+		public class HttpClientRequestFollowRedirectsConfigurationBuilder {
+
+			public HttpClientRequestConfigurationBuilder enabled() {
+				builder.followRedirects().enabled();
+				return HttpClientRequestConfigurationBuilder.this;
+			}
+
+			public HttpClientRequestConfigurationBuilder disabled() {
+				builder.followRedirects().disabled();
+				return HttpClientRequestConfigurationBuilder.this;
+			}
+		}
+
+		public class HttpClientRequestUseCachesConfigurationBuilder {
+
+			public HttpClientRequestConfigurationBuilder enabled() {
+				builder.useCaches().enabled();
+				return HttpClientRequestConfigurationBuilder.this;
+			}
+
+			public HttpClientRequestConfigurationBuilder disabled() {
+				builder.useCaches().disabled();
+				return HttpClientRequestConfigurationBuilder.this;
+			}
 		}
 	}
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
@@ -34,6 +34,8 @@ public class HttpClientRequestConfiguration {
 
 	private int connectionTimeout = 0;
 	private int readTimeout = 0;
+	private boolean followRedirects = true;
+	private boolean useCaches = true;
 
 	private Charset charset = Encoding.UTF_8.charset();
 
@@ -46,6 +48,14 @@ public class HttpClientRequestConfiguration {
 
 	public int readTimeout() {
 		return readTimeout;
+	}
+
+	public boolean followRedirects() {
+		return followRedirects;
+	}
+
+	public boolean useCaches() {
+		return useCaches;
 	}
 
 	public Charset charset() {
@@ -85,8 +95,52 @@ public class HttpClientRequestConfiguration {
 			return this;
 		}
 
+		public FolllowRedirectsBuilder followRedirects() {
+			return new FolllowRedirectsBuilder();
+		}
+
+		public Builder followRedirects(boolean enabled) {
+			configuration.followRedirects = enabled;
+			return this;
+		}
+
+		public UseCachesBuilder useCaches() {
+			return new UseCachesBuilder();
+		}
+
+		public Builder useCaches(boolean enabled) {
+			configuration.useCaches = enabled;
+			return this;
+		}
+
 		public HttpClientRequestConfiguration build() {
 			return configuration;
+		}
+
+		public class FolllowRedirectsBuilder {
+
+			public Builder enabled() {
+				configuration.followRedirects = true;
+				return Builder.this;
+			}
+
+			public Builder disabled() {
+				configuration.followRedirects = false;
+				return Builder.this;
+			}
+		}
+
+		public class UseCachesBuilder {
+
+			public Builder enabled() {
+				configuration.useCaches = true;
+				return Builder.this;
+			}
+
+			public Builder disabled() {
+				configuration.followRedirects = false;
+				return Builder.this;
+			}
 		}
 	}
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestFactory.java
@@ -63,6 +63,9 @@ public class JdkHttpClientRequestFactory implements HttpClientRequestFactory {
 
 			connection.setConnectTimeout(httpClientRequestConfiguration.connectionTimeout());
 			connection.setReadTimeout(httpClientRequestConfiguration.readTimeout());
+			connection.setReadTimeout(httpClientRequestConfiguration.readTimeout());
+			connection.setInstanceFollowRedirects(httpClientRequestConfiguration.followRedirects());
+			connection.setUseCaches(httpClientRequestConfiguration.useCaches());
 
 			connection.setDoOutput(true);
 			connection.setAllowUserInteraction(false);


### PR DESCRIPTION
## Configuração de requisições http (follow redirects e use caches) ☕️  

### Descrição
- Implementa novos campos na configuração de requisições http: *follow redirects* (se respostas do tipo 3xx devem ser seguidos automaticamente; o padrão é true) e *use caches* (se a conexão http deve utilizar cabeçalhos de cache http contidos na resposta; o padrão é true)

### Changelog
- Implementa novos campos na configuração de requisições http: *follow redirects* e *use caches* (a configuração pode ser preenchida via RestifyProxyBuilder ou na criação do objeto HttpClientRequestConfiguration). Essas configurações afetam apenas o request factory padrão (*JdkHttpClientRequestFactory*)
