### PR TITLE
[configure-http-ssl] Configuração de SSL e proxy HTTP

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/ProxyFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/ProxyFactory.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+
+class ProxyFactory {
+
+	private final InvocationHandler handler;
+
+	public ProxyFactory(InvocationHandler handler) {
+		this.handler = handler;
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T> T create(Class<T> type) {
+		return (T) Proxy.newProxyInstance(this.getClass().getClassLoader(), new Class[] {type}, handler);
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
@@ -36,6 +36,9 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSocketFactory;
+
 import com.github.ljtfreitas.restify.http.client.EndpointMethodExecutor;
 import com.github.ljtfreitas.restify.http.client.authentication.Authentication;
 import com.github.ljtfreitas.restify.http.client.call.EndpointCallFactory;
@@ -578,6 +581,10 @@ public class RestifyProxyBuilder {
 			return this;
 		}
 
+		public HttpClientRequestSslConfigurationBuilder ssl() {
+			return new HttpClientRequestSslConfigurationBuilder();
+		}
+
 		public RestifyProxyBuilder using(HttpClientRequestConfiguration httpClientRequestConfiguration) {
 			this.httpClientRequestConfiguration = httpClientRequestConfiguration;
 			return context;
@@ -614,6 +621,23 @@ public class RestifyProxyBuilder {
 			public HttpClientRequestConfigurationBuilder disabled() {
 				builder.useCaches().disabled();
 				return HttpClientRequestConfigurationBuilder.this;
+			}
+		}
+
+		public class HttpClientRequestSslConfigurationBuilder {
+
+			public HttpClientRequestConfigurationBuilder sslSocketFactory(SSLSocketFactory sslSocketFactory) {
+				builder.ssl().sslSocketFactory(sslSocketFactory);
+				return HttpClientRequestConfigurationBuilder.this;
+			}
+
+			public HttpClientRequestConfigurationBuilder hostnameVerifier(HostnameVerifier hostnameVerifier) {
+				builder.ssl().hostnameVerifier(hostnameVerifier);
+				return HttpClientRequestConfigurationBuilder.this;
+			}
+
+			public RestifyProxyBuilder and() {
+				return context;
 			}
 		}
 	}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
@@ -25,7 +25,7 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http;
 
-import java.lang.reflect.Proxy;
+import java.net.Proxy;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -202,11 +202,10 @@ public class RestifyProxyBuilder {
 			this.endpoint = endpoint;
 		}
 
-		@SuppressWarnings("unchecked")
 		public T build() {
 			RestifyProxyHandler restifyProxyHandler = doBuild();
 
-			return (T) Proxy.newProxyInstance(this.getClass().getClassLoader(), new Class[]{type}, restifyProxyHandler);
+			return new ProxyFactory(restifyProxyHandler).create(type);
 		}
 
 		private RestifyProxyHandler doBuild() {
@@ -560,6 +559,11 @@ public class RestifyProxyBuilder {
 
 		public HttpClientRequestConfigurationBuilder charset(Charset charset) {
 			builder.charset(charset);
+			return this;
+		}
+
+		public HttpClientRequestConfigurationBuilder proxy(Proxy proxy) {
+			builder.proxy(proxy);
 			return this;
 		}
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
@@ -27,6 +27,10 @@ package com.github.ljtfreitas.restify.http.client.request.jdk;
 
 import java.nio.charset.Charset;
 import java.time.Duration;
+import java.util.Optional;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSocketFactory;
 
 import com.github.ljtfreitas.restify.http.client.charset.Encoding;
 
@@ -38,6 +42,9 @@ public class HttpClientRequestConfiguration {
 	private boolean useCaches = true;
 
 	private Charset charset = Encoding.UTF_8.charset();
+
+	private SSLSocketFactory sslSocketFactory;
+	private HostnameVerifier hostnameVerifier;
 
 	private HttpClientRequestConfiguration() {
 	}
@@ -60,6 +67,14 @@ public class HttpClientRequestConfiguration {
 
 	public Charset charset() {
 		return charset;
+	}
+
+	public Optional<SSLSocketFactory> sslSocketFactory() {
+		return Optional.ofNullable(sslSocketFactory);
+	}
+
+	public Optional<HostnameVerifier> hostnameVerifier() {
+		return Optional.ofNullable(hostnameVerifier);
 	}
 
 	public static HttpClientRequestConfiguration useDefault() {

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
@@ -128,6 +128,10 @@ public class HttpClientRequestConfiguration {
 			return this;
 		}
 
+		public SslBuilder ssl() {
+			return new SslBuilder();
+		}
+
 		public HttpClientRequestConfiguration build() {
 			return configuration;
 		}
@@ -154,6 +158,23 @@ public class HttpClientRequestConfiguration {
 
 			public Builder disabled() {
 				configuration.followRedirects = false;
+				return Builder.this;
+			}
+		}
+
+		public class SslBuilder {
+
+			public Builder sslSocketFactory(SSLSocketFactory sslSocketFactory) {
+				configuration.sslSocketFactory = sslSocketFactory;
+				return Builder.this;
+			}
+
+			public Builder hostnameVerifier(HostnameVerifier hostnameVerifier) {
+				configuration.hostnameVerifier = hostnameVerifier;
+				return Builder.this;
+			}
+
+			public Builder and() {
 				return Builder.this;
 			}
 		}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
@@ -43,10 +43,9 @@ public class HttpClientRequestConfiguration {
 	private boolean useCaches = true;
 
 	private Charset charset = Encoding.UTF_8.charset();
+	private Proxy proxy = null;
 
-	private Proxy proxy;
-	private SSLSocketFactory sslSocketFactory;
-	private HostnameVerifier hostnameVerifier;
+	private HttpClientRequestSslConfiguration ssl = new HttpClientRequestSslConfiguration();
 
 	private HttpClientRequestConfiguration() {
 	}
@@ -75,16 +74,26 @@ public class HttpClientRequestConfiguration {
 		return Optional.ofNullable(proxy);
 	}
 
-	public Optional<SSLSocketFactory> sslSocketFactory() {
-		return Optional.ofNullable(sslSocketFactory);
-	}
-
-	public Optional<HostnameVerifier> hostnameVerifier() {
-		return Optional.ofNullable(hostnameVerifier);
+	public HttpClientRequestSslConfiguration ssl() {
+		return ssl;
 	}
 
 	public static HttpClientRequestConfiguration useDefault() {
 		return new HttpClientRequestConfiguration();
+	}
+
+	public class HttpClientRequestSslConfiguration {
+
+		private SSLSocketFactory sslSocketFactory;
+		private HostnameVerifier hostnameVerifier;
+
+		public Optional<SSLSocketFactory> sslSocketFactory() {
+			return Optional.ofNullable(sslSocketFactory);
+		}
+
+		public Optional<HostnameVerifier> hostnameVerifier() {
+			return Optional.ofNullable(hostnameVerifier);
+		}
 	}
 
 	public static class Builder {
@@ -176,12 +185,12 @@ public class HttpClientRequestConfiguration {
 		public class SslBuilder {
 
 			public Builder sslSocketFactory(SSLSocketFactory sslSocketFactory) {
-				configuration.sslSocketFactory = sslSocketFactory;
+				configuration.ssl().sslSocketFactory = sslSocketFactory;
 				return Builder.this;
 			}
 
 			public Builder hostnameVerifier(HostnameVerifier hostnameVerifier) {
-				configuration.hostnameVerifier = hostnameVerifier;
+				configuration.ssl().hostnameVerifier = hostnameVerifier;
 				return Builder.this;
 			}
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
@@ -25,6 +25,7 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.client.request.jdk;
 
+import java.net.Proxy;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.Optional;
@@ -43,6 +44,7 @@ public class HttpClientRequestConfiguration {
 
 	private Charset charset = Encoding.UTF_8.charset();
 
+	private Proxy proxy;
 	private SSLSocketFactory sslSocketFactory;
 	private HostnameVerifier hostnameVerifier;
 
@@ -67,6 +69,10 @@ public class HttpClientRequestConfiguration {
 
 	public Charset charset() {
 		return charset;
+	}
+
+	public Optional<Proxy> proxy() {
+		return Optional.ofNullable(proxy);
 	}
 
 	public Optional<SSLSocketFactory> sslSocketFactory() {
@@ -107,6 +113,11 @@ public class HttpClientRequestConfiguration {
 
 		public Builder charset(Charset charset) {
 			configuration.charset = charset;
+			return this;
+		}
+
+		public Builder proxy(Proxy proxy) {
+			configuration.proxy = proxy;
 			return this;
 		}
 

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestFactory.java
@@ -97,10 +97,10 @@ public class JdkHttpClientRequestFactory implements HttpClientRequestFactory {
 		if (connection instanceof HttpsURLConnection) {
 			HttpsURLConnection https = (HttpsURLConnection) connection;
 
-			httpClientRequestConfiguration.sslSocketFactory()
+			httpClientRequestConfiguration.ssl().sslSocketFactory()
 				.ifPresent(sslSocketFactory -> https.setSSLSocketFactory(sslSocketFactory));
 
-			httpClientRequestConfiguration.hostnameVerifier()
+			httpClientRequestConfiguration.ssl().hostnameVerifier()
 				.ifPresent(hostnameVerifier -> https.setHostnameVerifier(hostnameVerifier));
 		}
 	}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestFactory.java
@@ -89,5 +89,4 @@ public class JdkHttpClientRequestFactory implements HttpClientRequestFactory {
 			throw new RestifyHttpException(e);
 		}
 	}
-
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestFactory.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.nio.charset.Charset;
 
+import javax.net.ssl.HttpsURLConnection;
+
 import com.github.ljtfreitas.restify.http.RestifyHttpException;
 import com.github.ljtfreitas.restify.http.client.charset.Encoding;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
@@ -70,6 +72,16 @@ public class JdkHttpClientRequestFactory implements HttpClientRequestFactory {
 			connection.setDoOutput(true);
 			connection.setAllowUserInteraction(false);
 			connection.setRequestMethod(request.method());
+
+			if (connection instanceof HttpsURLConnection) {
+				HttpsURLConnection https = (HttpsURLConnection) connection;
+
+				httpClientRequestConfiguration.sslSocketFactory()
+						.ifPresent(sslSocketFactory -> https.setSSLSocketFactory(sslSocketFactory));
+
+				httpClientRequestConfiguration.hostnameVerifier()
+						.ifPresent(hostnameVerifier -> https.setHostnameVerifier(hostnameVerifier));
+			}
 
 			return new JdkHttpClientRequest(connection, charset, request.headers());
 

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/jdk/JdkHttpClientRequestTest.java
@@ -16,6 +16,8 @@ import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -27,6 +29,7 @@ import org.junit.rules.ExpectedException;
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.HttpRequest;
+import org.mockserver.socket.SSLFactory;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.ljtfreitas.restify.http.RestifyHttpException;
@@ -40,7 +43,7 @@ import com.github.ljtfreitas.restify.http.contract.Post;
 public class JdkHttpClientRequestTest {
 
 	@Rule
-	public MockServerRule mockServerRule = new MockServerRule(this, 7080);
+	public MockServerRule mockServerRule = new MockServerRule(this, 7080, 7084);
 
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
@@ -227,6 +230,46 @@ public class JdkHttpClientRequestTest {
 		expectedException.expectCause(isA(SocketTimeoutException.class));
 
 		myApi.json();
+	}
+
+	@Test
+	public void shouldSendSecureRequest() throws Exception {
+		mockServerClient = new MockServerClient("localhost", 7084);
+
+		char[] keyStorePassword = "changeit".toCharArray();
+
+		KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+		keyManagerFactory.init(SSLFactory.getInstance().buildKeyStore(), keyStorePassword);
+
+		SSLContext sslContext = SSLContext.getInstance("TLS");
+		sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
+
+		myApi = new RestifyProxyBuilder()
+				.client()
+					.ssl()
+						.sslSocketFactory(sslContext.getSocketFactory())
+					.and()
+				.target(MyApi.class, "https://localhost:7084")
+				.build();
+
+		HttpRequest secureRequest = request()
+				.withMethod("GET")
+				.withPath("/json")
+				.withSecure(true);
+
+		mockServerClient
+			.when(secureRequest)
+			.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "application/json")
+					.withBody(json("{\"name\": \"Tiago de Freitas Lima\",\"age\":31}")));
+
+		MyModel myModel = myApi.json();
+
+		assertEquals("Tiago de Freitas Lima", myModel.name);
+		assertEquals(31, myModel.age);
+
+		mockServerClient.verify(secureRequest);
 	}
 
 	interface MyApi {


### PR DESCRIPTION
### Configuração de SSL e proxy HTTP ☕️ 

#### Descrição
- Permite customização do [SSLSocketFactory](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLSocketFactory.html) e [HostnameVerifier](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/HostnameVerifier.html) utilizados em requisições HTTPS (SSL).
- Permite utilizar um [Proxy](https://docs.oracle.com/javase/8/docs/api/java/net/Proxy.html) para requisições HTTP
- Essas configurações afetam **apenas** as requisições realizadas com o HttpClientRequestFactory padrão (que utiliza HttpUrlConnection)

#### Changelog
- Cria novas propriedades na classe *HttpClientRequestConfiguration* para customização de requisições que utilizam SSL (permite customizar o *SSLSocketFactory* e *HostnameVerifier* utilizados na requisição)
- Cria nova propriedade na classe *HttpClientRequestConfiguration* para utilização de uma instância de *java.net.Proxy*, que será utilizada na requisição.
- Cria novos métodos no RestifyProxyBuilder para configuração do ssl e proxy
- Cria nova classe *ProxyFactory* para encapsular a proxyação da interface enviada ao RestifyProxyBuilder
