### PR TITLE
[improvement-oauth-token-cache] Cache de tokens OAuth - Melhorias

### DIFF
--- a/java-restify-oauth2-access-token-cache-caffeine/pom.xml
+++ b/java-restify-oauth2-access-token-cache-caffeine/pom.xml
@@ -20,5 +20,11 @@
 			<artifactId>caffeine</artifactId>
 			<version>2.6.2</version>
 		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-spi</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/java-restify-oauth2-access-token-cache-caffeine/pom.xml
+++ b/java-restify-oauth2-access-token-cache-caffeine/pom.xml
@@ -1,0 +1,24 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.github.ljtfreitas</groupId>
+		<artifactId>java-restify-group</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>java-restify-oauth2-access-token-cache-caffeine</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-oauth2-authentication</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>2.6.2</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/java-restify-oauth2-access-token-cache-caffeine/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/CaffeineAccessTokenStorage.java
+++ b/java-restify-oauth2-access-token-cache-caffeine/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/CaffeineAccessTokenStorage.java
@@ -26,7 +26,7 @@
 package com.github.ljtfreitas.restify.http.client.request.authentication.oauth2;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Optional;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -67,7 +67,7 @@ public class CaffeineAccessTokenStorage implements AccessTokenStorage {
 		@Override
 		public long expireAfterCreate(AccessTokenStorageKey key, AccessToken accessToken, long currentTime) {
 			return accessToken.expiration()
-				.map(end -> Duration.between(LocalDateTime.now(), end))
+				.map(end -> Duration.between(Instant.now(), end))
 					.map(d -> d.toNanos())
 						.orElseGet(() -> Long.MAX_VALUE);
 		}

--- a/java-restify-oauth2-access-token-cache-caffeine/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/CaffeineAccessTokenStorage.java
+++ b/java-restify-oauth2-access-token-cache-caffeine/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/CaffeineAccessTokenStorage.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.authentication.oauth2;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.CaffeineSpec;
+import com.github.benmanes.caffeine.cache.Expiry;
+
+public class CaffeineAccessTokenStorage implements AccessTokenStorage {
+
+	private final Cache<AccessTokenStorageKey, AccessToken> cache;
+
+	public CaffeineAccessTokenStorage() {
+		this.cache = Caffeine.newBuilder()
+				.expireAfter(new AccessTokenExpirationPolicy())
+				.build();
+	}
+
+	public CaffeineAccessTokenStorage(CaffeineSpec spec) {
+		this(Caffeine.from(spec).build());
+	}
+
+	public CaffeineAccessTokenStorage(Cache<AccessTokenStorageKey, AccessToken> cache) {
+		this.cache = cache;
+	}
+
+	@Override
+	public Optional<AccessToken> findBy(AccessTokenStorageKey key) {
+		return Optional.ofNullable(cache.getIfPresent(key));
+	}
+
+	@Override
+	public void add(AccessTokenStorageKey key, AccessToken accessToken) {
+		cache.put(key, accessToken);
+	}
+
+	private class AccessTokenExpirationPolicy implements Expiry<AccessTokenStorageKey, AccessToken> {
+
+		@Override
+		public long expireAfterCreate(AccessTokenStorageKey key, AccessToken accessToken, long currentTime) {
+			return accessToken.expiration()
+				.map(end -> Duration.between(LocalDateTime.now(), end))
+					.map(d -> d.toNanos())
+						.orElseGet(() -> Long.MAX_VALUE);
+		}
+
+		@Override
+		public long expireAfterUpdate(AccessTokenStorageKey key, AccessToken value, long currentTime,
+				long currentDuration) {
+			return currentDuration;
+		}
+
+		@Override
+		public long expireAfterRead(AccessTokenStorageKey key, AccessToken value, long currentTime,
+				long currentDuration) {
+			return currentDuration;
+		}
+	}
+}

--- a/java-restify-oauth2-access-token-cache-caffeine/src/main/resources/META-INF/services/com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AccessTokenStorage
+++ b/java-restify-oauth2-access-token-cache-caffeine/src/main/resources/META-INF/services/com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AccessTokenStorage
@@ -1,0 +1,1 @@
+com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.CaffeineAccessTokenStorage

--- a/java-restify-oauth2-access-token-cache-caffeine/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/CaffeineAccessTokenStorageServiceProviderTest.java
+++ b/java-restify-oauth2-access-token-cache-caffeine/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/CaffeineAccessTokenStorageServiceProviderTest.java
@@ -1,0 +1,24 @@
+package com.github.ljtfreitas.restify.http.client.request.authentication.oauth2;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import com.github.ljtfreitas.restify.spi.Provider;
+
+public class CaffeineAccessTokenStorageServiceProviderTest {
+
+	@Test
+	public void shouldDiscoveryCaffeineAccessTokenStorageService() {
+		Provider provider = new Provider();
+
+		Optional<AccessTokenStorage> service = provider.single(AccessTokenStorage.class);
+
+		assertThat(service.isPresent(), is(true));
+		assertThat(service.get(), instanceOf(CaffeineAccessTokenStorage.class));
+	}
+}

--- a/java-restify-oauth2-access-token-cache-caffeine/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/CaffeineAccessTokenStorageTest.java
+++ b/java-restify-oauth2-access-token-cache-caffeine/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/CaffeineAccessTokenStorageTest.java
@@ -9,22 +9,16 @@ import java.security.Principal;
 import java.time.Duration;
 import java.util.Optional;
 
-import javax.cache.CacheManager;
-import javax.cache.Caching;
-
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
 
-public class JCacheAccessTokenStorageTest {
+public class CaffeineAccessTokenStorageTest {
 
-	private JCacheAccessTokenStorage jCacheAccessTokenStorage;
+	private CaffeineAccessTokenStorage caffeineAccessTokenStorage;
 
 	private AccessTokenStorageKey key;
-
-	private CacheManager cacheManager;
 
 	@Before
 	public void setup() {
@@ -41,25 +35,18 @@ public class JCacheAccessTokenStorageTest {
 
 		key = AccessTokenStorageKey.by(request);
 
-		cacheManager = Caching.getCachingProvider().getCacheManager();
-
-		jCacheAccessTokenStorage = new JCacheAccessTokenStorage(cacheManager);
-	}
-
-	@After
-	public void after() {
-		cacheManager.getCacheNames().forEach(cache -> cacheManager.destroyCache(cache));
+		caffeineAccessTokenStorage = new CaffeineAccessTokenStorage();
 	}
 
 	@Test
 	public void shouldSaveAccessTokenOnStore() {
-		assertFalse(jCacheAccessTokenStorage.findBy(key).isPresent());
+		assertFalse(caffeineAccessTokenStorage.findBy(key).isPresent());
 
 		AccessToken accessToken = AccessToken.bearer("accessToken");
 
-		jCacheAccessTokenStorage.add(key, accessToken);
+		caffeineAccessTokenStorage.add(key, accessToken);
 
-		Optional<AccessToken> foundAccessToken = jCacheAccessTokenStorage.findBy(key);
+		Optional<AccessToken> foundAccessToken = caffeineAccessTokenStorage.findBy(key);
 
 		assertTrue(foundAccessToken.isPresent());
 		assertEquals(accessToken, foundAccessToken.get());
@@ -67,16 +54,16 @@ public class JCacheAccessTokenStorageTest {
 
 	@Test
 	public void shouldEvictAccessTokenAfterExpirarionPeriod() throws Exception {
-		assertFalse(jCacheAccessTokenStorage.findBy(key).isPresent());
+		assertFalse(caffeineAccessTokenStorage.findBy(key).isPresent());
 
 		AccessToken accessToken = AccessToken.bearer("accessToken", Duration.ofSeconds(5));
 
-		jCacheAccessTokenStorage.add(key, accessToken);
+		caffeineAccessTokenStorage.add(key, accessToken);
 
-		assertTrue(jCacheAccessTokenStorage.findBy(key).isPresent());
+		assertTrue(caffeineAccessTokenStorage.findBy(key).isPresent());
 
 		Thread.sleep(5500);
 
-		assertFalse(jCacheAccessTokenStorage.findBy(key).isPresent());
+		assertFalse(caffeineAccessTokenStorage.findBy(key).isPresent());
 	}
 }

--- a/java-restify-oauth2-access-token-cache-jcache/pom.xml
+++ b/java-restify-oauth2-access-token-cache-jcache/pom.xml
@@ -26,5 +26,11 @@
             <version>2.6.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-spi</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/java-restify-oauth2-access-token-cache-jcache/pom.xml
+++ b/java-restify-oauth2-access-token-cache-jcache/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.github.ljtfreitas</groupId>
+		<artifactId>java-restify-group</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>java-restify-oauth2-access-token-cache-jcache</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-oauth2-authentication</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.cache</groupId>
+			<artifactId>cache-api</artifactId>
+			<version>1.1.0</version>
+		</dependency>
+		<dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>jcache</artifactId>
+            <version>2.6.2</version>
+            <scope>test</scope>
+        </dependency>
+	</dependencies>
+</project>

--- a/java-restify-oauth2-access-token-cache-jcache/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/JCacheAccessTokenStorage.java
+++ b/java-restify-oauth2-access-token-cache-jcache/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/JCacheAccessTokenStorage.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.authentication.oauth2;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.Factory;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.CreatedExpiryPolicy;
+import javax.cache.expiry.Duration;
+import javax.cache.expiry.ExpiryPolicy;
+import javax.cache.spi.CachingProvider;
+
+public class JCacheAccessTokenStorage implements AccessTokenStorage {
+
+	private static final String CACHE_NAME_PREFIX = "access-token.";
+
+	private final CacheManager cacheManager;
+
+	public JCacheAccessTokenStorage() {
+		this(Caching.getCachingProvider());
+	}
+
+	public JCacheAccessTokenStorage(CachingProvider cachingProvider) {
+		this(cachingProvider.getCacheManager());
+	}
+
+	public JCacheAccessTokenStorage(CacheManager cacheManager) {
+		this.cacheManager = cacheManager;
+	}
+
+	@Override
+	public Optional<AccessToken> findBy(AccessTokenStorageKey key) {
+		return cacheTo(key).map(cache -> cache.get(key));
+	}
+
+	@Override
+	public void add(AccessTokenStorageKey key, AccessToken accessToken) {
+		cacheTo(key).orElseGet(() -> newCacheTo(key, accessToken.expiration())).put(key, accessToken);
+	}
+
+	private Optional<Cache<AccessTokenStorageKey, AccessToken>> cacheTo(AccessTokenStorageKey key) {
+		return Optional.ofNullable(cacheManager.getCache(CACHE_NAME_PREFIX + key));
+	}
+
+	private Cache<AccessTokenStorageKey, AccessToken> newCacheTo(AccessTokenStorageKey key, Optional<LocalDateTime> expiration) {
+		MutableConfiguration<AccessTokenStorageKey, AccessToken> configuration = new MutableConfiguration<>();
+
+		Factory<ExpiryPolicy> policy = CreatedExpiryPolicy.factoryOf(durationUntil(expiration));
+
+		configuration
+			.setTypes(AccessTokenStorageKey.class, AccessToken.class)
+			.setStoreByValue(true)
+			.setExpiryPolicyFactory(policy);
+
+		return cacheManager.createCache(CACHE_NAME_PREFIX + key, configuration);
+	}
+
+	private Duration durationUntil(Optional<LocalDateTime> expiration) {
+		return expiration
+			.map(end -> java.time.Duration.between(LocalDateTime.now(), end))
+				.map(d -> new Duration(TimeUnit.MILLISECONDS, d.toMillis()))
+					.orElseGet(() -> Duration.ETERNAL);
+	}
+}

--- a/java-restify-oauth2-access-token-cache-jcache/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/JCacheAccessTokenStorage.java
+++ b/java-restify-oauth2-access-token-cache-jcache/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/JCacheAccessTokenStorage.java
@@ -25,7 +25,7 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.client.request.authentication.oauth2;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -71,7 +71,7 @@ public class JCacheAccessTokenStorage implements AccessTokenStorage {
 		return Optional.ofNullable(cacheManager.getCache(CACHE_NAME_PREFIX + key));
 	}
 
-	private Cache<AccessTokenStorageKey, AccessToken> newCacheTo(AccessTokenStorageKey key, Optional<LocalDateTime> expiration) {
+	private Cache<AccessTokenStorageKey, AccessToken> newCacheTo(AccessTokenStorageKey key, Optional<Instant> expiration) {
 		MutableConfiguration<AccessTokenStorageKey, AccessToken> configuration = new MutableConfiguration<>();
 
 		Factory<ExpiryPolicy> policy = CreatedExpiryPolicy.factoryOf(durationUntil(expiration));
@@ -84,9 +84,9 @@ public class JCacheAccessTokenStorage implements AccessTokenStorage {
 		return cacheManager.createCache(CACHE_NAME_PREFIX + key, configuration);
 	}
 
-	private Duration durationUntil(Optional<LocalDateTime> expiration) {
+	private Duration durationUntil(Optional<Instant> expiration) {
 		return expiration
-			.map(end -> java.time.Duration.between(LocalDateTime.now(), end))
+			.map(end -> java.time.Duration.between(Instant.now(), end))
 				.map(d -> new Duration(TimeUnit.MILLISECONDS, d.toMillis()))
 					.orElseGet(() -> Duration.ETERNAL);
 	}

--- a/java-restify-oauth2-access-token-cache-jcache/src/main/resources/META-INF/services/com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AccessTokenStorage
+++ b/java-restify-oauth2-access-token-cache-jcache/src/main/resources/META-INF/services/com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AccessTokenStorage
@@ -1,0 +1,1 @@
+com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.JCacheAccessTokenStorage

--- a/java-restify-oauth2-access-token-cache-jcache/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/JCacheAccessTokenStorageServiceProviderTest.java
+++ b/java-restify-oauth2-access-token-cache-jcache/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/JCacheAccessTokenStorageServiceProviderTest.java
@@ -1,0 +1,24 @@
+package com.github.ljtfreitas.restify.http.client.request.authentication.oauth2;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import com.github.ljtfreitas.restify.spi.Provider;
+
+public class JCacheAccessTokenStorageServiceProviderTest {
+
+	@Test
+	public void shouldDiscoveryCaffeineAccessTokenStorageService() {
+		Provider provider = new Provider();
+
+		Optional<AccessTokenStorage> service = provider.single(AccessTokenStorage.class);
+
+		assertThat(service.isPresent(), is(true));
+		assertThat(service.get(), instanceOf(JCacheAccessTokenStorage.class));
+	}
+}

--- a/java-restify-oauth2-access-token-cache-jcache/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/JCacheAccessTokenStorageTest.java
+++ b/java-restify-oauth2-access-token-cache-jcache/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/JCacheAccessTokenStorageTest.java
@@ -1,0 +1,82 @@
+package com.github.ljtfreitas.restify.http.client.request.authentication.oauth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.security.Principal;
+import java.time.Duration;
+import java.util.Optional;
+
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+
+public class JCacheAccessTokenStorageTest {
+
+	private JCacheAccessTokenStorage accessTokenMemoryStore;
+
+	private AccessTokenStorageKey key;
+
+	private CacheManager cacheManager;
+
+	@Before
+	public void setup() {
+		Principal user = () -> "user-identity-key";
+
+		GrantProperties properties = new GrantProperties.Builder()
+				.credentials(ClientCredentials.clientId("client-id"))
+				.scopes("read", "write")
+				.build();
+
+		EndpointRequest source = new EndpointRequest(URI.create("http://my.resource.server/path"), "GET");
+
+		OAuth2AuthenticatedEndpointRequest request = new OAuth2AuthenticatedEndpointRequest(source, properties, user);
+
+		key = AccessTokenStorageKey.by(request);
+
+		cacheManager = Caching.getCachingProvider().getCacheManager();
+
+		accessTokenMemoryStore = new JCacheAccessTokenStorage(cacheManager);
+	}
+
+	@After
+	public void after() {
+		cacheManager.getCacheNames().forEach(cache -> cacheManager.destroyCache(cache));
+	}
+
+	@Test
+	public void shouldSaveAccessTokenOnStore() {
+		assertFalse(accessTokenMemoryStore.findBy(key).isPresent());
+
+		AccessToken accessToken = AccessToken.bearer("accessToken");
+
+		accessTokenMemoryStore.add(key, accessToken);
+
+		Optional<AccessToken> foundAccessToken = accessTokenMemoryStore.findBy(key);
+
+		assertTrue(foundAccessToken.isPresent());
+		assertEquals(accessToken, foundAccessToken.get());
+	}
+
+	@Test
+	public void shouldEvictAccessTokenAfterExpirarionPeriod() throws Exception {
+		assertFalse(accessTokenMemoryStore.findBy(key).isPresent());
+
+		AccessToken accessToken = AccessToken.bearer("accessToken", Duration.ofSeconds(5));
+
+		accessTokenMemoryStore.add(key, accessToken);
+
+		assertTrue(accessTokenMemoryStore.findBy(key).isPresent());
+
+		Thread.sleep(5500);
+
+		assertFalse(accessTokenMemoryStore.findBy(key).isPresent());
+	}
+}

--- a/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessToken.java
+++ b/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessToken.java
@@ -82,8 +82,8 @@ public class AccessToken implements Serializable {
 		return this;
 	}
 
-	public LocalDateTime expiration() {
-		return expiration;
+	public Optional<LocalDateTime> expiration() {
+		return Optional.ofNullable(expiration);
 	}
 
 	public boolean expired() {

--- a/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessToken.java
+++ b/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessToken.java
@@ -29,7 +29,7 @@ import static com.github.ljtfreitas.restify.util.Preconditions.nonNull;
 
 import java.io.Serializable;
 import java.time.Duration;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
@@ -46,7 +46,7 @@ public class AccessToken implements Serializable {
 	private final AccessTokenType tokenType;
 	private final String token;
 
-	private LocalDateTime expiration = null;
+	private Instant expiration = null;
 	private Set<String> scopes = Collections.emptySet();
 	private String refreshToken = null;
 
@@ -60,8 +60,8 @@ public class AccessToken implements Serializable {
 		this.expiration = expirationTo(seconds);
 	}
 
-	private LocalDateTime expirationTo(Duration seconds) {
-		return LocalDateTime.now().plus(seconds);
+	private Instant expirationTo(Duration seconds) {
+		return Instant.now().plus(seconds);
 	}
 
 	public AccessTokenType type() {
@@ -82,12 +82,12 @@ public class AccessToken implements Serializable {
 		return this;
 	}
 
-	public Optional<LocalDateTime> expiration() {
+	public Optional<Instant> expiration() {
 		return Optional.ofNullable(expiration);
 	}
 
 	public boolean expired() {
-		return expiration != null && expiration.isBefore(LocalDateTime.now());
+		return expiration != null && expiration.isBefore(Instant.now());
 	}
 
 	private AccessToken scope(String scope) {

--- a/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessToken.java
+++ b/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessToken.java
@@ -32,6 +32,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -118,6 +119,24 @@ public class AccessToken implements Serializable {
 
 	public Optional<String> refreshToken() {
 		return Optional.ofNullable(refreshToken);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(tokenType, token);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof AccessToken) {
+			AccessToken that = (AccessToken) obj;
+
+			return this.tokenType.equals(that.tokenType)
+				&& this.token.equals(that.token);
+
+		} else {
+			return false;
+		}
 	}
 
 	@Override

--- a/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessTokenStorage.java
+++ b/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessTokenStorage.java
@@ -29,8 +29,8 @@ import java.util.Optional;
 
 public interface AccessTokenStorage {
 
-	public Optional<AccessToken> findBy(OAuth2AuthenticatedEndpointRequest request);
+	public Optional<AccessToken> findBy(AccessTokenStorageKey key);
 
-	public void add(OAuth2AuthenticatedEndpointRequest request, AccessToken accessToken);
+	public void add(AccessTokenStorageKey key, AccessToken accessToken);
 
 }

--- a/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessTokenStorageKey.java
+++ b/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessTokenStorageKey.java
@@ -65,6 +65,19 @@ public class AccessTokenStorageKey implements Serializable {
 		}
 	}
 
+	@Override
+	public String toString() {
+		return new StringBuilder()
+			.append(resource)
+				.append(".")
+			.append(clientId)
+				.append(".")
+			.append(scope == null ? "none" : scope)
+				.append(".")
+			.append(username == null ? "none" : username)
+			.toString();
+	}
+
 	public static AccessTokenStorageKey by(OAuth2AuthenticatedEndpointRequest request) {
 		String resource = request.endpoint().getHost();
 		String clientId = request.clientId();

--- a/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessTokenStorageKey.java
+++ b/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessTokenStorageKey.java
@@ -25,21 +25,52 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.client.request.authentication.oauth2;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+import java.io.Serializable;
+import java.security.Principal;
+import java.util.Objects;
 
-class AccessTokenMemoryStorage implements AccessTokenStorage {
+public class AccessTokenStorageKey implements Serializable {
 
-	private final Map<AccessTokenStorageKey, AccessToken> tokens = new ConcurrentHashMap<>();
+	private static final long serialVersionUID = 1L;
 
-	@Override
-	public void add(AccessTokenStorageKey key, AccessToken accessToken) {
-		tokens.put(key, accessToken);
+	private final String resource;
+	private final String clientId;
+	private final String scope;
+	private final String username;
+
+	private AccessTokenStorageKey(String resourceServer, String clientId, String scope, String username) {
+		this.resource = resourceServer;
+		this.clientId = clientId;
+		this.scope = scope;
+		this.username = username;
 	}
 
 	@Override
-	public Optional<AccessToken> findBy(AccessTokenStorageKey key) {
-		return Optional.ofNullable(tokens.get(key));
+	public int hashCode() {
+		return Objects.hash(resource, clientId, scope, username);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof AccessTokenStorageKey) {
+			AccessTokenStorageKey that = (AccessTokenStorageKey) obj;
+
+			return Objects.equals(this.resource, that.resource)
+				&& Objects.equals(this.clientId, that.clientId)
+				&& Objects.equals(this.scope, that.scope)
+				&& Objects.equals(this.username, that.username);
+
+		} else {
+			return false;
+		}
+	}
+
+	public static AccessTokenStorageKey by(OAuth2AuthenticatedEndpointRequest request) {
+		String resource = request.endpoint().getHost();
+		String clientId = request.clientId();
+		String scope = request.scope();
+		String username = request.user().map(Principal::getName).orElse(null);
+
+		return new AccessTokenStorageKey(resource, clientId, scope, username);
 	}
 }

--- a/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/OAuth2AuthenticationBuilder.java
+++ b/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/OAuth2AuthenticationBuilder.java
@@ -101,7 +101,9 @@ public class OAuth2AuthenticationBuilder {
 	}
 
 	private AccessTokenStorage accessTokenStorage() {
-		return Optional.ofNullable(accessTokenStorage).orElseGet(AccessTokenMemoryStorage::new);
+		return Optional.ofNullable(accessTokenStorage)
+			.orElseGet(() -> new Provider().single(AccessTokenStorage.class)
+				.orElseGet(AccessTokenMemoryStorage::new));
 	}
 
 	public class OAuth2AuthorizationServerBuilder {

--- a/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessTokenMemoryStorageTest.java
+++ b/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessTokenMemoryStorageTest.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.security.Principal;
 import java.util.Optional;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
@@ -17,10 +18,12 @@ import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.O
 
 public class AccessTokenMemoryStorageTest {
 
-	private AccessTokenMemoryStorage acessTokenMemoryStore;
+	private AccessTokenStorageKey key;
 
-	@Test
-	public void shouldSaveAccessTokenOnStore() {
+	private AccessTokenMemoryStorage accessTokenMemoryStore;
+
+	@Before
+	public void setup() {
 		Principal user = () -> "user-identity-key";
 
 		GrantProperties properties = new GrantProperties.Builder()
@@ -32,15 +35,20 @@ public class AccessTokenMemoryStorageTest {
 
 		OAuth2AuthenticatedEndpointRequest request = new OAuth2AuthenticatedEndpointRequest(source, properties, user);
 
-		acessTokenMemoryStore = new AccessTokenMemoryStorage();
+		key = AccessTokenStorageKey.by(request);
 
-		assertFalse(acessTokenMemoryStore.findBy(request).isPresent());
+		accessTokenMemoryStore = new AccessTokenMemoryStorage();
+	}
+
+	@Test
+	public void shouldSaveAccessTokenOnStore() {
+		assertFalse(accessTokenMemoryStore.findBy(key).isPresent());
 
 		AccessToken accessToken = AccessToken.bearer("accessToken");
 
-		acessTokenMemoryStore.add(request, accessToken);
+		accessTokenMemoryStore.add(key, accessToken);
 
-		Optional<AccessToken> foundAccessToken = acessTokenMemoryStore.findBy(request);
+		Optional<AccessToken> foundAccessToken = accessTokenMemoryStore.findBy(key);
 
 		assertTrue(foundAccessToken.isPresent());
 		assertSame(accessToken, foundAccessToken.get());

--- a/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessTokenMemoryStorageTest.java
+++ b/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AccessTokenMemoryStorageTest.java
@@ -20,7 +20,7 @@ public class AccessTokenMemoryStorageTest {
 
 	private AccessTokenStorageKey key;
 
-	private AccessTokenMemoryStorage accessTokenMemoryStore;
+	private AccessTokenMemoryStorage accessTokenMemoryStorage;
 
 	@Before
 	public void setup() {
@@ -37,18 +37,18 @@ public class AccessTokenMemoryStorageTest {
 
 		key = AccessTokenStorageKey.by(request);
 
-		accessTokenMemoryStore = new AccessTokenMemoryStorage();
+		accessTokenMemoryStorage = new AccessTokenMemoryStorage();
 	}
 
 	@Test
 	public void shouldSaveAccessTokenOnStore() {
-		assertFalse(accessTokenMemoryStore.findBy(key).isPresent());
+		assertFalse(accessTokenMemoryStorage.findBy(key).isPresent());
 
 		AccessToken accessToken = AccessToken.bearer("accessToken");
 
-		accessTokenMemoryStore.add(key, accessToken);
+		accessTokenMemoryStorage.add(key, accessToken);
 
-		Optional<AccessToken> foundAccessToken = accessTokenMemoryStore.findBy(key);
+		Optional<AccessToken> foundAccessToken = accessTokenMemoryStorage.findBy(key);
 
 		assertTrue(foundAccessToken.isPresent());
 		assertSame(accessToken, foundAccessToken.get());

--- a/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AuthorizationCodeAccessTokenProviderTest.java
+++ b/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AuthorizationCodeAccessTokenProviderTest.java
@@ -9,7 +9,8 @@ import static org.mockserver.model.JsonBody.json;
 import static org.mockserver.model.ParameterBody.params;
 
 import java.net.URI;
-import java.time.LocalDateTime;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 import org.junit.Before;
@@ -23,14 +24,6 @@ import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.Parameter;
 
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AccessToken;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AccessTokenType;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AuthorizationCodeAccessTokenProvider;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AuthorizationCodeGrantProperties;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.ClientCredentials;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.DefaultAuthorizationCodeProvider;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.GrantProperties;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.OAuth2AuthenticatedEndpointRequest;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AuthorizationCodeAccessTokenProviderTest {
@@ -94,7 +87,7 @@ public class AuthorizationCodeAccessTokenProviderTest {
 
 		assertEquals("read write", accessToken.scope());
 
-		LocalDateTime expectedExpiration = LocalDateTime.now().plusSeconds(3600);
+		Instant expectedExpiration = Instant.now().plus(Duration.ofSeconds(3600));
 		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), accessToken.expiration().get().truncatedTo(ChronoUnit.SECONDS));
 
 		verify(authorizationCodeProvider).provides(request);
@@ -126,7 +119,7 @@ public class AuthorizationCodeAccessTokenProviderTest {
 
 		assertEquals("read write", newAccessToken.scope());
 
-		LocalDateTime expectedExpiration = LocalDateTime.now().plusSeconds(3600);
+		Instant expectedExpiration = Instant.now().plus(Duration.ofSeconds(3600));
 		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), newAccessToken.expiration().get().truncatedTo(ChronoUnit.SECONDS));
 	}
 }

--- a/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AuthorizationCodeAccessTokenProviderTest.java
+++ b/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AuthorizationCodeAccessTokenProviderTest.java
@@ -95,7 +95,7 @@ public class AuthorizationCodeAccessTokenProviderTest {
 		assertEquals("read write", accessToken.scope());
 
 		LocalDateTime expectedExpiration = LocalDateTime.now().plusSeconds(3600);
-		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), accessToken.expiration().truncatedTo(ChronoUnit.SECONDS));
+		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), accessToken.expiration().get().truncatedTo(ChronoUnit.SECONDS));
 
 		verify(authorizationCodeProvider).provides(request);
 	}
@@ -127,6 +127,6 @@ public class AuthorizationCodeAccessTokenProviderTest {
 		assertEquals("read write", newAccessToken.scope());
 
 		LocalDateTime expectedExpiration = LocalDateTime.now().plusSeconds(3600);
-		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), newAccessToken.expiration().truncatedTo(ChronoUnit.SECONDS));
+		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), newAccessToken.expiration().get().truncatedTo(ChronoUnit.SECONDS));
 	}
 }

--- a/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/ClientCredentialsAccessTokenProviderTest.java
+++ b/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/ClientCredentialsAccessTokenProviderTest.java
@@ -7,7 +7,8 @@ import static org.mockserver.model.JsonBody.json;
 import static org.mockserver.model.ParameterBody.params;
 
 import java.net.URI;
-import java.time.LocalDateTime;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 import org.junit.Before;
@@ -20,12 +21,6 @@ import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.Parameter;
 
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AccessToken;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AccessTokenType;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.ClientCredentials;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.ClientCredentialsAccessTokenProvider;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.GrantProperties;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.OAuth2AuthenticatedEndpointRequest;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClientCredentialsAccessTokenProviderTest {
@@ -81,7 +76,7 @@ public class ClientCredentialsAccessTokenProviderTest {
 
 		assertEquals("read write", accessToken.scope());
 
-		LocalDateTime expectedExpiration = LocalDateTime.now().plusSeconds(3600);
+		Instant expectedExpiration = Instant.now().plus(Duration.ofSeconds(3600));
 		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), accessToken.expiration().get().truncatedTo(ChronoUnit.SECONDS));
 	}
 

--- a/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/ClientCredentialsAccessTokenProviderTest.java
+++ b/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/ClientCredentialsAccessTokenProviderTest.java
@@ -82,7 +82,7 @@ public class ClientCredentialsAccessTokenProviderTest {
 		assertEquals("read write", accessToken.scope());
 
 		LocalDateTime expectedExpiration = LocalDateTime.now().plusSeconds(3600);
-		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), accessToken.expiration().truncatedTo(ChronoUnit.SECONDS));
+		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), accessToken.expiration().get().truncatedTo(ChronoUnit.SECONDS));
 	}
 
 	@Test(expected = UnsupportedOperationException.class)

--- a/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/DefaultAccessTokenRepositoryTest.java
+++ b/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/DefaultAccessTokenRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.github.ljtfreitas.restify.http.client.request.authentication.oauth2;
 
 import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,7 +60,8 @@ public class DefaultAccessTokenRepositoryTest {
 	public void shouldGetAccessTokenFromStore() {
 		AccessToken accessToken = AccessToken.bearer("access-token");
 
-		when(accessTokenStorage.findBy(request)).thenReturn(Optional.of(accessToken));
+		when(accessTokenStorage.findBy(notNull(AccessTokenStorageKey.class)))
+			.thenReturn(Optional.of(accessToken));
 
 		AccessToken output = accessTokenRepository.findBy(request);
 
@@ -70,15 +72,18 @@ public class DefaultAccessTokenRepositoryTest {
 	public void shouldGetAccessTokenFromProviderWhenStoreHasNoToken() {
 		AccessToken accessToken = AccessToken.bearer("access-token");
 
-		when(accessTokenStorage.findBy(request)).thenReturn(Optional.empty());
-		when(accessTokenProvider.provides(request)).thenReturn(accessToken);
+		when(accessTokenStorage.findBy(notNull(AccessTokenStorageKey.class)))
+			.thenReturn(Optional.empty());
+
+		when(accessTokenProvider.provides(request))
+			.thenReturn(accessToken);
 
 		AccessToken output = accessTokenRepository.findBy(request);
 
 		assertSame(output, accessToken);
 
 		verify(accessTokenProvider).provides(request);
-		verify(accessTokenStorage).add(request, accessToken);
+		verify(accessTokenStorage).add(notNull(AccessTokenStorageKey.class), accessToken);
 	}
 
 	@Test
@@ -86,8 +91,11 @@ public class DefaultAccessTokenRepositoryTest {
 		AccessToken expiredAccessToken = AccessToken.bearer("access-token", Duration.ofMillis(500));
 		AccessToken newAccessToken = AccessToken.bearer("new-access-token");
 
-		when(accessTokenStorage.findBy(request)).thenReturn(Optional.of(expiredAccessToken));
-		when(accessTokenProvider.provides(request)).thenReturn(newAccessToken);
+		when(accessTokenStorage.findBy(notNull(AccessTokenStorageKey.class)))
+			.thenReturn(Optional.of(expiredAccessToken));
+
+		when(accessTokenProvider.provides(request))
+			.thenReturn(newAccessToken);
 
 		Thread.sleep(1000);
 
@@ -95,9 +103,9 @@ public class DefaultAccessTokenRepositoryTest {
 
 		assertSame(newAccessToken, output);
 
-		verify(accessTokenStorage).findBy(request);
+		verify(accessTokenStorage).findBy(notNull(AccessTokenStorageKey.class));
 		verify(accessTokenProvider).provides(request);
-		verify(accessTokenStorage).add(request, newAccessToken);
+		verify(accessTokenStorage).add(notNull(AccessTokenStorageKey.class), newAccessToken);
 	}
 
 	@Test
@@ -109,8 +117,11 @@ public class DefaultAccessTokenRepositoryTest {
 
 		AccessToken newAccessToken = AccessToken.bearer("new-access-token");
 
-		when(accessTokenStorage.findBy(request)).thenReturn(Optional.of(expiredAccessToken));
-		when(accessTokenProvider.refresh(expiredAccessToken, request)).thenReturn(newAccessToken);
+		when(accessTokenStorage.findBy(notNull(AccessTokenStorageKey.class)))
+			.thenReturn(Optional.of(expiredAccessToken));
+
+		when(accessTokenProvider.refresh(expiredAccessToken, request))
+			.thenReturn(newAccessToken);
 
 		Thread.sleep(1000);
 
@@ -118,9 +129,9 @@ public class DefaultAccessTokenRepositoryTest {
 
 		assertSame(output, newAccessToken);
 
-		verify(accessTokenStorage).findBy(request);
+		verify(accessTokenStorage).findBy(notNull(AccessTokenStorageKey.class));
 		verify(accessTokenProvider, never()).provides(request);
 		verify(accessTokenProvider).refresh(expiredAccessToken, request);
-		verify(accessTokenStorage).add(request, newAccessToken);
+		verify(accessTokenStorage).add(notNull(AccessTokenStorageKey.class), newAccessToken);
 	}
 }

--- a/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/DefaultAccessTokenRepositoryTest.java
+++ b/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/DefaultAccessTokenRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.github.ljtfreitas.restify.http.client.request.authentication.oauth2;
 
 import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -50,6 +51,7 @@ public class DefaultAccessTokenRepositoryTest {
 	@Before
 	public void setup() {
 		when(user.getName()).thenReturn("user-identity-key");
+		when(properties.credentials()).thenReturn(ClientCredentials.clientId("client-id"));
 
 		EndpointRequest source = new EndpointRequest(URI.create("http://my.resource.server/path"), "GET");
 
@@ -83,7 +85,7 @@ public class DefaultAccessTokenRepositoryTest {
 		assertSame(output, accessToken);
 
 		verify(accessTokenProvider).provides(request);
-		verify(accessTokenStorage).add(notNull(AccessTokenStorageKey.class), accessToken);
+		verify(accessTokenStorage).add(notNull(AccessTokenStorageKey.class), eq(accessToken));
 	}
 
 	@Test
@@ -105,7 +107,7 @@ public class DefaultAccessTokenRepositoryTest {
 
 		verify(accessTokenStorage).findBy(notNull(AccessTokenStorageKey.class));
 		verify(accessTokenProvider).provides(request);
-		verify(accessTokenStorage).add(notNull(AccessTokenStorageKey.class), newAccessToken);
+		verify(accessTokenStorage).add(notNull(AccessTokenStorageKey.class), eq(newAccessToken));
 	}
 
 	@Test
@@ -132,6 +134,6 @@ public class DefaultAccessTokenRepositoryTest {
 		verify(accessTokenStorage).findBy(notNull(AccessTokenStorageKey.class));
 		verify(accessTokenProvider, never()).provides(request);
 		verify(accessTokenProvider).refresh(expiredAccessToken, request);
-		verify(accessTokenStorage).add(notNull(AccessTokenStorageKey.class), newAccessToken);
+		verify(accessTokenStorage).add(notNull(AccessTokenStorageKey.class), eq(newAccessToken));
 	}
 }

--- a/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/ImplicitAccessTokenProviderTest.java
+++ b/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/ImplicitAccessTokenProviderTest.java
@@ -6,7 +6,8 @@ import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.JsonBody.json;
 
 import java.net.URI;
-import java.time.LocalDateTime;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 import org.junit.Before;
@@ -17,14 +18,6 @@ import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.Parameter;
 
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AccessToken;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AccessTokenType;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.GrantProperties;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.ImplicitAccessTokenProvider;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.ImplicitGrantProperties;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.OAuth2AuthenticatedEndpointRequest;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.OAuth2Exception;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.OAuth2UserApprovalRequiredException;
 
 public class ImplicitAccessTokenProviderTest {
 
@@ -79,7 +72,7 @@ public class ImplicitAccessTokenProviderTest {
 
 		assertEquals("read write", accessToken.scope());
 
-		LocalDateTime expectedExpiration = LocalDateTime.now().plusSeconds(3600);
+		Instant expectedExpiration = Instant.now().plus(Duration.ofSeconds(3600));
 		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), accessToken.expiration().get().truncatedTo(ChronoUnit.SECONDS));
 	}
 

--- a/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/ImplicitAccessTokenProviderTest.java
+++ b/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/ImplicitAccessTokenProviderTest.java
@@ -80,7 +80,7 @@ public class ImplicitAccessTokenProviderTest {
 		assertEquals("read write", accessToken.scope());
 
 		LocalDateTime expectedExpiration = LocalDateTime.now().plusSeconds(3600);
-		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), accessToken.expiration().truncatedTo(ChronoUnit.SECONDS));
+		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), accessToken.expiration().get().truncatedTo(ChronoUnit.SECONDS));
 	}
 
 	@Test(expected = OAuth2UserApprovalRequiredException.class)

--- a/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/OAuth2AuthenticationBuilderTest.java
+++ b/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/OAuth2AuthenticationBuilderTest.java
@@ -117,7 +117,7 @@ public class OAuth2AuthenticationBuilderTest {
 	public void shouldBuildOAuth2AuthenticationObjectToClientCredentialsGrantTypeUsingCustomizedAccessTokenStorage() {
 		AccessTokenStorage accessTokenStorage = mock(AccessTokenStorage.class);
 
-		when(accessTokenStorage.findBy(notNull(OAuth2AuthenticatedEndpointRequest.class)))
+		when(accessTokenStorage.findBy(notNull(AccessTokenStorageKey.class)))
 			.thenReturn(Optional.ofNullable(AccessToken.bearer("aaa111")));
 
 		OAuth2Authentication authentication = new OAuth2AuthenticationBuilder()
@@ -136,7 +136,7 @@ public class OAuth2AuthenticationBuilderTest {
 
 		assertEquals("Bearer aaa111", content);
 
-		verify(accessTokenStorage).findBy(notNull(OAuth2AuthenticatedEndpointRequest.class));
+		verify(accessTokenStorage).findBy(notNull(AccessTokenStorageKey.class));
 	}
 
 	@Test
@@ -256,7 +256,7 @@ public class OAuth2AuthenticationBuilderTest {
 	public void shouldBuildOAuth2AuthenticationObjectToResourceOwnerGrantTypeUsingCustomizedAccessTokenStorage() {
 		AccessTokenStorage accessTokenStorage = mock(AccessTokenStorage.class);
 
-		when(accessTokenStorage.findBy(notNull(OAuth2AuthenticatedEndpointRequest.class)))
+		when(accessTokenStorage.findBy(notNull(AccessTokenStorageKey.class)))
 			.thenReturn(Optional.ofNullable(AccessToken.bearer("aaa111")));
 
 		OAuth2Authentication authentication = new OAuth2AuthenticationBuilder()
@@ -276,7 +276,7 @@ public class OAuth2AuthenticationBuilderTest {
 
 		assertEquals("Bearer aaa111", content);
 
-		verify(accessTokenStorage).findBy(notNull(OAuth2AuthenticatedEndpointRequest.class));
+		verify(accessTokenStorage).findBy(notNull(AccessTokenStorageKey.class));
 	}
 
 	@Test
@@ -401,7 +401,7 @@ public class OAuth2AuthenticationBuilderTest {
 	public void shouldBuildOAuth2AuthenticationObjectToImplicitGrantTypeUsingCustomizedAccessTokenStorage() {
 		AccessTokenStorage accessTokenStorage = mock(AccessTokenStorage.class);
 
-		when(accessTokenStorage.findBy(notNull(OAuth2AuthenticatedEndpointRequest.class)))
+		when(accessTokenStorage.findBy(notNull(AccessTokenStorageKey.class)))
 			.thenReturn(Optional.ofNullable(AccessToken.bearer("aaa111")));
 
 		OAuth2Authentication authentication = new OAuth2AuthenticationBuilder()
@@ -423,7 +423,7 @@ public class OAuth2AuthenticationBuilderTest {
 
 		assertEquals("Bearer aaa111", content);
 
-		verify(accessTokenStorage).findBy(notNull(OAuth2AuthenticatedEndpointRequest.class));
+		verify(accessTokenStorage).findBy(notNull(AccessTokenStorageKey.class));
 	}
 
 	@Test
@@ -569,7 +569,7 @@ public class OAuth2AuthenticationBuilderTest {
 	public void shouldBuildOAuth2AuthenticationObjectToAuthorizationCodeGrantTypeUsingCustomizedAccessTokenStorage() {
 		AccessTokenStorage accessTokenStorage = mock(AccessTokenStorage.class);
 
-		when(accessTokenStorage.findBy(notNull(OAuth2AuthenticatedEndpointRequest.class)))
+		when(accessTokenStorage.findBy(notNull(AccessTokenStorageKey.class)))
 			.thenReturn(Optional.ofNullable(AccessToken.bearer("aaa111")));
 
 		OAuth2Authentication authentication = new OAuth2AuthenticationBuilder()
@@ -592,7 +592,7 @@ public class OAuth2AuthenticationBuilderTest {
 
 		assertEquals("Bearer aaa111", content);
 
-		verify(accessTokenStorage).findBy(notNull(OAuth2AuthenticatedEndpointRequest.class));
+		verify(accessTokenStorage).findBy(notNull(AccessTokenStorageKey.class));
 	}
 
 	@Test

--- a/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/ResourceOwnerPasswordAccessTokenProviderTest.java
+++ b/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/ResourceOwnerPasswordAccessTokenProviderTest.java
@@ -7,7 +7,8 @@ import static org.mockserver.model.JsonBody.json;
 import static org.mockserver.model.ParameterBody.params;
 
 import java.net.URI;
-import java.time.LocalDateTime;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 import org.junit.Before;
@@ -20,13 +21,6 @@ import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.Parameter;
 
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AccessToken;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.AccessTokenType;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.ClientCredentials;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.GrantProperties;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.OAuth2AuthenticatedEndpointRequest;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.ResourceOwnerGrantProperties;
-import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.ResourceOwnerPasswordAccessTokenProvider;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ResourceOwnerPasswordAccessTokenProviderTest {
@@ -85,7 +79,7 @@ public class ResourceOwnerPasswordAccessTokenProviderTest {
 
 		assertEquals("read write", accessToken.scope());
 
-		LocalDateTime expectedExpiration = LocalDateTime.now().plusSeconds(3600);
+		Instant expectedExpiration = Instant.now().plus(Duration.ofSeconds(3600));
 		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), accessToken.expiration().get().truncatedTo(ChronoUnit.SECONDS));
 	}
 
@@ -115,7 +109,7 @@ public class ResourceOwnerPasswordAccessTokenProviderTest {
 
 		assertEquals("read write", newAccessToken.scope());
 
-		LocalDateTime expectedExpiration = LocalDateTime.now().plusSeconds(3600);
+		Instant expectedExpiration = Instant.now().plus(Duration.ofSeconds(3600));
 		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), newAccessToken.expiration().get().truncatedTo(ChronoUnit.SECONDS));
 	}
 }

--- a/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/ResourceOwnerPasswordAccessTokenProviderTest.java
+++ b/java-restify-oauth2-authentication/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/ResourceOwnerPasswordAccessTokenProviderTest.java
@@ -86,7 +86,7 @@ public class ResourceOwnerPasswordAccessTokenProviderTest {
 		assertEquals("read write", accessToken.scope());
 
 		LocalDateTime expectedExpiration = LocalDateTime.now().plusSeconds(3600);
-		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), accessToken.expiration().truncatedTo(ChronoUnit.SECONDS));
+		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), accessToken.expiration().get().truncatedTo(ChronoUnit.SECONDS));
 	}
 
 	@Test
@@ -116,6 +116,6 @@ public class ResourceOwnerPasswordAccessTokenProviderTest {
 		assertEquals("read write", newAccessToken.scope());
 
 		LocalDateTime expectedExpiration = LocalDateTime.now().plusSeconds(3600);
-		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), newAccessToken.expiration().truncatedTo(ChronoUnit.SECONDS));
+		assertEquals(expectedExpiration.truncatedTo(ChronoUnit.SECONDS), newAccessToken.expiration().get().truncatedTo(ChronoUnit.SECONDS));
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,9 @@
 		<module>java-restify-jaxrs-contract</module>
 
 		<module>java-restify-hateoas</module>
+
 		<module>java-restify-oauth2-authentication</module>
+		<module>java-restify-oauth2-access-token-cache-jcache</module>
 
 		<module>java-restify-util</module>
 	</modules>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
 
 		<module>java-restify-oauth2-authentication</module>
 		<module>java-restify-oauth2-access-token-cache-jcache</module>
+		<module>java-restify-oauth2-access-token-cache-caffeine</module>
 
 		<module>java-restify-util</module>
 	</modules>


### PR DESCRIPTION
## Cache de tokens OAuth - Melhorias

### Descrição
- Cria novas implementações do *AccessTokenStorage*, alternativas à implementação padrão baseada em um ConcurrentHashMap. Se uma implementação alternativa estiver presente no classpath, ela será descoberta via *service provider*.

### Changelog
- Cria novo projeto *java-restify-oauth2-access-token-cache-jcache*, que implementa um cache de access tokens usando o JCache (api padrão do Java EE para cache temporal)
- Cria novo projeto *java-restify-oauth2-access-token-cache-caffeine* que implementa um cache de access tokens usando o Caffeine