### PR TITLE
[timeout-annotation] Configuração de timeout por método

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/Timeout.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/Timeout.java
@@ -1,0 +1,21 @@
+package com.github.ljtfreitas.restify.http.client.request;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.github.ljtfreitas.restify.http.contract.metadata.Metadata;
+
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD })
+@Metadata
+public @interface Timeout {
+
+	long read() default -1;
+
+	long connection() default -1;
+
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
@@ -57,7 +57,7 @@ public class HttpClientRequestConfiguration {
 		this.useCaches = source.useCaches;
 		this.charset = source.charset;
 		this.proxy = source.proxy;
-		this.ssl = new HttpClientRequestSsl(ssl);
+		this.ssl = new HttpClientRequestSsl(source.ssl);
 	}
 
 	public int connectionTimeout() {

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/jdk/HttpClientRequestConfiguration.java
@@ -45,9 +45,19 @@ public class HttpClientRequestConfiguration {
 	private Charset charset = Encoding.UTF_8.charset();
 	private Proxy proxy = null;
 
-	private HttpClientRequestSslConfiguration ssl = new HttpClientRequestSslConfiguration();
+	private HttpClientRequestSsl ssl = new HttpClientRequestSsl();
 
 	private HttpClientRequestConfiguration() {
+	}
+
+	private HttpClientRequestConfiguration(HttpClientRequestConfiguration source) {
+		this.connectionTimeout = source.connectionTimeout;
+		this.readTimeout = source.readTimeout;
+		this.followRedirects = source.followRedirects;
+		this.useCaches = source.useCaches;
+		this.charset = source.charset;
+		this.proxy = source.proxy;
+		this.ssl = new HttpClientRequestSsl(ssl);
 	}
 
 	public int connectionTimeout() {
@@ -74,7 +84,7 @@ public class HttpClientRequestConfiguration {
 		return Optional.ofNullable(proxy);
 	}
 
-	public HttpClientRequestSslConfiguration ssl() {
+	public HttpClientRequestSsl ssl() {
 		return ssl;
 	}
 
@@ -82,10 +92,18 @@ public class HttpClientRequestConfiguration {
 		return new HttpClientRequestConfiguration();
 	}
 
-	public class HttpClientRequestSslConfiguration {
+	public class HttpClientRequestSsl {
 
 		private SSLSocketFactory sslSocketFactory;
 		private HostnameVerifier hostnameVerifier;
+
+		private HttpClientRequestSsl() {
+		}
+		
+		private HttpClientRequestSsl(HttpClientRequestSsl source) {
+			this.sslSocketFactory = source.sslSocketFactory;
+			this.hostnameVerifier = source.hostnameVerifier;
+		}
 
 		public Optional<SSLSocketFactory> sslSocketFactory() {
 			return Optional.ofNullable(sslSocketFactory);
@@ -153,7 +171,7 @@ public class HttpClientRequestConfiguration {
 		}
 
 		public HttpClientRequestConfiguration build() {
-			return configuration;
+			return new HttpClientRequestConfiguration(configuration);
 		}
 
 		public class FolllowRedirectsBuilder {

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequestConfiguration.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequestConfiguration.java
@@ -47,6 +47,14 @@ public class NettyHttpClientRequestConfiguration {
 	private NettyHttpClientRequestConfiguration() {
 	}
 
+	private NettyHttpClientRequestConfiguration(NettyHttpClientRequestConfiguration configuration) {
+		this.connectionTimeout = configuration.connectionTimeout;
+		this.readTimeout = configuration.readTimeout;
+		this.maxResponseSize = configuration.maxResponseSize;
+		this.sslContext = configuration.sslContext;
+		this.charset = configuration.charset;
+	}
+
 	public int connectionTimeout() {
 		return connectionTimeout;
 	}
@@ -111,7 +119,7 @@ public class NettyHttpClientRequestConfiguration {
 		}
 
 		public NettyHttpClientRequestConfiguration build() {
-			return configuration;
+			return new NettyHttpClientRequestConfiguration(configuration);
 		}
 	}
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequestFactory.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/request/netty/NettyHttpClientRequestFactory.java
@@ -37,9 +37,8 @@ import io.netty.channel.EventLoopGroup;
 
 public class NettyHttpClientRequestFactory implements HttpClientRequestFactory, Closeable {
 
-	private final Bootstrap bootstrap;
 	private final EventLoopGroup eventLoopGroup;
-	private NettyHttpClientRequestConfiguration nettyHttpClientRequestConfiguration;
+	private final NettyHttpClientRequestConfiguration nettyHttpClientRequestConfiguration;
 
 	public NettyHttpClientRequestFactory() {
 		this(new NettyEventLoopGroupFactory().create());
@@ -56,11 +55,13 @@ public class NettyHttpClientRequestFactory implements HttpClientRequestFactory, 
 	public NettyHttpClientRequestFactory(EventLoopGroup eventLoopGroup, NettyHttpClientRequestConfiguration nettyHttpClientRequestConfiguration) {
 		this.eventLoopGroup = eventLoopGroup;
 		this.nettyHttpClientRequestConfiguration = nettyHttpClientRequestConfiguration;
-		this.bootstrap = new NettyBootstrapFactory(eventLoopGroup, nettyHttpClientRequestConfiguration).create();
 	}
 
 	@Override
 	public HttpClientRequest createOf(EndpointRequest endpointRequest) {
+		Bootstrap bootstrap = new NettyBootstrapFactory(eventLoopGroup, nettyHttpClientRequestConfiguration)
+				.createTo(endpointRequest);
+
 		return new NettyHttpClientRequest(bootstrap, endpointRequest.endpoint(), endpointRequest.headers(), endpointRequest.method(),
 				nettyHttpClientRequestConfiguration.charset());
 	}


### PR DESCRIPTION
## Configuração de timeout por método :boom:

### Descrição
- Permite configuração de timeout da requisição http por método. Já era possível configurar o timeout do através do RestifyProxyBuilder, mas havia algumas limitações: essa configuração afetava apenas o HttpClientRequestFactory padrão (jdk) e não permitia configuração granular, no nível do método. Esse pull request introduz uma nova anotação, *Timeout*, para esse papel.

### Changelog
- Cria nova anotação *Timeout*, para configuração granular do timeout da requisição http. Essa anotação pode ser usada no método ou na interface proxyficada, e afeta as requisições realizadas com o HttpUrlConnection (padrão), Apache HttpClient e Netty. O OkHttpClientRequestFactory não foi alterado porque o OkHttp não permite a configuração no nível da requisição (apenas no objeto OkHttp)