### PR TITLE
[fix-string-write-message] Conversão de String considerando o encoding, ao gerar o corpo da requisição

### DIFF
--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/text/TextMessageConverter.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/text/TextMessageConverter.java
@@ -63,7 +63,7 @@ public abstract class TextMessageConverter implements HttpMessageReader<String>,
 	@Override
 	public void write(String body, HttpRequestMessage httpRequestMessage) throws RestifyHttpMessageWriteException {
 		try {
-			httpRequestMessage.output().write(body.toString().getBytes());
+			httpRequestMessage.output().write(body.toString().getBytes(httpRequestMessage.charset()));
 		} catch (IOException e) {
 			throw new RestifyHttpMessageWriteException(e);
 		}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/text/TextMessageConverterTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/text/TextMessageConverterTest.java
@@ -10,7 +10,7 @@ import java.io.ByteArrayOutputStream;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.github.ljtfreitas.restify.http.client.message.converter.text.TextMessageConverter;
+import com.github.ljtfreitas.restify.http.client.charset.Encoding;
 import com.github.ljtfreitas.restify.http.client.request.SimpleHttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.response.SimpleHttpResponseMessage;
 
@@ -59,6 +59,18 @@ public class TextMessageConverterTest {
 		converter.write(message, new SimpleHttpRequestMessage(output));
 
 		assertEquals(message, output.toString());
+	}
+
+	@Test
+	public void shouldWriteStringMessageUsingCharset() throws Exception {
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+		message = new String("Hellóòú".getBytes("UTF-8"));
+
+		converter.write(message, new SimpleHttpRequestMessage(output, Encoding.ISO_8859_1));
+
+		assertEquals(new String(message.getBytes("ISO-8859-1")),
+				output.toString());
 	}
 
 	@Test

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/SimpleHttpRequestMessage.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/request/SimpleHttpRequestMessage.java
@@ -14,6 +14,7 @@ public class SimpleHttpRequestMessage implements HttpRequestMessage {
 	private final OutputStream output;
 	private final Headers headers;
 	private final EndpointRequest source;
+	private final Encoding encoding;
 
 	public SimpleHttpRequestMessage(EndpointRequest source) {
 		this(source, new ByteArrayOutputStream(), source.headers());
@@ -31,10 +32,19 @@ public class SimpleHttpRequestMessage implements HttpRequestMessage {
 		this(null, output, headers);
 	}
 
+	public SimpleHttpRequestMessage(OutputStream output, Encoding encoding) {
+		this(null, output, new Headers(), encoding);
+	}
+
 	private SimpleHttpRequestMessage(EndpointRequest source, OutputStream output, Headers headers) {
+		this(source, output, headers, Encoding.UTF_8);
+	}
+
+	private SimpleHttpRequestMessage(EndpointRequest source, OutputStream output, Headers headers, Encoding encoding) {
 		this.source = source;
 		this.output = output;
 		this.headers = headers;
+		this.encoding = encoding;
 	}
 
 	@Override
@@ -54,7 +64,7 @@ public class SimpleHttpRequestMessage implements HttpRequestMessage {
 
 	@Override
 	public Charset charset() {
-		return Encoding.UTF_8.charset();
+		return encoding.charset();
 	}
 
 	@Override


### PR DESCRIPTION
## Conversão de String considerando o encoding, ao gerar o corpo da requisição :horse:

### Descrição
- Ao gerar o corpo da requisição usando o tipo String (por exemplo, *text/plain*), o objeto *TextMessageConverter* não considerava o *charset* da requisição. Esse pull request corrige esse problema.

### Changelog
- Modifica a implementação do método *write* do *TextMessageConverter* para considerar o charset do request, ao gerar o corpo da requisição.
