### PR TITLE
[fix-restify-proxy-builder-url] Configuração de endpoints usando URL e URI

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
@@ -26,6 +26,8 @@
 package com.github.ljtfreitas.restify.http;
 
 import java.net.Proxy;
+import java.net.URI;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -193,6 +195,14 @@ public class RestifyProxyBuilder {
 		return new RestifyProxyBuilderOnTarget<>(target, endpoint);
 	}
 
+	public <T> RestifyProxyBuilderOnTarget<T> target(Class<T> target, URL endpoint) {
+		return new RestifyProxyBuilderOnTarget<>(target, endpoint.toString());
+	}
+
+	public <T> RestifyProxyBuilderOnTarget<T> target(Class<T> target, URI endpoint) {
+		return new RestifyProxyBuilderOnTarget<>(target, endpoint.toString());
+	}
+
 	public class RestifyProxyBuilderOnTarget<T> {
 		private final Class<T> type;
 		private final String endpoint;
@@ -209,7 +219,7 @@ public class RestifyProxyBuilder {
 		}
 
 		private RestifyProxyHandler doBuild() {
-			EndpointTarget target = new EndpointTarget(type, endpoint);
+			EndpointTarget target = new EndpointTarget(type, endpoint.toString());
 
 			EndpointMethodExecutor endpointMethodExecutor = new EndpointMethodExecutor(endpointCallExecutables(), endpointMethodCallFactory()); 
 


### PR DESCRIPTION
### Configuração de endpoints usando URL e URI ☕️ 

#### Descrição
- Permite parametrizar o endpoint target da interface (no RestifyProxyBuilder) usando objetos do tipo URL e URI

#### Changelog
- Cria novos métodos no RestifyProxyBuilder, que permitem parametrizar o endpoint base da interface usando objetos do tipo URL e URI, e não apenas String
