### PR TITLE
[fix-hystrix-fallback-return-type] Hystrix - Retorno inválido ao utilizar o fallback em métodos com retorno diferente da resposta

### DIFF
--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandFallback.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandFallback.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.call.exec;
+
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.util.Tryable;
+
+class HystrixCommandFallback {
+
+	private final EndpointMethod endpointMethod;
+	private final Object[] args;
+	private final Object fallback;
+
+	HystrixCommandFallback(EndpointMethod endpointMethod, Object[] args, Object fallback) {
+		this.endpointMethod = endpointMethod;
+		this.args = args;
+		this.fallback = fallback;
+	}
+
+	@SuppressWarnings("unchecked")
+	<T> T run() {
+		return Tryable.of(() -> (T) endpointMethod.javaMethod().invoke(fallback, args));
+	}
+}

--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandEndpointCallExecutableFactoryTest.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/call/exec/HystrixCommandEndpointCallExecutableFactoryTest.java
@@ -65,6 +65,23 @@ public class HystrixCommandEndpointCallExecutableFactoryTest {
 		verify(delegate).execute(notNull(EndpointCall.class), any());
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	public void shouldGetObservableFromHystrixCommand() throws Exception {
+		EndpointCallExecutable<HystrixCommand<String>, String> executable = factory
+				.create(new SimpleEndpointMethod(SomeType.class.getMethod("command")), delegate);
+
+		String result = "result";
+
+		HystrixCommand<String> hystrixCommand = executable.execute(() -> result, null);
+
+		String output = hystrixCommand.toObservable().toBlocking().single();
+
+		assertEquals(result, output);
+
+		verify(delegate).execute(notNull(EndpointCall.class), any());
+	}
+
 	@Test
 	public void shouldReturnObjectTypeWhenHystrixCommandIsNotParameterized() throws Exception {
 		assertEquals(JavaType.of(Object.class), factory.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbCommand"))));


### PR DESCRIPTION
### Hystrix - Erro em caso de fallback com tipo de retorno diferente do tipo da resposta :anguished:

#### Descrição
- Quando o fallback do Hystrtix era utilizado em situações onde o tipo de retorno do método era diferente do tipo da resposta, o valor retornado pelo proxy era inválido. Isso ocorria porque a execução do *HystrixCircuitBreakerFallbackExecutable* delega ao *Executable* nativo o resultado do HystrixCommand, que em caso de sucesso devolve o tipo da resposta, e em caso de fallback, o retorno do método de fallback, o que fazia com que o valor fallback fosse novamente encapsulado pelo Executable.
- O *HystrixCircuitBreakerFallbackExecutable* também não permitia que o fallback retornasse *null*. Eses pull request modifica esse comportamento assumindo que, se houver fallback, ele deve ser executado e retornado (independente do retorno ser nulo)

#### Changelog
- Cria novo objeto *EndpointCallExecutableHystrixCommand* para representar o HystrixCommand, que deve devolver sempre o tipo de retorno do método.
- Cria novo objeto *HystrixCommandFallback* para encapsular a execução do fallback, se informado
- Refatoração interna das classes *HystrixCircuitBreakerEndpointCallExecutable* e *HystrixCommandEndpointCallExecutable*
- Testes de unidade para os cenários descritos acima