### PR TITLE
[fix-zookeeper-configuration] Configuração do Zookeeper (ServiceDiscovery) - Multiplos hosts

### DIFF
--- a/java-restify-netflix-zookeeper-service-discovery/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/ZookeeperConfiguration.java
+++ b/java-restify-netflix-zookeeper-service-discovery/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/ZookeeperConfiguration.java
@@ -25,35 +25,30 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.netflix.client.request.discovery.zookeeper;
 
-import static com.github.ljtfreitas.restify.http.util.Preconditions.nonNull;
-
 public class ZookeeperConfiguration {
 
-	private final String address;
-	private final Integer port;
-	private final String root;
+	private final ZookeeperQuorum quorum;
+	private final String chroot;
 
-	public ZookeeperConfiguration(String root) {
-		this(null, 2181, root);
+	public ZookeeperConfiguration(ZookeeperQuorum quorum) {
+		this(quorum, quorum.chroot());
 	}
 
-	public ZookeeperConfiguration(String address, int port) {
-		this(address, port, "/");
+	public ZookeeperConfiguration(ZookeeperQuorum quorum, String chroot) {
+		this.quorum = quorum;
+		this.chroot = chroot;
 	}
 
-	public ZookeeperConfiguration(String address, int port, String root) {
-		this.address = address;
-		this.port = port;
-		this.root = root;
-	}
-
-	public String root() {
-		return root;
+	public String chroot() {
+		return chroot;
 	}
 
 	public String connectionString() {
-		nonNull(address, "Zookeeper address cannot be null.");
-		nonNull(port, "Zookeeper port cannot be null.");
-		return address + ":" + port;
+		return quorum.connectionString();
+	}
+
+	@Override
+	public String toString() {
+		return quorum.connectionString();
 	}
 }

--- a/java-restify-netflix-zookeeper-service-discovery/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/ZookeeperCuratorServiceDiscovery.java
+++ b/java-restify-netflix-zookeeper-service-discovery/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/ZookeeperCuratorServiceDiscovery.java
@@ -78,7 +78,7 @@ public class ZookeeperCuratorServiceDiscovery<T> implements Closeable {
 
 			ServiceDiscovery<T> serviceDiscovery = ServiceDiscoveryBuilder.builder(instanceType)
 					.client(curator)
-						.basePath(configuration.root())
+						.basePath(configuration.chroot())
 						.serializer(serializer)
 							.build();
 

--- a/java-restify-netflix-zookeeper-service-discovery/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/ZookeeperQuorum.java
+++ b/java-restify-netflix-zookeeper-service-discovery/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/ZookeeperQuorum.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.netflix.client.request.discovery.zookeeper;
+
+import static com.github.ljtfreitas.restify.http.util.Preconditions.nonNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class ZookeeperQuorum {
+
+	private static final int DEFAULT_PORT = 2181;
+
+	private final Collection<ZookeeperServer> servers;
+	private final String chroot;
+
+	private ZookeeperQuorum(Collection<ZookeeperServer> servers, String chroot) {
+		this.servers = servers;
+		this.chroot = chroot;
+	}
+
+	public String chroot() {
+		return chroot;
+	}
+
+	public String connectionString() {
+		return doConnectionString();
+	}
+
+	@Override
+	public String toString() {
+		return doConnectionString();
+	}
+
+	private String doConnectionString() {
+		return servers.stream().map(ZookeeperServer::toString).collect(Collectors.joining(","));
+	}
+
+	public static ZookeeperQuorum of(String connectionString) {
+		String chroot = null;
+
+		int slash = connectionString.lastIndexOf("/");
+		if (slash >= 0) {
+			chroot = connectionString.substring(slash);
+		}
+
+		String hosts = connectionString.substring(0, slash == -1 ? connectionString.length() : slash);
+
+		Collection<ZookeeperServer> servers = Arrays.stream(hosts.split(","))
+			.map(host -> host.split(":"))
+				.map(host -> new ZookeeperServer(host[0], host.length == 1 ? DEFAULT_PORT : Integer.valueOf(host[1])))
+					.collect(Collectors.toList());
+
+		return new ZookeeperQuorum(servers, chroot);
+	}
+
+	private static class ZookeeperServer {
+
+		private final String address;
+		private final int port;
+
+		private ZookeeperServer(String address, int port) {
+			this.address = nonNull(address, "Zookeeper address cannot be null");
+			this.port = port;
+		}
+
+		@Override
+		public String toString() {
+			return address + ":" + port;
+		}
+	}
+}

--- a/java-restify-netflix-zookeeper-service-discovery/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/DefaultZookeeperServiceDiscoveryTest.java
+++ b/java-restify-netflix-zookeeper-service-discovery/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/DefaultZookeeperServiceDiscoveryTest.java
@@ -49,7 +49,7 @@ public class DefaultZookeeperServiceDiscoveryTest {
 	public void setup() throws Exception {
 		zookeeperServer = new TestingServer(2181, true);
 
-		ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration("localhost", 2181, "/services");
+		ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration(ZookeeperQuorum.of("localhost:2181"), "/services");
 
 		ZookeeperCuratorServiceDiscovery<ZookeeperServiceInstance> zookeeperCuratorServiceDiscovery = new ZookeeperCuratorServiceDiscovery<>(ZookeeperServiceInstance.class, zookeeperConfiguration, new ZookeeperInstanceSerializer());
 

--- a/java-restify-netflix-zookeeper-service-discovery/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/ZookeeperQuorumTest.java
+++ b/java-restify-netflix-zookeeper-service-discovery/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/ZookeeperQuorumTest.java
@@ -1,0 +1,29 @@
+package com.github.ljtfreitas.restify.http.netflix.client.request.discovery.zookeeper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class ZookeeperQuorumTest {
+
+	@Test
+	public void shouldBuildZookeeperQuorumFromConnectionString() {
+		String connectionString = "localhost:2181,localhost:2182";
+
+		ZookeeperQuorum quorum = ZookeeperQuorum.of(connectionString);
+
+		assertEquals(connectionString, quorum.connectionString());
+		assertNull(quorum.chroot());
+	}
+
+	@Test
+	public void shouldBuildZookeeperQuorumFromConnectionStringWithChroot() {
+		String connectionString = "localhost:2181,localhost:2182/services";
+
+		ZookeeperQuorum quorum = ZookeeperQuorum.of(connectionString);
+
+		assertEquals("localhost:2181,localhost:2182", quorum.connectionString());
+		assertEquals("/services", quorum.chroot());
+	}
+}

--- a/java-restify-netflix-zookeeper-service-discovery/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/ZookeeperServiceCacheDiscoveryTest.java
+++ b/java-restify-netflix-zookeeper-service-discovery/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/ZookeeperServiceCacheDiscoveryTest.java
@@ -49,7 +49,7 @@ public class ZookeeperServiceCacheDiscoveryTest {
 	public void setup() throws Exception {
 		zookeeperServer = new TestingServer(2181, true);
 
-		ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration("localhost", 2181, "/services");
+		ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration(ZookeeperQuorum.of("localhost:2181"), "/services");
 
 		ZookeeperCuratorServiceDiscovery<ZookeeperServiceInstance> zookeeperCuratorServiceDiscovery = new ZookeeperCuratorServiceDiscovery<>(ZookeeperServiceInstance.class, zookeeperConfiguration, new ZookeeperInstanceSerializer());
 

--- a/java-restify-netflix-zookeeper-service-discovery/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/ZookeeperServiceProviderDiscoveryTest.java
+++ b/java-restify-netflix-zookeeper-service-discovery/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/discovery/zookeeper/ZookeeperServiceProviderDiscoveryTest.java
@@ -49,7 +49,7 @@ public class ZookeeperServiceProviderDiscoveryTest {
 	public void setup() throws Exception {
 		zookeeperServer = new TestingServer(2181, true);
 
-		ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration("localhost", 2181, "/services");
+		ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration(ZookeeperQuorum.of("localhost:2181/services"));
 
 		ZookeeperCuratorServiceDiscovery<ZookeeperServiceInstance> zookeeperCuratorServiceDiscovery = new ZookeeperCuratorServiceDiscovery<>(ZookeeperServiceInstance.class, zookeeperConfiguration, new ZookeeperInstanceSerializer());
 


### PR DESCRIPTION
## Configuração do Zookeeper (ServiceDiscovery) - Multiplos hosts (quórum)  :hushed:

### Descrição
- Refatora a implementação do pull request #44 do ServiceDiscovery com Zookeeper, especialmente o objeto *ZookeeperConfiguration*, para permitir a utilização de múltiplos hosts (quórum).

### Changelog
- Cria novo objeto *ZookeeperQuorum*, para representar a configuração de múltiplos hosts (cluster) do Zookeeper. Esse objeto é criado a partir de uma *connection string* no formato: *host:port,host:port,host:port*. Esse objeto também suporta a configuração de um "chroot", que pode ser usado como sufixo (*host:port,host:port/folder*)
- Altera o teste do ZookeeperServiceInstanceDiscovery para utilizar um *cluster* do Zookeeper