### PR TITLE
[fix-async-endpoint-call-null-response] Corrige handler de requisicoes assíncronas, para respostas sem corpo

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/async/DefaultAsyncEndpointCall.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/async/DefaultAsyncEndpointCall.java
@@ -59,13 +59,15 @@ class DefaultAsyncEndpointCall<T> implements AsyncEndpointCall<T> {
 	}
 
 	private void handle(T value, Throwable throwable, EndpointCallSuccessCallback<T> successCallback, EndpointCallFailureCallback failureCallback) {
-		if (value != null && successCallback != null) {
+		if (throwable != null) {
+			if (failureCallback != null) {
+				Throwable cause = deepCause(throwable);
+
+				failureCallback.onFailure(cause);
+			}
+
+		} else if (successCallback != null) {
 			successCallback.onSuccess(value);
-
-		} else if (throwable != null && failureCallback != null) {
-			Throwable cause = deepCause(throwable);
-
-			failureCallback.onFailure(cause);
 		}
 	}
 

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/async/DefaultAsyncEndpointCallTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/async/DefaultAsyncEndpointCallTest.java
@@ -33,7 +33,7 @@ public class DefaultAsyncEndpointCallTest {
 	private DefaultAsyncEndpointCall<String> asyncCall;
 
 	@Test
-	public void shouldCallSuccessCallbackOnEndpointCallReturnsSomeResult() throws Exception {
+	public void shouldCallSuccessCallbackOnEndpointCallWhenReturnsSomeResult() throws Exception {
 		asyncCall = new DefaultAsyncEndpointCall<>(r -> r.run(), () -> "result");
 
 		asyncCall.execute(callback);
@@ -41,6 +41,15 @@ public class DefaultAsyncEndpointCallTest {
 		verify(callback).onSuccess("result");
 	}
 
+	@Test
+	public void shouldCallSuccessCallbackOnEndpointCallWhenNotReturnsResult() throws Exception {
+		asyncCall = new DefaultAsyncEndpointCall<>(r -> r.run(), () -> null);
+
+		asyncCall.execute(callback);
+
+		verify(callback).onSuccess(null);
+	}
+	
 	@Test
 	public void shouldCallFailureCallbackWhenEndpointCallThrowException() throws Exception {
 		RuntimeException exception = new RuntimeException("some exception");


### PR DESCRIPTION
## Handler/callback de requisições assíncronas, para respostas sem corpo (bug)  :dizzy_face:

### Descrição
- Corrige bug no handler de requisições assíncronas (executadas via *DefaultAsyncEndpointCall*), onde o callback de sucesso não era invocado caso a resposta http não tivesse retorno, ou o callback fosse tipado com *Void*

### Changelog
- Corrige o *DefaultAsyncEndpointCall* para considerar casos de sucesso com valores nulos (o valor de sucesso é enviado normalmente para o callback, mesmo que seja *null*)