### PR TITLE
[annotation-request-metadata] Refatoração do RestifyContratReader, e metadados adicionais do método/requisição HTTP

### DIFF
--- a/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/JaxRsContractReader.java
+++ b/java-restify-jaxrs-contract/src/main/java/com/github/ljtfreitas/restify/http/jaxrs/contract/JaxRsContractReader.java
@@ -41,6 +41,7 @@ import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParame
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameter.EndpointMethodParameterType;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameterSerializer;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameters;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethods;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointTarget;
 import com.github.ljtfreitas.restify.http.contract.metadata.RestifyContractReader;
 import com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.JaxRsEndpointHeader;
@@ -50,13 +51,22 @@ import com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.reflection.Jax
 import com.github.ljtfreitas.restify.http.jaxrs.contract.metadata.reflection.JaxRsJavaTypeMetadata;
 import com.github.ljtfreitas.restify.http.util.Tryable;
 
-
 public class JaxRsContractReader implements RestifyContractReader {
 
 	@Override
-	public EndpointMethod read(EndpointTarget target, java.lang.reflect.Method javaMethod) {
+	public EndpointMethods read(EndpointTarget endpointTarget) {
+		return new EndpointMethods(doRead(endpointTarget));
+	}
+
+	private Collection<EndpointMethod> doRead(EndpointTarget target) {
 		JaxRsJavaTypeMetadata javaTypeMetadata = new JaxRsJavaTypeMetadata(target.type());
 
+		return target.methods().stream()
+				.map(javaMethod -> doReadMethod(target, javaTypeMetadata, javaMethod))
+					.collect(Collectors.toList());
+	}
+
+	private EndpointMethod doReadMethod(EndpointTarget target, JaxRsJavaTypeMetadata javaTypeMetadata, java.lang.reflect.Method javaMethod) {
 		JaxRsJavaMethodMetadata javaMethodMetadata = new JaxRsJavaMethodMetadata(javaMethod);
 
 		JaxRsJavaMethodParameters javaMethodParameters = new JaxRsJavaMethodParameters(javaMethod, target.type());

--- a/java-restify-jaxrs-contract/src/test/java/com/github/ljtfreitas/restify/http/jaxrs/contract/JaxRsContractReaderTest.java
+++ b/java-restify-jaxrs-contract/src/test/java/com/github/ljtfreitas/restify/http/jaxrs/contract/JaxRsContractReaderTest.java
@@ -65,8 +65,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodHasSingleParameter() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("method", new Class[] { String.class }));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("method", new Class[] { String.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/{path}", endpointMethod.path());
@@ -81,8 +82,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodHasMultiplesParameters() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("method", new Class[] { String.class, String.class, Object.class }));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("method", new Class[] { String.class, String.class, Object.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/{path}", endpointMethod.path());
@@ -106,8 +108,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWithHeadersWhenMethodHasHeaderParameters() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("headers", new Class[] { String.class, String.class }));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("headers", new Class[] { String.class, String.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/headers", endpointMethod.path());
@@ -134,8 +137,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWithContentTypeHeaderWhenMethodHasConsumesAnnotation() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("consumes", new Class[] { Object.class }));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("consumes", new Class[] { Object.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/consumes", endpointMethod.path());
@@ -152,8 +156,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWithAcceptHeaderWhenMethodHasProducesAnnotation() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("produces", new Class[0]));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("produces", new Class[0]))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/produces", endpointMethod.path());
@@ -166,8 +171,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWithAcceptHeaderWhenMethodHasProducesAnnotationWithMultiplesValues() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("multipleProduces", new Class[0]));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("multipleProduces", new Class[0]))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/produces", endpointMethod.path());
@@ -180,8 +186,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodMergingMethodHeaderAnnotationsWithHeaderParameters() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("mergeHeaders", new Class[] { Object.class, String.class }));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("mergeHeaders", new Class[] { Object.class, String.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/mergeHeaders", endpointMethod.path());
@@ -202,20 +209,19 @@ public class JaxRsContractReaderTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowExceptionWhenMethodHasNotAPathAnnotation() throws Exception {
-		jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("withoutPath"));
+		jaxRsContractReader.read(new EndpointTarget(MyWrongApiWithoutPath.class));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowExceptionWhenMethodHasNotAHttpMethodAnnotation() throws Exception {
-		jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("withoutHttpMethod"));
+		jaxRsContractReader.read(new EndpointTarget(MyWrongApiWithoutHttpMethod.class));
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWhenPathAnnotationOnMethodHasNoSlashOnStart() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("pathWithoutSlash"));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("pathWithoutSlash"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/path", endpointMethod.path());
@@ -224,8 +230,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodHasCustomizedParameterNames() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("customizedNames", new Class[] { String.class }));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("customizedNames", new Class[] { String.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/{customArgumentPath}", endpointMethod.path());
@@ -239,8 +246,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodOfMethodWithHttpMethodMetaAnnotation() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("metaAnnotationOfHttpMethod"));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("metaAnnotationOfHttpMethod"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("POST", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/some-method", endpointMethod.path());
@@ -249,8 +257,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodOfMethodWithQueryStringParameter() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("queryString", new Class[] { String.class, int.class }));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("queryString", new Class[] { String.class, int.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/query", endpointMethod.path());
@@ -269,30 +278,32 @@ public class JaxRsContractReaderTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowExceptionWhenMethodHasMoreThanOneBodyParameter() throws Exception {
-		jaxRsContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("methodWithTwoBodyParameters", new Class[] { Object.class, Object.class }));
+		jaxRsContractReader.read(new EndpointTarget(MyWrongApiWithTwoBodyParameters.class));
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWhenInterfaceHasAInheritance() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myInheritanceApiTarget,
-				MyInheritanceApiType.class.getMethod("method"));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myInheritanceApiTarget)
+				.find(MyInheritanceApiType.class.getMethod("method"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.api.com/simple", endpointMethod.path());
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodIsInherited() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myInheritanceApiTarget,
-				MyInheritanceApiType.class.getMethod("inheritedMethod"));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myInheritanceApiTarget)
+				.find(MyInheritanceApiType.class.getMethod("inheritedMethod"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.api.com/inherited", endpointMethod.path());
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWithInheritedProducesAnnotation() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myInheritanceApiTarget,
-				MyInheritanceApiType.class.getMethod("getWithHeaders", new Class[] { String.class }));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myInheritanceApiTarget)
+				.find(MyInheritanceApiType.class.getMethod("getWithHeaders", new Class[] { String.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.api.com/getWithHeaders", endpointMethod.path());
 
@@ -307,8 +318,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodHasAGenericParameter() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("create", new Class[] { Object.class }));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("create", new Class[] { Object.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/create", endpointMethod.path());
 
@@ -319,8 +331,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsASimpleGenericType() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("find", new Class[] { int.class }));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("find", new Class[] { int.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/find", endpointMethod.path());
 		assertEquals(MyModel.class, endpointMethod.returnType().classType());
@@ -328,8 +341,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsACollectionWithGenericType() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("allAsList"));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("allAsList"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(new SimpleParameterizedType(List.class, null, MyModel.class), endpointMethod.returnType().unwrap());
@@ -337,8 +351,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsGenericArray() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("allAsArray"));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("allAsArray"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(new SimpleGenericArrayType(MyModel.class), endpointMethod.returnType().unwrap());
@@ -346,8 +361,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsArray() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("myModelArray"));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("myModelArray"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(MyModel[].class, endpointMethod.returnType().classType());
@@ -355,8 +371,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsMap() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("myModelAsMap"));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("myModelAsMap"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(new SimpleParameterizedType(Map.class, null, String.class, MyModel.class),
@@ -365,8 +382,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsMapWithGenericValue() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("allAsMap"));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("allAsMap"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(new SimpleParameterizedType(Map.class, null, String.class, MyModel.class),
@@ -375,8 +393,9 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsMapWithGenericKeyAndValue() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("anyAsMap"));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("anyAsMap"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/any", endpointMethod.path());
 		assertEquals(
@@ -388,15 +407,18 @@ public class JaxRsContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenTargetHasEndpointUrl() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(myContextApiTarget,
-				MyContextApi.class.getMethod("method"));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(myContextApiTarget)
+				.find(MyContextApi.class.getMethod("method"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.api.com/context/any", endpointMethod.path());
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWhenJavaMethodHasNotPathAnnotation() throws Exception {
-		EndpointMethod endpointMethod = jaxRsContractReader.read(mySimpleCrudApiTarget, MySimpleCrudApi.class.getMethod("post", MyModel.class));
+		EndpointMethod endpointMethod = jaxRsContractReader.read(mySimpleCrudApiTarget)
+				.find(MySimpleCrudApi.class.getMethod("post", MyModel.class))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.api.com/context", endpointMethod.path());
 		assertEquals("POST", endpointMethod.httpMethod());
@@ -404,8 +426,7 @@ public class JaxRsContractReaderTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowExceptionWhenInterfaceTypeIsAnnotatedWithApplicationPathAndPathAnnotations() throws Exception {
-		jaxRsContractReader.read(new EndpointTarget(MyWrongApi.class),
-				MyWrongApi.class.getMethod("wrong"));
+		jaxRsContractReader.read(new EndpointTarget(MyWrongApi.class));
 	}
 
 	@ApplicationPath("http://my.api.com")
@@ -435,10 +456,6 @@ public class JaxRsContractReaderTest {
 		@GET
 		public void queryString(@QueryParam("name") String name, @QueryParam("age") int age);
 
-		@Path("/twoBodyParameters")
-		@GET
-		public String methodWithTwoBodyParameters(Object first, Object second);
-
 		@Path("/headers")
 		@GET
 		public String headers(@HeaderParam("X-Custom-Header") String customHeader, @HeaderParam("X-Other-Custom-Header") String otherCustomHeader);
@@ -464,10 +481,25 @@ public class JaxRsContractReaderTest {
 		@Produces("application/json")
 		public Object mergeHeaders(Object body, @HeaderParam("X-Custom-Header") String customHeader);
 
+	}
+
+	interface MyWrongApiWithoutPath {
+
 		public void withoutPath();
+	}
+
+	interface MyWrongApiWithoutHttpMethod {
 
 		@Path("/withoutHttpMethod")
 		public void withoutHttpMethod();
+	}
+
+	@ApplicationPath("http://my.api.com")
+	interface MyWrongApiWithTwoBodyParameters {
+
+		@Path("/twoBodyParameters")
+		@GET
+		public String methodWithTwoBodyParameters(Object first, Object second);
 	}
 
 	@ApplicationPath("http://my.api.com")

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/BaseHystrixCircuitBreakerEndpointCallExecutableFactory.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/BaseHystrixCircuitBreakerEndpointCallExecutableFactory.java
@@ -70,7 +70,7 @@ public abstract class BaseHystrixCircuitBreakerEndpointCallExecutableFactory<T, 
 	}
 
 	private boolean onCircuitBreaker(EndpointMethod endpointMethod) {
-		return endpointMethod.annotations().contains(OnCircuitBreaker.class);
+		return endpointMethod.metadata().contains(OnCircuitBreaker.class);
 	}
 
 	private boolean returnHystrixCommand(EndpointMethod endpointMethod) {

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandMetadataFactory.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandMetadataFactory.java
@@ -44,7 +44,7 @@ class HystrixCommandMetadataFactory {
 
 	public HystrixCommandMetadataFactory(EndpointMethod endpointMethod) {
 		this.endpointMethod = endpointMethod;
-		this.onCircuitBreaker = endpointMethod.annotations().get(OnCircuitBreaker.class);
+		this.onCircuitBreaker = endpointMethod.metadata().get(OnCircuitBreaker.class);
 	}
 
 	public HystrixCommand.Setter create() {

--- a/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/contract/SpringWebContractReader.java
+++ b/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/contract/SpringWebContractReader.java
@@ -44,6 +44,7 @@ import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParame
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameter.EndpointMethodParameterType;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameterSerializer;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameters;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethods;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointTarget;
 import com.github.ljtfreitas.restify.http.contract.metadata.RestifyContractExpressionResolver;
 import com.github.ljtfreitas.restify.http.contract.metadata.RestifyContractReader;
@@ -66,9 +67,19 @@ public class SpringWebContractReader implements RestifyContractReader {
 	}
 
 	@Override
-	public EndpointMethod read(EndpointTarget target, Method javaMethod) {
+	public EndpointMethods read(EndpointTarget target) {
+		return new EndpointMethods(doRead(target));
+	}
+
+	private Collection<EndpointMethod> doRead(EndpointTarget target) {
 		SpringWebJavaTypeMetadata javaTypeMetadata = new SpringWebJavaTypeMetadata(target.type());
 
+		return target.methods().stream()
+				.map(javaMethod -> doReadMethod(target, javaTypeMetadata, javaMethod))
+					.collect(Collectors.toList());
+	}
+
+	private EndpointMethod doReadMethod(EndpointTarget target, SpringWebJavaTypeMetadata javaTypeMetadata, Method javaMethod) {
 		SpringWebJavaMethodMetadata javaMethodMetadata = new SpringWebJavaMethodMetadata(javaMethod);
 
 		String endpointPath = endpointPath(target, javaTypeMetadata, javaMethodMetadata);

--- a/java-restify-spring/src/test/java/com/github/ljtfreitas/restify/http/spring/contract/SpringWebContractReaderTest.java
+++ b/java-restify-spring/src/test/java/com/github/ljtfreitas/restify/http/spring/contract/SpringWebContractReaderTest.java
@@ -77,8 +77,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodHasNoParameter() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("method"));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("method"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.api.com/path", endpointMethod.path());
 		assertEquals("GET", endpointMethod.httpMethod());
@@ -87,8 +88,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodHasSingleParameter() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("method", new Class[] { String.class }));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("method", new Class[] { String.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.api.com/{path}", endpointMethod.path());
 		assertEquals("GET", endpointMethod.httpMethod());
@@ -103,8 +105,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodHasMultiplesParameters() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("method", new Class[] { String.class, String.class, Object.class }));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("method", new Class[] { String.class, String.class, Object.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/{path}", endpointMethod.path());
@@ -132,8 +135,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenPathAnnotationOnMethodHasNoSlashOnStart() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("pathWithoutSlash"));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("pathWithoutSlash"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/path", endpointMethod.path());
@@ -142,8 +146,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodMergingEndpointHeadersDeclaredOnTypeWithDeclaredOnMethod() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("mergeHeaders"));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("mergeHeaders"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/mergeHeaders", endpointMethod.path());
@@ -168,8 +173,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodHasCustomizedParameterNames() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("customizedNames", new Class[] { String.class, String.class }));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("customizedNames", new Class[] { String.class, String.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/{customArgumentPath}", endpointMethod.path());
@@ -192,8 +198,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldReadMetadataOfMethodWithHttpMethodMetaAnnotation() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("metaAnnotationOfHttpMethod"));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("metaAnnotationOfHttpMethod"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("POST", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/some-method", endpointMethod.path());
@@ -202,8 +209,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldReadMetadataOfMethodWithQueryStringParameter() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("queryString", new Class[] { Map.class }));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myApiTypeTarget)
+				.find(MyApiType.class.getMethod("queryString", new Class[] { Map.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/query", endpointMethod.path());
@@ -217,36 +225,37 @@ public class SpringWebContractReaderTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowExceptionWhenMethodHasMoreThanOneBodyParameter() throws Exception {
-		springMvcContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("methodWithTwoBodyParameters", new Class[] { Object.class, Object.class }));
+		springMvcContractReader.read(new EndpointTarget(MyWrongApiWithTwoBodyParameters.class, "http://my.api.com"));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowExceptionWhenMethodParameterHasNoAnnotations() throws Exception {
-		springMvcContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("withoutAnnotation", new Class[] { String.class }));
+		springMvcContractReader.read(new EndpointTarget(MyWrongApiWithoutParameterAnnotation.class, "http://my.api.com"));
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWhenInterfaceHasAInheritance() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myInheritanceApiTarget,
-				MyInheritanceApiType.class.getMethod("method"));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myInheritanceApiTarget)
+				.find(MyInheritanceApiType.class.getMethod("method"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.api.com/context/simple", endpointMethod.path());
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodIsInherited() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myInheritanceApiTarget,
-				MyInheritanceApiType.class.getMethod("inheritedMethod"));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myInheritanceApiTarget)
+				.find(MyInheritanceApiType.class.getMethod("inheritedMethod"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.api.com/context/inherited", endpointMethod.path());
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodHasAGenericParameter() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("create", new Class[] { Object.class }));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("create", new Class[] { Object.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/create", endpointMethod.path());
 
@@ -257,8 +266,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsASimpleGenericType() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("find", new Class[] { int.class }));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("find", new Class[] { int.class }))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.model.api/find", endpointMethod.path());
 		assertEquals(JavaType.of(MyModel.class), endpointMethod.returnType());
@@ -266,8 +276,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsACollectionWithGenericType() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("allAsList"));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("allAsList"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(JavaType.of(new SimpleParameterizedType(List.class, null, MyModel.class)), endpointMethod.returnType());
@@ -275,8 +286,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsGenericArray() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("allAsArray"));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("allAsArray"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(JavaType.of(new SimpleGenericArrayType(MyModel.class)), endpointMethod.returnType());
@@ -284,8 +296,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsArray() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("myModelArray"));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("myModelArray"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(JavaType.of(MyModel[].class), endpointMethod.returnType());
@@ -293,8 +306,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsMap() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("myModelAsMap"));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("myModelAsMap"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(JavaType.of(new SimpleParameterizedType(Map.class, null, String.class, MyModel.class)),
@@ -303,8 +317,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsMapWithGenericValue() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("allAsMap"));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("allAsMap"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(JavaType.of(new SimpleParameterizedType(Map.class, null, String.class, MyModel.class)),
@@ -313,8 +328,9 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsMapWithGenericKeyAndValue() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("anyAsMap"));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myGenericSpecificApiTarget)
+				.find(MySpecificApi.class.getMethod("anyAsMap"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.model.api/any", endpointMethod.path());
 		assertEquals(
@@ -326,16 +342,18 @@ public class SpringWebContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenTargetHasEndpointUrl() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(myContextApiTarget,
-				MyContextApi.class.getMethod("method"));
+		EndpointMethod endpointMethod = springMvcContractReader.read(myContextApiTarget)
+				.find(MyContextApi.class.getMethod("method"))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.api.com/context/any", endpointMethod.path());
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWhenJavaMethodHasNoPathOnRequestMappingAnnotation() throws Exception {
-		EndpointMethod endpointMethod = springMvcContractReader.read(mySimpleCrudApiTarget,
-				MySimpleCrudApi.class.getMethod("post", MyModel.class));
+		EndpointMethod endpointMethod = springMvcContractReader.read(mySimpleCrudApiTarget)
+				.find(MySimpleCrudApi.class.getMethod("post", MyModel.class))
+					.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.api.com/context", endpointMethod.path());
 		assertEquals("POST", endpointMethod.httpMethod());
@@ -370,11 +388,17 @@ public class SpringWebContractReaderTest {
 
 		@RequestMapping(value = "/query", method = RequestMethod.GET)
 		public Void queryString(@RequestParam Map<String, String> parameters);
+	}
 
-		@RequestMapping("/twoBodyParameters")
+	interface MyWrongApiWithTwoBodyParameters {
+
+		@RequestMapping(path = "/twoBodyParameters", method = RequestMethod.POST)
 		public String methodWithTwoBodyParameters(@RequestBody Object first, @RequestBody Object second);
+	}
 
-		@RequestMapping(path = "/{path}", method = RequestMethod.GET)
+	interface MyWrongApiWithoutParameterAnnotation {
+
+		@RequestMapping(path = "/withoutAnnotation", method = RequestMethod.GET)
 		public String withoutAnnotation(String path);
 	}
 
@@ -420,7 +444,7 @@ public class SpringWebContractReaderTest {
 	interface MySpecificApi extends MyGenericApiType<MyModel> {
 
 		@PutMapping("/update")
-		public MyModel update(MyModel myModel);
+		public MyModel update(@RequestBody MyModel myModel);
 
 		@GetMapping("/all")
 		public MyModel[] myModelArray();

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequest.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequest.java
@@ -42,6 +42,7 @@ public class EndpointRequest {
 	private final Object body;
 	private final JavaType responseType;
 	private final EndpointVersion version;
+	private final EndpointRequestMetadata metadata;
 
 	public EndpointRequest(URI endpoint, String method) {
 		this(endpoint, method, (EndpointVersion) null);
@@ -80,20 +81,22 @@ public class EndpointRequest {
 	}
 
 	public EndpointRequest(URI endpoint, String method, Headers headers, Object body, Type responseType, EndpointVersion version) {
-		this(endpoint, method, headers, body, JavaType.of(responseType), version);
+		this(endpoint, method, headers, body, JavaType.of(responseType), version, EndpointRequestMetadata.empty());
 	}
 
 	public EndpointRequest(URI endpoint, String method, Headers headers, Object body, JavaType responseType) {
-		this(endpoint, method, headers, body, responseType, null);
+		this(endpoint, method, headers, body, responseType, null, EndpointRequestMetadata.empty());
 	}
 
-	public EndpointRequest(URI endpoint, String method, Headers headers, Object body, JavaType responseType, EndpointVersion version) {
+	public EndpointRequest(URI endpoint, String method, Headers headers, Object body, JavaType responseType,
+			EndpointVersion version, EndpointRequestMetadata metadata) {
 		this.endpoint = endpoint;
 		this.method = method;
 		this.headers = headers;
 		this.body = body;
 		this.responseType = responseType;
 		this.version = version;
+		this.metadata = metadata;
 	}
 
 	public URI endpoint() {
@@ -120,6 +123,10 @@ public class EndpointRequest {
 		return Optional.ofNullable(version);
 	}
 
+	public EndpointRequestMetadata metadata() {
+		return metadata;
+	}
+
 	public EndpointRequest appendParameter(String name, String value) {
 		String appender = endpoint.getQuery() == null ? "" : "&";
 
@@ -132,14 +139,14 @@ public class EndpointRequest {
 			URI newURI = new URI(endpoint.getScheme(), endpoint.getRawAuthority(), endpoint.getRawPath(),
 					newQuery, endpoint.getRawFragment());
 
-			return new EndpointRequest(newURI, method, headers, body, responseType, version);
+			return new EndpointRequest(newURI, method, headers, body, responseType, version, metadata);
 		} catch (URISyntaxException e) {
 			throw new RestifyHttpException(e);
 		}
 	}
 
 	public EndpointRequest replace(URI endpoint) {
-		return new EndpointRequest(endpoint, method, headers, body, responseType, version);
+		return new EndpointRequest(endpoint, method, headers, body, responseType, version, metadata);
 	}
 
 	@Override

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestFactory.java
@@ -67,7 +67,9 @@ public class EndpointRequestFactory {
 
 			EndpointVersion version = endpointMethod.version().map(EndpointVersion::of).orElse(null);
 
-			return new EndpointRequest(endpoint, endpointMethod.httpMethod(), headers, body, responseType, version);
+			EndpointRequestMetadata metadata = new EndpointRequestMetadata(endpointMethod.metadata().all());
+
+			return new EndpointRequest(endpoint, endpointMethod.httpMethod(), headers, body, responseType, version, metadata);
 
 		} catch (URISyntaxException e) {
 			throw new RestifyHttpException(e);

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestMetadata.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestMetadata.java
@@ -23,59 +23,37 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.contract.metadata.reflection;
+package com.github.ljtfreitas.restify.http.client.request;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import com.github.ljtfreitas.restify.http.contract.metadata.Metadata;
+public class EndpointRequestMetadata {
 
-public class MethodMetadata {
+	private final Collection<Annotation> annotations;
 
-	private final Map<Class<? extends Annotation>, List<Annotation>> annotations;
-
-	public MethodMetadata(Method javaMethod) {
-		this.annotations = scan(javaMethod).stream().collect(Collectors.groupingBy(Annotation::annotationType));
-	}
-
-	private List<Annotation> scan(Method javaMethod) {
-		List<Annotation> annotations = new ArrayList<>();
-		annotations.addAll(Arrays.asList(new JavaAnnotationScanner(javaMethod).allWith(Metadata.class)));
-		annotations.addAll(Arrays.asList(new JavaAnnotationScanner(javaMethod.getDeclaringClass()).allWith(Metadata.class)));
-		return annotations;
-	}
-
-	public <A extends Annotation> boolean contains(Class<A> annotation) {
-		return annotations.containsKey(annotation);
+	public EndpointRequestMetadata(Collection<Annotation> annotations) {
+		this.annotations = Collections.unmodifiableCollection(annotations);
 	}
 
 	@SuppressWarnings("unchecked")
 	public <A extends Annotation> Optional<A> get(Class<A> annotation) {
-		return annotations.getOrDefault(annotation, Collections.emptyList()).stream()
+		return annotations.stream().filter(a -> a.annotationType().isAssignableFrom(annotation))
 				.findFirst()
 					.map(a -> (A) a);
 	}
 
 	@SuppressWarnings("unchecked")
 	public <A extends Annotation> Collection<A> all(Class<A> annotation) {
-		return (List<A>) annotations.getOrDefault(annotation, Collections.emptyList());
-	}
-
-	public Collection<Annotation> all() {
-		return annotations.values().stream()
-				.flatMap(c -> c.stream())
+		return annotations.stream().filter(a -> a.annotationType().isAssignableFrom(annotation))
+				.map(a -> (A) a)
 					.collect(Collectors.toList());
 	}
 
-	public static MethodMetadata of(Method method) {
-		return new MethodMetadata(method);
+	public static EndpointRequestMetadata empty() {
+		return new EndpointRequestMetadata(Collections.emptyList());
 	}
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/DefaultRestifyContract.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/DefaultRestifyContract.java
@@ -27,10 +27,6 @@ package com.github.ljtfreitas.restify.http.contract;
 
 import static com.github.ljtfreitas.restify.http.util.Preconditions.nonNull;
 
-import java.util.Collection;
-import java.util.stream.Collectors;
-
-import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethods;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointTarget;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointType;
@@ -48,10 +44,8 @@ public class DefaultRestifyContract implements RestifyContract {
 	public EndpointType read(EndpointTarget target) {
 		nonNull(target, "Endpoint target cannot be null.");
 
-		Collection<EndpointMethod> endpointMethods = target.methods().stream()
-					.map(javaMethod -> reader.read(target, javaMethod))
-						.collect(Collectors.toSet());
+		EndpointMethods endpointMethods = reader.read(target);
 
-		return new EndpointType(target, new EndpointMethods(endpointMethods));
+		return new EndpointType(target, endpointMethods);
 	}
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReader.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReader.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -57,9 +58,18 @@ public class DefaultRestifyContractReader implements RestifyContractReader {
 	}
 
 	@Override
-	public EndpointMethod read(EndpointTarget target, java.lang.reflect.Method javaMethod) {
-		JavaTypeMetadata javaTypeMetadata = new JavaTypeMetadata(target.type());
+	public EndpointMethods read(EndpointTarget target) {
+		return new EndpointMethods(doRead(target));
+	}
 
+	private Collection<EndpointMethod> doRead(EndpointTarget target) {
+		JavaTypeMetadata javaTypeMetadata = new JavaTypeMetadata(target.type());
+		return target.methods().stream()
+			.map(javaMethod -> doReadMethod(target, javaTypeMetadata, javaMethod))
+				.collect(Collectors.toList());
+	}
+
+	private EndpointMethod doReadMethod(EndpointTarget target, JavaTypeMetadata javaTypeMetadata, java.lang.reflect.Method javaMethod) {
 		JavaMethodMetadata javaMethodMetadata = new JavaMethodMetadata(javaMethod);
 
 		String endpointPath = endpointPath(target, javaTypeMetadata, javaMethodMetadata);

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethod.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/EndpointMethod.java
@@ -32,7 +32,7 @@ import java.lang.reflect.Type;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaMethodAnnotations;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.MethodMetadata;
 import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
 
 public class EndpointMethod {
@@ -43,7 +43,7 @@ public class EndpointMethod {
 	private final EndpointMethodParameters parameters;
 	private final EndpointHeaders headers;
 	private final JavaType returnType;
-	private final JavaMethodAnnotations annotations;
+	private final MethodMetadata metadata;
 	private final String version;
 
 	public EndpointMethod(Method javaMethod, String path, String httpMethod) {
@@ -96,7 +96,7 @@ public class EndpointMethod {
 		this.parameters = nonNull(parameters, "EndpointMethod needs a parameters collection.");
 		this.headers = nonNull(headers, "EndpointMethod needs a HTTP headers collection.");
 		this.returnType = returnType;
-		this.annotations = new JavaMethodAnnotations(javaMethod);
+		this.metadata = new MethodMetadata(javaMethod);
 		this.version = version;
 	}
 
@@ -128,8 +128,8 @@ public class EndpointMethod {
 		return returnType.voidType() && !parameters.callbacks().isEmpty();
 	}
 
-	public JavaMethodAnnotations annotations() {
-		return annotations;
+	public MethodMetadata metadata() {
+		return metadata;
 	}
 
 	public Optional<String> version() {

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/Metadata.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/Metadata.java
@@ -23,7 +23,7 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker;
+package com.github.ljtfreitas.restify.http.contract.metadata;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -31,19 +31,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.github.ljtfreitas.restify.http.contract.metadata.Metadata;
-
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target(ElementType.ANNOTATION_TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@Metadata
-public @interface OnCircuitBreaker {
-
-	String groupKey() default "";
-
-	String commandKey() default "";
-
-	String threadPoolKey() default "";
-
-	CircuitBreakerProperty[] properties() default {};
+public @interface Metadata {
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/RestifyContractReader.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/RestifyContractReader.java
@@ -25,10 +25,8 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.contract.metadata;
 
-import java.lang.reflect.Method;
-
 public interface RestifyContractReader {
 
-	EndpointMethod read(EndpointTarget endpointTarget, Method javaMethod);
+	public EndpointMethods read(EndpointTarget endpointTarget);
 
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaAnnotationScanner.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/contract/metadata/reflection/JavaAnnotationScanner.java
@@ -48,6 +48,12 @@ public class JavaAnnotationScanner {
 						.orElse(null);
 	}
 
+	public <T extends Annotation> Annotation[] allWith(Class<T> javaAnnotationType) {
+		return Arrays.stream(javaAnnotatedElement.getAnnotations())
+				.filter(a -> a.annotationType().isAnnotationPresent(javaAnnotationType))
+					.toArray(Annotation[]::new);
+	}
+
 	public <T extends Annotation> T scan(Class<T> javaAnnotationType) {
 		return doScan(javaAnnotationType);
 	}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestMetadataTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestMetadataTest.java
@@ -1,0 +1,63 @@
+package com.github.ljtfreitas.restify.http.client.request;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import com.github.ljtfreitas.restify.http.contract.metadata.Metadata;
+import com.github.ljtfreitas.restify.http.contract.metadata.reflection.MethodMetadata;
+
+public class EndpointRequestMetadataTest {
+
+	@Test
+	public void shouldGetAnnotationByType() throws Exception {
+		MethodMetadata methodMetadata = MethodMetadata.of(MyType.class.getMethod("bla"));
+
+		EndpointRequestMetadata endpointRequestMetadata = new EndpointRequestMetadata(methodMetadata.all());
+
+		Optional<Whatever> whatever = endpointRequestMetadata.get(Whatever.class);
+
+		assertTrue(whatever.isPresent());
+		assertEquals("method", whatever.get().value());
+	}
+
+	@Test
+	public void shouldGetAllAnnotationsByType() throws Exception {
+		MethodMetadata methodMetadata = MethodMetadata.of(MyType.class.getMethod("bla"));
+
+		EndpointRequestMetadata endpointRequestMetadata = new EndpointRequestMetadata(methodMetadata.all());
+
+		List<Whatever> whatevers = new ArrayList<>(endpointRequestMetadata.all(Whatever.class));
+
+		assertThat(whatevers, hasSize(2));
+
+		assertEquals("method", whatevers.get(0).value());
+		assertEquals("type", whatevers.get(1).value());
+	}
+
+	@Whatever("type")
+	private interface MyType {
+
+		@Whatever("method")
+		String bla();
+	}
+
+	@Target({ ElementType.TYPE, ElementType.METHOD })
+	@Retention(RetentionPolicy.RUNTIME)
+	@Metadata
+	private @interface Whatever {
+
+		String value();
+	}
+}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/DefaultRestifyContractTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/DefaultRestifyContractTest.java
@@ -2,12 +2,12 @@ package com.github.ljtfreitas.restify.http.contract;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Optional;
 
 import org.junit.Before;
@@ -17,8 +17,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.github.ljtfreitas.restify.http.contract.DefaultRestifyContract;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethods;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointTarget;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointType;
 import com.github.ljtfreitas.restify.http.contract.metadata.RestifyContractReader;
@@ -38,8 +38,10 @@ public class DefaultRestifyContractTest {
 	public void setup() {
 		endpointTarget = new EndpointTarget(MyApiType.class);
 
-		when(restifyContractReaderMock.read(same(endpointTarget), any(Method.class)))
-			.then(invocation -> new EndpointMethod(invocation.getArgumentAt(1, Method.class), "/path", "GET"));
+		when(restifyContractReaderMock.read(same(endpointTarget)))
+			.then(invocation ->
+				new EndpointMethods(Arrays.asList(
+						new EndpointMethod(invocation.getArgumentAt(0, EndpointTarget.class).type().getMethods()[0], "/path", "GET"))));
 	}
 
 	@Test
@@ -55,7 +57,7 @@ public class DefaultRestifyContractTest {
 
 		assertEquals(javaMethod, endpointMethod.get().javaMethod());
 
-		verify(restifyContractReaderMock).read(endpointTarget, javaMethod);
+		verify(restifyContractReaderMock).read(endpointTarget);
 	}
 	
 	private interface MyApiType {

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReaderTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/contract/metadata/DefaultRestifyContractReaderTest.java
@@ -74,8 +74,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodHasSingleParameter() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("method", new Class[] { String.class }));
+		EndpointMethods endpointMethods = restifyContractReader.read(myApiTypeTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyApiType.class.getMethod("method", new Class[] { String.class }))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/{path}", endpointMethod.path());
@@ -90,8 +92,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodHasMultiplesParameters() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("method", new Class[] { String.class, String.class, Object.class }));
+		EndpointMethods endpointMethods = restifyContractReader.read(myApiTypeTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyApiType.class.getMethod("method", new Class[] { String.class, String.class, Object.class }))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/{path}", endpointMethod.path());
@@ -115,8 +119,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenPathAnnotationOnMethodHasNoSlashOnStart() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("pathWithoutSlash"));
+		EndpointMethods endpointMethods = restifyContractReader.read(myApiTypeTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyApiType.class.getMethod("pathWithoutSlash"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/path", endpointMethod.path());
@@ -125,8 +131,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodMergingEndpointHeadersDeclaredOnTypeWithDeclaredOnMethod() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("mergeHeaders"));
+		EndpointMethods endpointMethods = restifyContractReader.read(myApiTypeTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyApiType.class.getMethod("mergeHeaders"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/mergeHeaders", endpointMethod.path());
@@ -147,8 +155,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWithEndpointHeadersMetaAnnotation() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("metaHeaders"));
+		EndpointMethods endpointMethods = restifyContractReader.read(myApiTypeTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyApiType.class.getMethod("metaHeaders"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/metaHeaders", endpointMethod.path());
@@ -169,8 +179,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodHasCustomizedParameterNames() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("customizedNames", new Class[] { String.class, String.class }));
+		EndpointMethods endpointMethods = restifyContractReader.read(myApiTypeTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyApiType.class.getMethod("customizedNames", new Class[] { String.class, String.class }))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/{customArgumentPath}", endpointMethod.path());
@@ -189,8 +201,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodOfMethodWithHttpMethodMetaAnnotation() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("metaAnnotationOfHttpMethod"));
+		EndpointMethods endpointMethods = restifyContractReader.read(myApiTypeTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyApiType.class.getMethod("metaAnnotationOfHttpMethod"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("POST", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/some-method", endpointMethod.path());
@@ -199,8 +213,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodOfMethodWithQueryStringParameter() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myApiTypeTarget,
-				MyApiType.class.getMethod("queryString", new Class[] { Parameters.class }));
+		EndpointMethods endpointMethods = restifyContractReader.read(myApiTypeTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyApiType.class.getMethod("queryString", new Class[] { Parameters.class }))
+				.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/query", endpointMethod.path());
@@ -214,14 +230,15 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowExceptionWhenMethodHasMoreThanOneBodyParameter() throws Exception {
-		new DefaultRestifyContractReader().read(myApiTypeTarget,
-				MyApiType.class.getMethod("methodWithTwoBodyParameters", new Class[] { Object.class, Object.class }));
+		new DefaultRestifyContractReader().read(new EndpointTarget(MyApiTypeWithWrongBodyParameter.class));
 	}
 
 	@Test
 	public void shouldCreateAsyncEndpointMethodWhenMethodHasOneCallback() throws Exception {
-		EndpointMethod endpointMethod = new DefaultRestifyContractReader().read(myApiTypeTarget,
-				MyApiType.class.getMethod("async", new Class[] { EndpointCallCallback.class }));
+		EndpointMethods endpointMethods = new DefaultRestifyContractReader().read(myApiTypeTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyApiType.class.getMethod("async", new Class[] { EndpointCallCallback.class }))
+				.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/async", endpointMethod.path());
@@ -239,8 +256,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateAsyncEndpointMethodWhenMethodHasMultiplesCallbacks() throws Exception {
-		EndpointMethod endpointMethod = new DefaultRestifyContractReader().read(myApiTypeTarget,
-				MyApiType.class.getMethod("async", new Class[] { EndpointCallSuccessCallback.class, EndpointCallFailureCallback.class }));
+		EndpointMethods endpointMethods = new DefaultRestifyContractReader().read(myApiTypeTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyApiType.class.getMethod("async", new Class[] { EndpointCallSuccessCallback.class, EndpointCallFailureCallback.class }))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("GET", endpointMethod.httpMethod());
 		assertEquals("http://my.api.com/async", endpointMethod.path());
@@ -264,30 +283,35 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowExceptionWhenMethodHasMoreOneCallbackParameterOfSameType() throws Exception {
-		new DefaultRestifyContractReader().read(myApiTypeTarget,
-				MyApiType.class.getMethod("asyncWithTwoCallbacks", new Class[] { EndpointCallCallback.class, EndpointCallCallback.class }));
+		new DefaultRestifyContractReader().read(new EndpointTarget(MyApiTypeWithWrongCallbackParameter.class));
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWhenInterfaceHasAInheritance() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myInheritanceApiTarget,
-				MyInheritanceApiType.class.getMethod("method"));
+		EndpointMethods endpointMethods = restifyContractReader.read(myInheritanceApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyInheritanceApiType.class.getMethod("method"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.api.com/simple", endpointMethod.path());
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodIsInherited() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myInheritanceApiTarget,
-				MyInheritanceApiType.class.getMethod("inheritedMethod"));
+		EndpointMethods endpointMethods = restifyContractReader.read(myInheritanceApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyInheritanceApiType.class.getMethod("inheritedMethod"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.api.com/inherited", endpointMethod.path());
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodHasAGenericParameter() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("create", new Class[] { Object.class }));
+		EndpointMethods endpointMethods = restifyContractReader.read(myGenericSpecificApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MySpecificApi.class.getMethod("create", new Class[] { Object.class }))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/create", endpointMethod.path());
 
@@ -298,8 +322,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsASimpleGenericType() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("find", new Class[] { int.class }));
+		EndpointMethods endpointMethods = restifyContractReader.read(myGenericSpecificApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MySpecificApi.class.getMethod("find", new Class[] { int.class }))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/find", endpointMethod.path());
 		assertEquals(MyModel.class, endpointMethod.returnType().classType());
@@ -307,8 +333,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsACollectionWithGenericType() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("allAsList"));
+		EndpointMethods endpointMethods = restifyContractReader.read(myGenericSpecificApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MySpecificApi.class.getMethod("allAsList"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(new SimpleParameterizedType(List.class, null, MyModel.class), endpointMethod.returnType().unwrap());
@@ -316,8 +344,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsGenericArray() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("allAsArray"));
+		EndpointMethods endpointMethods = restifyContractReader.read(myGenericSpecificApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MySpecificApi.class.getMethod("allAsArray"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(new SimpleGenericArrayType(MyModel.class), endpointMethod.returnType().unwrap());
@@ -325,8 +355,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsArray() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("myModelArray"));
+		EndpointMethods endpointMethods = restifyContractReader.read(myGenericSpecificApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MySpecificApi.class.getMethod("myModelArray"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(MyModel[].class, endpointMethod.returnType().classType());
@@ -334,8 +366,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsMap() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("myModelAsMap"));
+		EndpointMethods endpointMethods = restifyContractReader.read(myGenericSpecificApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MySpecificApi.class.getMethod("myModelAsMap"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(new SimpleParameterizedType(Map.class, null, String.class, MyModel.class),
@@ -344,8 +378,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsMapWithGenericValue() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("allAsMap"));
+		EndpointMethods endpointMethods = restifyContractReader.read(myGenericSpecificApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MySpecificApi.class.getMethod("allAsMap"))
+				.orElseThrow(() -> new IllegalStateException("Method not found..."));
 
 		assertEquals("http://my.model.api/all", endpointMethod.path());
 		assertEquals(new SimpleParameterizedType(Map.class, null, String.class, MyModel.class),
@@ -354,8 +390,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenMethodReturnTypeIsMapWithGenericKeyAndValue() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("anyAsMap"));
+		EndpointMethods endpointMethods = restifyContractReader.read(myGenericSpecificApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MySpecificApi.class.getMethod("anyAsMap"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.model.api/any", endpointMethod.path());
 		assertEquals(
@@ -367,8 +405,10 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateAsyncEndpointMethodWhenMethodHasOneCallbackWithGenericType() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myGenericSpecificApiTarget,
-				MySpecificApi.class.getMethod("async", EndpointCallCallback.class));
+		EndpointMethods endpointMethods = restifyContractReader.read(myGenericSpecificApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MySpecificApi.class.getMethod("async", EndpointCallCallback.class))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.model.api/async", endpointMethod.path());
 		assertEquals("GET", endpointMethod.httpMethod());
@@ -386,15 +426,20 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWhenTargetHasEndpointUrl() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myContextApiTarget,
-				MyContextApi.class.getMethod("method"));
+		EndpointMethods endpointMethods = restifyContractReader.read(myContextApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyContextApi.class.getMethod("method"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.api.com/context/any", endpointMethod.path());
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWhenJavaMethodHasNotPathAnnotation() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(mySimpleCrudApiTarget, MySimpleCrudApi.class.getMethod("post", MyModel.class));
+		EndpointMethods endpointMethods = restifyContractReader.read(mySimpleCrudApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MySimpleCrudApi.class.getMethod("post", MyModel.class))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.api.com/context", endpointMethod.path());
 	}
@@ -405,7 +450,10 @@ public class DefaultRestifyContractReaderTest {
 
 		EndpointTarget dynamicApiTarget = new EndpointTarget(MyDynamicApi.class);
 
-		EndpointMethod endpointMethod = restifyContractReader.read(dynamicApiTarget, MyDynamicApi.class.getMethod("method"));
+		EndpointMethods endpointMethods = restifyContractReader.read(dynamicApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(MyDynamicApi.class.getMethod("method"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://localhost:8080/any", endpointMethod.path());
 	}
@@ -416,15 +464,19 @@ public class DefaultRestifyContractReaderTest {
 
 		EndpointTarget dynamicApiTarget = new EndpointTarget(OtherDynamicApi.class, "@{api.endpoint}");
 
-		EndpointMethod endpointMethod = restifyContractReader.read(dynamicApiTarget, OtherDynamicApi.class.getMethod("method"));
+		EndpointMethods endpointMethods = restifyContractReader.read(dynamicApiTarget);
+
+		EndpointMethod endpointMethod = endpointMethods.find(OtherDynamicApi.class.getMethod("method"))
+			.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://localhost:8080/context/any", endpointMethod.path());
 	}
 
 	@Test
 	public void shouldCreateEndpointMethodWithVersionWhenTypeIsVersioned() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myVersionedApiTarget,
-				MyVersionedApi.class.getMethod("versionOne"));
+		EndpointMethod endpointMethod = restifyContractReader.read(myVersionedApiTarget)
+			.find(MyVersionedApi.class.getMethod("versionOne"))
+				.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.api.com/v1/model", endpointMethod.path());
 
@@ -434,8 +486,9 @@ public class DefaultRestifyContractReaderTest {
 
 	@Test
 	public void shouldCreateEndpointMethodWithMethodVersionWhenVersionAnnotationIsPresentOnMethod() throws Exception {
-		EndpointMethod endpointMethod = restifyContractReader.read(myVersionedApiTarget,
-				MyVersionedApi.class.getMethod("versionTwo"));
+		EndpointMethod endpointMethod = restifyContractReader.read(myVersionedApiTarget)
+			.find(MyVersionedApi.class.getMethod("versionTwo"))
+				.orElseThrow(() -> new IllegalStateException("Method not found..."));;
 
 		assertEquals("http://my.api.com/v2/model", endpointMethod.path());
 
@@ -480,10 +533,6 @@ public class DefaultRestifyContractReaderTest {
 		@Get
 		public Void queryString(@QueryParameters Parameters parameters);
 
-		@Path("/twoBodyParameters")
-		@Get
-		public String methodWithTwoBodyParameters(@BodyParameter Object first, @BodyParameter Object second);
-
 		@Path("/async")
 		@Get
 		public void async(@CallbackParameter EndpointCallCallback<String> callback);
@@ -493,16 +542,28 @@ public class DefaultRestifyContractReaderTest {
 		public void async(@CallbackParameter EndpointCallSuccessCallback<String> successCallback,
 				@CallbackParameter EndpointCallFailureCallback failureCallback);
 
-		@Path("/asyncWithTwoCallbacks")
-		@Get
-		public void asyncWithTwoCallbacks(@CallbackParameter EndpointCallCallback<String> first, @CallbackParameter EndpointCallCallback<String> second);
-
 		@Path("/metaHeaders")
 		@Method("GET")
 		@JsonContent
 		@AcceptJson
 		@Header(name = "User-Agent", value = "Restify-Agent")
 		public String metaHeaders();
+	}
+
+	@Path("http://my.api.com")
+	interface MyApiTypeWithWrongBodyParameter {
+
+		@Path("/twoBodyParameters")
+		@Get
+		public String methodWithTwoBodyParameters(@BodyParameter Object first, @BodyParameter Object second);
+	}
+
+	@Path("http://my.api.com")
+	interface MyApiTypeWithWrongCallbackParameter {
+
+		@Path("/asyncWithTwoCallbacks")
+		@Get
+		public void asyncWithTwoCallbacks(@CallbackParameter EndpointCallCallback<String> first, @CallbackParameter EndpointCallCallback<String> second);
 	}
 
 	@Path("http://my.api.com")


### PR DESCRIPTION
### Refatoração do RestifyContractReader, e metadados adicionais do método/requisição HTTP 💭 

#### Descrição
- Refatora contrato do objeto *RestifyContractReader*; passa a receber apenas um objeto EndpointTarget e retorna uma coleção de objetos EndpointMethod. Esse modelo melhora a performance ao realizar a leitura das anotações do objeto apenas uma vez. 
- Implementa anotação *Metadata* para representar mata-anotações de dados adicionais ao método/requisição http. Essas anotações serão propagadas para o objeto EndpointRequest.
- Implementa anotação *Metadata* para representar mata-anotações de dados adicionais ao 
método/requisição http. Essas anotações serão propagadas para o objeto EndpointRequest.

#### Changelog
- Refatora contrato da interface *RestifyContractRader*, e refatora todas as implementações atualmente existentes.
- Cria nova anotação *Metadata*, para ser utilizada em outras anotações.
- Renomeia objeto *JavaMethodAnnotations* para *MethodMetadata*; esse objeto passa a representar apenas as anotações marcadas com *Metadata*, presentes no método/classe.
- Cria novo objeto *EndpointRequestMetada* para representar metadados adicionais da requisição incluídos no método pela anotação *Metadata*. O objeto EndpointRequest passa a ter um atributo do tipo EndpointRequestMetadata
