### PR TITLE
[hateoas-support-link-body] Suporte para hipermedia e HATEOAS - Links usando métodos POST e PUT

### DIFF
--- a/java-restify-hateoas/src/main/java/com/github/ljtfreitas/restify/http/client/hateoas/browser/Hop.java
+++ b/java-restify-hateoas/src/main/java/com/github/ljtfreitas/restify/http/client/hateoas/browser/Hop.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import com.github.ljtfreitas.restify.http.client.Header;
 import com.github.ljtfreitas.restify.http.client.Headers;
+import com.github.ljtfreitas.restify.http.contract.ContentType;
 
 public class Hop {
 
@@ -110,15 +111,19 @@ public class Hop {
 		return new Hop(rel, parameters, headers, "POST", body);
 	}
 
-	public Hop usingPost(Object body) {
-		return new Hop(rel, parameters, headers, "POST", body);
+	public Hop usingPost(Object body, ContentType contentType) {
+		Headers newHeaders = new Headers(this.headers);
+		newHeaders.put(new Header(Headers.CONTENT_TYPE, contentType.toString()));
+		return new Hop(rel, parameters, newHeaders, "POST", body);
 	}
 
 	public Hop usingPut() {
 		return new Hop(rel, parameters, headers, "PUT", body);
 	}
 
-	public Hop usingPut(Object body) {
+	public Hop usingPut(Object body, ContentType contentType) {
+		Headers newHeaders = new Headers(this.headers);
+		newHeaders.put(new Header(Headers.CONTENT_TYPE, contentType.toString()));
 		return new Hop(rel, parameters, headers, "PUT", body);
 	}
 
@@ -130,8 +135,10 @@ public class Hop {
 		return new Hop(rel, parameters, headers, method, body);
 	}
 
-	public Hop usingMethod(String method, Object body) {
-		return new Hop(rel, parameters, headers, method, body);
+	public Hop usingMethod(String method, Object body, ContentType contentType) {
+		Headers newHeaders = new Headers(this.headers);
+		newHeaders.put(new Header(Headers.CONTENT_TYPE, contentType.toString()));
+		return new Hop(rel, parameters, newHeaders, method, body);
 	}
 
 	public static Hop rel(String rel) {

--- a/java-restify-hateoas/src/test/java/com/github/ljtfreitas/restify/http/client/hateoas/browser/LinkBrowserTest.java
+++ b/java-restify-hateoas/src/test/java/com/github/ljtfreitas/restify/http/client/hateoas/browser/LinkBrowserTest.java
@@ -12,6 +12,8 @@ import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.JsonBody.json;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -28,6 +30,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.ljtfreitas.restify.http.client.hateoas.Link;
 import com.github.ljtfreitas.restify.http.client.request.interceptor.EndpointRequestInterceptorStack;
+import com.github.ljtfreitas.restify.http.contract.ContentType;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LinkBrowserTest {
@@ -420,6 +423,8 @@ public class LinkBrowserTest {
 		HttpRequest avatarRequest = request()
 			.withMethod("POST")
 			.withHeader("X-Whatever", "whatever")
+			.withHeader("Content-Type", "application/json; charset=UTF-8")
+			.withBody(json("{\"image\":\"http://path.to.image/image.jpg\"}"))
 			.withPath("/me/avatar");
 
 		mockServerClient.when(personRequest)
@@ -439,9 +444,14 @@ public class LinkBrowserTest {
 
 		linkBrowser = new LinkBrowserBuilder().baseURL("http://localhost:7080").build();
 
+		Map<String, String> body = new HashMap<>();
+		body.put("image", "http://path.to.image/image.jpg");
+
 		String result = linkBrowser
 				.follow(Link.self("http://localhost:7080/me"))
-					.follow(rel("update_avatar").usingPost().usingHeader("X-Whatever", "whatever"))
+					.follow(rel("update_avatar")
+							.usingPost(body, ContentType.of("application/json"))
+							.usingHeader("X-Whatever", "whatever"))
 						.as(String.class);
 
 		assertEquals("ok", result);

--- a/java-restify-hateoas/src/test/resources/logback.xml
+++ b/java-restify-hateoas/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <logger name="org.mockserver" level="OFF"/>
+    <logger name="org.mockserver" level="INFO"/>
 
     <root level="INFO">
         <appender class="ch.qos.logback.core.ConsoleAppender">

--- a/java-restify-jaxrs-http-client/src/test/resources/logback.xml
+++ b/java-restify-jaxrs-http-client/src/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <logger name="org.mockserver" level="OFF"/>
-    
+
     <root level="INFO">
         <appender class="ch.qos.logback.core.ConsoleAppender">
             <encoder>

--- a/java-restify-netflix-kubernetes-service-discovery/src/test/resources/logback.xml
+++ b/java-restify-netflix-kubernetes-service-discovery/src/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <logger name="org.mockserver" level="OFF"/>
-    
+
     <root level="INFO">
         <appender class="ch.qos.logback.core.ConsoleAppender">
             <encoder>

--- a/java-restify-netflix-zookeeper-service-discovery/src/test/resources/logback.xml
+++ b/java-restify-netflix-zookeeper-service-discovery/src/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <logger name="org.mockserver" level="OFF"/>
-    
+
     <root level="INFO">
         <appender class="ch.qos.logback.core.ConsoleAppender">
             <encoder>

--- a/java-restify-netflix/src/test/resources/logback.xml
+++ b/java-restify-netflix/src/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <logger name="org.mockserver" level="OFF"/>
-    
+
     <root level="INFO">
         <appender class="ch.qos.logback.core.ConsoleAppender">
             <encoder>

--- a/java-restify-oauth2-authentication/src/test/resources/logback.xml
+++ b/java-restify-oauth2-authentication/src/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <logger name="org.mockserver" level="OFF"/>
-    
+
     <root level="INFO">
         <appender class="ch.qos.logback.core.ConsoleAppender">
             <encoder>

--- a/java-restify/src/test/resources/logback.xml
+++ b/java-restify/src/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <logger name="org.mockserver" level="OFF"/>
-    
+
     <root level="INFO">
         <appender class="ch.qos.logback.core.ConsoleAppender">
             <encoder>


### PR DESCRIPTION
### Suporte para Hipermedia e HATEOAS (links usando métodos POST e PUT)🤘 

#### Descrição
- Complemento do pull request #41: modifica métodos de navegação que utilizam os verbos POST e PUT para obrigar o envio do cabeçalho Content-Type, se algum corpo for utilizado na requisição.

#### Changelog
- Modifica métodos *usingPost*, *usingPut* e *usingMethod* da classe Hop para receber um argumento do tipo ContentType