### PR TITLE
[spring-response-entity-exception] Propação da exceção de resposta HTTP em retornos de método do tipo ResponseEntity (Spring)

### DIFF
--- a/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/client/call/exec/ResponseEntityConverter.java
+++ b/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/client/call/exec/ResponseEntityConverter.java
@@ -39,7 +39,7 @@ class ResponseEntityConverter<T> implements Converter<EndpointResponse<T>, Respo
 	public ResponseEntity<T> convert(EndpointResponse<T> source) {
 		return ResponseEntity.status(HttpStatus.valueOf(source.code().value()))
 				.headers(headersOf(source.headers()))
-				.body(source.code().isError() ? null : source.body());
+				.body(source.body());
 	}
 
 	private HttpHeaders headersOf(Headers headers) {

--- a/java-restify-spring/src/test/java/com/github/ljtfreitas/restify/http/spring/client/call/exec/ResponseEntityConverterTest.java
+++ b/java-restify-spring/src/test/java/com/github/ljtfreitas/restify/http/spring/client/call/exec/ResponseEntityConverterTest.java
@@ -12,8 +12,8 @@ import org.springframework.http.ResponseEntity;
 
 import com.github.ljtfreitas.restify.http.client.Headers;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
+import com.github.ljtfreitas.restify.http.client.response.RestifyEndpointResponseInternalServerErrorException;
 import com.github.ljtfreitas.restify.http.client.response.StatusCode;
-import com.github.ljtfreitas.restify.http.spring.client.call.exec.ResponseEntityConverter;
 
 public class ResponseEntityConverterTest {
 
@@ -40,5 +40,15 @@ public class ResponseEntityConverterTest {
 		assertEquals("expected result", responseEntity.getBody());
 
 		assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+	}
+
+	@Test(expected = RestifyEndpointResponseInternalServerErrorException.class)
+	public void shouldThrowExceptionWhenEndpointResponseIsError() {
+		RestifyEndpointResponseInternalServerErrorException exception = new RestifyEndpointResponseInternalServerErrorException("Internal Server Error",
+				new Headers(), "oops...");
+
+		endpointResponse = EndpointResponse.error(exception);
+
+		converter.convert(endpointResponse);
 	}
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/EndpointResponseCall.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/EndpointResponseCall.java
@@ -45,7 +45,7 @@ class EndpointResponseCall<T> implements EndpointCall<EndpointResponse<T>> {
 		try {
 			return endpointRequestExecutor.execute(endpointRequest);
 		} catch (RestifyEndpointResponseException e) {
-			return EndpointResponse.error(e.statusCode(), e.headers(), e.bodyAsString());
+			return EndpointResponse.error(e);
 		}
 	}
 }

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/response/EndpointResponse.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/response/EndpointResponse.java
@@ -79,20 +79,24 @@ public class EndpointResponse<T> {
 	public static <T> EndpointResponse<T> error(StatusCode statusCode, Headers headers, String body) {
 		isTrue(statusCode.isError(), "StatusCode [" + statusCode + "] is not a HTTP error!");
 
-		return new EndpointResponse<T>(statusCode, headers, null) {
+		String message = new StringBuilder("HTTP response is a error of type ")
+				.append("[")
+					.append(statusCode)
+				.append("].")
+					.append("\n")
+				.append("Raw response body is:")
+					.append("\n")
+				.append(body)
+					.toString();
+
+		return error(new RestifyEndpointResponseException(message, statusCode, headers, body));
+	}
+
+	public static <T> EndpointResponse<T> error(RestifyEndpointResponseException exception) {
+		return new EndpointResponse<T>(exception.statusCode(), exception.headers(), null) {
 			@Override
 			public T body() {
-				String message = new StringBuilder("HTTP response is a error of type ")
-						.append("[")
-							.append(statusCode)
-						.append("].")
-							.append("\n")
-						.append("Raw response body is:")
-							.append("\n")
-						.append(body)
-							.toString();
-
-				throw new RestifyEndpointResponseException(message, statusCode, headers, body);
+				throw exception;
 			}
 		};
 	}


### PR DESCRIPTION
## Propação da exceção de resposta HTTP em retornos de método do tipo ResponseEntity (Spring)  :leaves:

### Descrição
- Passa a propagar exceção em casos de resposta de erro, quando o retorno do método for um objeto do tipo ResponseEntity. A motivação dessa mudança foi tornar o uso desse objeto mais compatível com o comportamento do *RestTemplate* do Spring

### Changelog
- Passa a propagar exceção em casos de resposta de erro, em retornos de método do tipo ResponseEntity
- Passa a propagar a exceção original, representando a resposta de erro, no objeto EndpointResponse
