### PR TITLE
[fix-hystrix-property-names] Modifica nome padrão do commandName do Hystrix

### DIFF
--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/BaseHystrixCircuitBreakerEndpointCallExecutableFactory.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/BaseHystrixCircuitBreakerEndpointCallExecutableFactory.java
@@ -33,7 +33,6 @@ import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
 import com.github.ljtfreitas.restify.http.contract.metadata.reflection.JavaType;
 import com.github.ljtfreitas.restify.http.netflix.client.request.circuitbreaker.OnCircuitBreaker;
 import com.netflix.hystrix.HystrixCommand;
-import com.netflix.hystrix.HystrixCommand.Setter;
 
 public abstract class BaseHystrixCircuitBreakerEndpointCallExecutableFactory<T, O> implements EndpointCallExecutableDecoratorFactory<T, T, O> {
 
@@ -44,11 +43,11 @@ public abstract class BaseHystrixCircuitBreakerEndpointCallExecutableFactory<T, 
 		this(null, null);
 	}
 
-	protected BaseHystrixCircuitBreakerEndpointCallExecutableFactory(Setter hystrixMetadata) {
+	protected BaseHystrixCircuitBreakerEndpointCallExecutableFactory(HystrixCommand.Setter hystrixMetadata) {
 		this(hystrixMetadata, null);
 	}
 
-	protected BaseHystrixCircuitBreakerEndpointCallExecutableFactory(Setter hystrixMetadata, Object fallback) {
+	protected BaseHystrixCircuitBreakerEndpointCallExecutableFactory(HystrixCommand.Setter hystrixMetadata, Object fallback) {
 		this.hystrixMetadata = hystrixMetadata;
 		this.fallback = fallback;
 	}

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerEndpointCallExecutableFactory.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCircuitBreakerEndpointCallExecutableFactory.java
@@ -25,7 +25,7 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
 
-import com.netflix.hystrix.HystrixCommand.Setter;
+import com.netflix.hystrix.HystrixCommand;
 
 public class HystrixCircuitBreakerEndpointCallExecutableFactory<T, O> extends BaseHystrixCircuitBreakerEndpointCallExecutableFactory<T, O> {
 
@@ -33,7 +33,7 @@ public class HystrixCircuitBreakerEndpointCallExecutableFactory<T, O> extends Ba
 		super();
 	}
 
-	public HystrixCircuitBreakerEndpointCallExecutableFactory(Setter hystrixMetadata) {
+	public HystrixCircuitBreakerEndpointCallExecutableFactory(HystrixCommand.Setter hystrixMetadata) {
 		super(hystrixMetadata);
 	}
 }

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandMetadataFactory.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandMetadataFactory.java
@@ -69,7 +69,7 @@ class HystrixCommandMetadataFactory {
 	private HystrixCommandKey commandKey() {
 		String commandKey = onCircuitBreaker.map(a -> a.commandKey())
 				.filter(g -> g != null && !"".equals(g))
-					.orElseGet(() -> endpointMethod.javaMethod().getName());
+					.orElseGet(() -> groupKey() + "." + endpointMethod.javaMethod().getName());
 
 		return HystrixCommandKey.Factory.asKey(commandKey);
 	}

--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandMetadataFactoryTest.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandMetadataFactoryTest.java
@@ -25,7 +25,7 @@ public class HystrixCommandMetadataFactoryTest {
 		EmptyHystrixCommand command = new EmptyHystrixCommand(hystrixMetadata);
 
 		assertEquals("MyApiWithCircuitBreaker", command.getCommandGroup().name());
-		assertEquals("simple", command.getCommandKey().name());
+		assertEquals("MyApiWithCircuitBreaker.simple", command.getCommandKey().name());
 		assertEquals("MyApiWithCircuitBreaker", command.getThreadPoolKey().name());
 	}
 
@@ -51,7 +51,7 @@ public class HystrixCommandMetadataFactoryTest {
 		EmptyHystrixCommand command = new EmptyHystrixCommand(hystrixMetadata);
 
 		assertEquals("MyApiWithCircuitBreaker", command.getCommandGroup().name());
-		assertEquals("customizedProperties", command.getCommandKey().name());
+		assertEquals("MyApiWithCircuitBreaker.customizedProperties", command.getCommandKey().name());
 		assertEquals("MyApiWithCircuitBreaker", command.getThreadPoolKey().name());
 
 		assertEquals(ExecutionIsolationStrategy.SEMAPHORE, command.getProperties().executionIsolationStrategy().get());


### PR DESCRIPTION
## Hystrix - Command Name

## Descrição
- Modifica a geração do *commandName* padrão dos comandos do Hystrix; passa a utilizar o nome da classe concatenado ao nome do método.

## Changelog
- Modifica a geração do *commandName* padrão dos comandos do Hystrix; passa a utilizar o nome da classe concatenado ao nome do método (o nome fornecido pelo usuário continua tendo preferência).