### PR TITLE
[gzip-support] Suporte para compressao e descompressao gzip

### DIFF
--- a/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/FormURLEncodedFormObjectMessageConverterTest.java
+++ b/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/FormURLEncodedFormObjectMessageConverterTest.java
@@ -16,7 +16,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 import com.github.ljtfreitas.restify.http.contract.Form;
 import com.github.ljtfreitas.restify.http.contract.Form.Field;
@@ -61,7 +61,7 @@ public class FormURLEncodedFormObjectMessageConverterTest {
 
 	@Test
 	public void shouldWriteFormUrlEncodedMessageWithFormObjectSource() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 		
 		when(request.body()).thenReturn(output);
 
@@ -71,7 +71,7 @@ public class FormURLEncodedFormObjectMessageConverterTest {
 
 		converter.write(myFormObject, request);
 
-		assertEquals("name=Tiago+de+Freitas&customFieldName=31", output.asString());
+		assertEquals("name=Tiago+de+Freitas&customFieldName=31", new String(output.asBytes()));
 	}
 
 	@Form

--- a/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/FormURLEncodedMapMessageConverterTest.java
+++ b/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/FormURLEncodedMapMessageConverterTest.java
@@ -17,7 +17,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -46,13 +46,13 @@ public class FormURLEncodedMapMessageConverterTest {
 		body.put("param1", "value1");
 		body.put("param2", "value2");
 
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 
 		converter.write(body, request);
 
-		assertEquals(messageBody, output.asString());
+		assertEquals(messageBody, new String(output.asBytes()));
 	}
 
 	@Test(expected = UnsupportedOperationException.class)

--- a/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/FormURLEncodedParametersMessageConverterTest.java
+++ b/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/FormURLEncodedParametersMessageConverterTest.java
@@ -15,7 +15,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 import com.github.ljtfreitas.restify.http.contract.Parameters;
 
@@ -45,13 +45,13 @@ public class FormURLEncodedParametersMessageConverterTest {
 			.put("param1", "value1")
 			.put("param2", "value2");
 
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 		
 		converter.write(body, request);
 
-		assertEquals(messageBody, output.asString());
+		assertEquals(messageBody, new String(output.asBytes()));
 	}
 
 	@Test

--- a/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/multipart/BaseMultipartFormMessageWriterTest.java
+++ b/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/multipart/BaseMultipartFormMessageWriterTest.java
@@ -22,7 +22,7 @@ import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BaseMultipartFormMessageWriterTest {
@@ -65,7 +65,7 @@ public class BaseMultipartFormMessageWriterTest {
 		when(request.headers()).thenReturn(headers);
 		
 		HttpRequestMessage newRequest = mock(HttpRequestMessage.class);
-		when(newRequest.body()).thenReturn(new BufferedHttpRequestBody());
+		when(newRequest.body()).thenReturn(new BufferedByteArrayHttpRequestBody());
 
 		Answer<HttpRequestMessage> answer = new Answer<HttpRequestMessage>() {
 			@Override
@@ -90,7 +90,7 @@ public class BaseMultipartFormMessageWriterTest {
 
 	@Test
 	public void shouldWriteHttpRequestBody() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 
@@ -98,6 +98,6 @@ public class BaseMultipartFormMessageWriterTest {
 
 		String expectedBody = "MultipartFormMessageWriterTest\r\n------abc1234--";
 
-		assertEquals(expectedBody, output.asString());
+		assertEquals(expectedBody, new String(output.asBytes()));
 	}
 }

--- a/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/multipart/MultipartFormFileObjectMessageWriterTest.java
+++ b/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/multipart/MultipartFormFileObjectMessageWriterTest.java
@@ -19,7 +19,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.contract.MultipartFile;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -32,7 +32,7 @@ public class MultipartFormFileObjectMessageWriterTest {
 
 	private MultipartFile multipartFile;
 
-	private BufferedHttpRequestBody output;
+	private BufferedByteArrayHttpRequestBody output;
 
 	private File file;
 
@@ -49,7 +49,7 @@ public class MultipartFormFileObjectMessageWriterTest {
 		fileWriter.flush();
 		fileWriter.close();
 
-		output = new BufferedHttpRequestBody();
+		output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 		when(request.headers()).thenReturn(new Headers(Header.contentType("multipart/form-data")));
@@ -76,7 +76,7 @@ public class MultipartFormFileObjectMessageWriterTest {
 
 		converter.write(multipartFile, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -99,7 +99,7 @@ public class MultipartFormFileObjectMessageWriterTest {
 
 		converter.write(multipartFile, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -123,6 +123,6 @@ public class MultipartFormFileObjectMessageWriterTest {
 
 		converter.write(multipartFile, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 }

--- a/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/multipart/MultipartFormMapMessageWriterTest.java
+++ b/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/multipart/MultipartFormMapMessageWriterTest.java
@@ -24,7 +24,7 @@ import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.contract.MultipartFile;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -56,7 +56,7 @@ public class MultipartFormMapMessageWriterTest {
 
 		parameters = new LinkedHashMap<>();
 
-		output = new BufferedHttpRequestBody();
+		output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 		when(request.headers()).thenReturn(new Headers(Header.contentType("multipart/form-data")));
@@ -101,7 +101,7 @@ public class MultipartFormMapMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -124,7 +124,7 @@ public class MultipartFormMapMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -145,7 +145,7 @@ public class MultipartFormMapMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -168,7 +168,7 @@ public class MultipartFormMapMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -191,7 +191,7 @@ public class MultipartFormMapMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -214,7 +214,7 @@ public class MultipartFormMapMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -238,6 +238,6 @@ public class MultipartFormMapMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 }

--- a/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/multipart/MultipartFormObjectMessageWriterTest.java
+++ b/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/multipart/MultipartFormObjectMessageWriterTest.java
@@ -19,7 +19,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.contract.Form.Field;
 import com.github.ljtfreitas.restify.http.contract.MultipartForm;
 import com.github.ljtfreitas.restify.http.contract.MultipartForm.MultipartField;
@@ -34,7 +34,7 @@ public class MultipartFormObjectMessageWriterTest {
 
 	private MyMultipartFormObject myMultipartFormObject;
 
-	private BufferedHttpRequestBody output;
+	private BufferedByteArrayHttpRequestBody output;
 
 	private File file;
 
@@ -53,7 +53,7 @@ public class MultipartFormObjectMessageWriterTest {
 		fileWriter.flush();
 		fileWriter.close();
 
-		output = new BufferedHttpRequestBody();
+		output = new BufferedByteArrayHttpRequestBody();
 		
 		when(request.body()).thenReturn(output);
 		when(request.headers()).thenReturn(new Headers(Header.contentType("multipart/form-data")));
@@ -91,7 +91,7 @@ public class MultipartFormObjectMessageWriterTest {
 
 		converter.write(myMultipartFormObject, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@MultipartForm

--- a/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/multipart/MultipartFormParametersMessageWriterTest.java
+++ b/java-restify-form-encoded-multipart-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/form/multipart/MultipartFormParametersMessageWriterTest.java
@@ -20,7 +20,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.contract.MultipartFile;
 import com.github.ljtfreitas.restify.http.contract.MultipartParameters;
 
@@ -34,7 +34,7 @@ public class MultipartFormParametersMessageWriterTest {
 
 	private MultipartParameters parameters;
 
-	private BufferedHttpRequestBody output;
+	private BufferedByteArrayHttpRequestBody output;
 
 	private File file;
 
@@ -53,7 +53,7 @@ public class MultipartFormParametersMessageWriterTest {
 		fileWriter.flush();
 		fileWriter.close();
 
-		output = new BufferedHttpRequestBody();
+		output = new BufferedByteArrayHttpRequestBody();
 		
 		when(request.body()).thenReturn(output);
 		when(request.headers()).thenReturn(new Headers(Header.contentType("multipart/form-data")));
@@ -99,7 +99,7 @@ public class MultipartFormParametersMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -122,7 +122,7 @@ public class MultipartFormParametersMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -143,7 +143,7 @@ public class MultipartFormParametersMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -166,7 +166,7 @@ public class MultipartFormParametersMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -189,7 +189,7 @@ public class MultipartFormParametersMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -212,7 +212,7 @@ public class MultipartFormParametersMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 
 	@Test
@@ -235,6 +235,6 @@ public class MultipartFormParametersMessageWriterTest {
 
 		converter.write(parameters, request);
 
-		assertEquals(body, output.asString());
+		assertEquals(body, new String(output.asBytes()));
 	}
 }

--- a/java-restify-http-client-apache-httpclient/src/main/java/com/github/ljtfreitas/restify/http/client/apache/httpclient/ApacheAsyncHttpClientRequest.java
+++ b/java-restify-http-client-apache-httpclient/src/main/java/com/github/ljtfreitas/restify/http/client/apache/httpclient/ApacheAsyncHttpClientRequest.java
@@ -43,7 +43,7 @@ import org.apache.http.protocol.HttpContext;
 import com.github.ljtfreitas.restify.http.client.HttpClientException;
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.request.async.AsyncHttpClientRequest;
@@ -61,7 +61,7 @@ class ApacheAsyncHttpClientRequest implements AsyncHttpClientRequest {
 
 	ApacheAsyncHttpClientRequest(HttpAsyncClient httpAsyncClient, HttpUriRequest httpRequest, HttpContext context,
 			Charset charset, Headers headers) {
-		this(httpAsyncClient, httpRequest, context, charset, headers, new BufferedHttpRequestBody(charset));
+		this(httpAsyncClient, httpRequest, context, charset, headers, new BufferedByteArrayHttpRequestBody(charset));
 	}
 
 	private ApacheAsyncHttpClientRequest(HttpAsyncClient httpAsyncClient, HttpUriRequest httpRequest,
@@ -117,7 +117,7 @@ class ApacheAsyncHttpClientRequest implements AsyncHttpClientRequest {
 
 		if (httpRequest instanceof HttpEntityEnclosingRequest) {
 			HttpEntityEnclosingRequest entityEnclosingRequest = (HttpEntityEnclosingRequest) httpRequest;
-			HttpEntity requestEntity = new ByteArrayEntity(body.asBuffer().array());
+			HttpEntity requestEntity = new ByteArrayEntity(body.asBytes());
 			entityEnclosingRequest.setEntity(requestEntity);
 		}
 

--- a/java-restify-http-client-apache-httpclient/src/main/java/com/github/ljtfreitas/restify/http/client/apache/httpclient/ApacheHttpClientRequest.java
+++ b/java-restify-http-client-apache-httpclient/src/main/java/com/github/ljtfreitas/restify/http/client/apache/httpclient/ApacheHttpClientRequest.java
@@ -40,7 +40,7 @@ import org.apache.http.protocol.HttpContext;
 import com.github.ljtfreitas.restify.http.client.HttpClientException;
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
@@ -54,15 +54,15 @@ class ApacheHttpClientRequest implements HttpClientRequest {
 	private final Charset charset;
 	private final Headers headers;
 
-	private final BufferedHttpRequestBody body;
+	private final BufferedByteArrayHttpRequestBody body;
 
 	public ApacheHttpClientRequest(HttpClient httpClient, HttpUriRequest httpRequest, HttpContext httpContext, Charset charset,
 			Headers headers) {
-		this(httpClient, httpRequest, httpContext, charset, headers, new BufferedHttpRequestBody(charset));
+		this(httpClient, httpRequest, httpContext, charset, headers, new BufferedByteArrayHttpRequestBody(charset));
 	}
 
 	private ApacheHttpClientRequest(HttpClient httpClient, HttpUriRequest httpRequest, HttpContext httpContext, Charset charset,
-			Headers headers, BufferedHttpRequestBody body) {
+			Headers headers, BufferedByteArrayHttpRequestBody body) {
 		this.httpClient = httpClient;
 		this.httpRequest = httpRequest;
 		this.httpContext = httpContext;
@@ -77,7 +77,7 @@ class ApacheHttpClientRequest implements HttpClientRequest {
 
 		if (httpRequest instanceof HttpEntityEnclosingRequest) {
 			HttpEntityEnclosingRequest entityEnclosingRequest = (HttpEntityEnclosingRequest) httpRequest;
-			HttpEntity requestEntity = new ByteArrayEntity(body.asBuffer().array());
+			HttpEntity requestEntity = new ByteArrayEntity(body.asBytes());
 			entityEnclosingRequest.setEntity(requestEntity);
 		}
 

--- a/java-restify-http-client-jersey/src/main/java/com/github/ljtfreitas/restify/http/client/request/jersey/ErrorHtpResponseMessage.java
+++ b/java-restify-http-client-jersey/src/main/java/com/github/ljtfreitas/restify/http/client/request/jersey/ErrorHtpResponseMessage.java
@@ -35,7 +35,7 @@ import javax.ws.rs.core.Response;
 
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.response.StatusCode;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
@@ -83,7 +83,7 @@ class HttpErrorResponse extends BaseHttpClientResponse {
 		}
 
 		@Override
-		public BufferedHttpRequestBody body() {
+		public BufferedByteArrayHttpRequestBody body() {
 			throw new UnsupportedOperationException();
 		}
 

--- a/java-restify-http-client-netty/src/main/java/com/github/ljtfreitas/restify/http/client/netty/ByteBufRequestBody.java
+++ b/java-restify-http-client-netty/src/main/java/com/github/ljtfreitas/restify/http/client/netty/ByteBufRequestBody.java
@@ -23,27 +23,36 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.client.message.request;
+package com.github.ljtfreitas.restify.http.client.netty;
 
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
 
-import com.github.ljtfreitas.restify.util.Tryable;
+import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
 
-public interface HttpRequestBody {
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.Unpooled;
 
-	OutputStream output();
+class ByteBufRequestBody implements HttpRequestBody {
 
-	byte[] asBytes();
-	
-	boolean empty();
+	private final ByteBufOutputStream output = new ByteBufOutputStream(Unpooled.buffer());
 
-	default void writeTo(OutputStream other) {
-		WritableByteChannel channel = Channels.newChannel(other);
-		Tryable.run(() -> {
-			channel.write(ByteBuffer.wrap(asBytes()));
-		});
+	@Override
+	public OutputStream output() {
+		return output;
+	}
+
+	@Override
+	public byte[] asBytes() {
+		return output.buffer().array();
+	}
+
+	@Override
+	public boolean empty() {
+		return output.buffer().hasArray() && output.buffer().array().length == 0;
+	}
+
+	ByteBuf asByteBuf() {
+		return output.buffer();
 	}
 }

--- a/java-restify-http-client-okhttp/src/main/java/com/github/ljtfreitas/restify/http/client/okhttp/OkHttpClientRequest.java
+++ b/java-restify-http-client-okhttp/src/main/java/com/github/ljtfreitas/restify/http/client/okhttp/OkHttpClientRequest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.CompletionStage;
 import com.github.ljtfreitas.restify.http.client.HttpClientException;
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.StatusCode;
@@ -61,11 +61,11 @@ class OkHttpClientRequest implements AsyncHttpClientRequest {
 	private final HttpRequestBody body;
 
 	public OkHttpClientRequest(OkHttpClient okHttpClient, URI uri, String method, Headers headers, Charset charset) {
-		this(okHttpClient, uri, method, headers, charset, new BufferedHttpRequestBody(charset));
+		this(okHttpClient, uri, method, headers, charset, new BufferedByteArrayHttpRequestBody(charset));
 	}
 
 	private OkHttpClientRequest(OkHttpClient okHttpClient, URI uri, String method, Headers headers, Charset charset,
-			BufferedHttpRequestBody body) {
+			BufferedByteArrayHttpRequestBody body) {
 		this.okHttpClient = okHttpClient;
 		this.uri = uri;
 		this.method = method;
@@ -144,7 +144,7 @@ class OkHttpClientRequest implements AsyncHttpClientRequest {
 		MediaType contentType = headers.get("Content-Type").map(header -> MediaType.parse(header.value()))
 				.orElse(null);
 
-		byte[] content = body.asBuffer().array();
+		byte[] content = body.asBytes();
 
 		okhttp3.RequestBody body = (content.length > 0 ? okhttp3.RequestBody.create(contentType, content) : null);
 

--- a/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/jdk/JdkHttpClientRequest.java
+++ b/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/jdk/JdkHttpClientRequest.java
@@ -36,7 +36,7 @@ import java.util.Collection;
 import com.github.ljtfreitas.restify.http.client.HttpClientException;
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.StatusCode;
@@ -52,10 +52,10 @@ class JdkHttpClientRequest implements HttpClientRequest {
 	private final HttpRequestBody body;
 
 	public JdkHttpClientRequest(HttpURLConnection connection, Charset charset, Headers headers) {
-		this(connection, charset, headers, new BufferedHttpRequestBody(charset));
+		this(connection, charset, headers, new BufferedByteArrayHttpRequestBody(charset));
 	}
 
-	private JdkHttpClientRequest(HttpURLConnection connection, Charset charset, Headers headers, BufferedHttpRequestBody body) {
+	private JdkHttpClientRequest(HttpURLConnection connection, Charset charset, Headers headers, BufferedByteArrayHttpRequestBody body) {
 		this.connection = connection;
 		this.charset = charset;
 		this.headers = new JdkHttpClientHeadersDecorator(connection, headers);

--- a/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/gzip/Gzip.java
+++ b/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/gzip/Gzip.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.interceptor.gzip;
+
+import java.util.stream.Collectors;
+
+import com.github.ljtfreitas.restify.http.client.message.Header;
+import com.github.ljtfreitas.restify.http.client.message.Headers;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
+import com.github.ljtfreitas.restify.http.client.response.HttpClientResponse;
+
+public class Gzip {
+
+	private static final String GZIP_ALGORITHM = "gzip";
+	
+	@SuppressWarnings("unchecked")
+	public <T extends HttpClientRequest> T applyTo(T request) {
+		if (!request.body().empty()) {
+			return request.headers().get(Headers.CONTENT_ENCODING)
+				.map(h -> request)
+					.orElseGet(() -> (T) request.replace(Header.contentEncoding(GZIP_ALGORITHM)));
+
+		} else return request;
+	}
+	
+	public HttpClientResponse applyTo(HttpClientResponse response) {
+		String encoding = response.headers().all(Headers.CONTENT_ENCODING)
+				.stream()
+					.map(Header::value)
+						.collect(Collectors.joining(","));
+
+		return encoding.contains(GZIP_ALGORITHM) ? new GzipHttpClientResponse(response) : response;
+	}
+}

--- a/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/gzip/GzipHttpClientRequestInterceptor.java
+++ b/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/gzip/GzipHttpClientRequestInterceptor.java
@@ -1,0 +1,219 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.interceptor.gzip;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.util.stream.Collectors;
+
+import com.github.ljtfreitas.restify.http.client.HttpClientException;
+import com.github.ljtfreitas.restify.http.client.message.Header;
+import com.github.ljtfreitas.restify.http.client.message.Headers;
+import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
+import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseBody;
+import com.github.ljtfreitas.restify.http.client.message.response.StatusCode;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
+import com.github.ljtfreitas.restify.http.client.request.interceptor.HttpClientRequestInterceptor;
+import com.github.ljtfreitas.restify.http.client.response.HttpClientResponse;
+
+public class GzipHttpClientRequestInterceptor implements HttpClientRequestInterceptor {
+
+	private static final String GZIP_ALGORITHM = "gzip";
+
+	private final boolean applyToRequest;
+	private final boolean applyToResponse;
+
+	public GzipHttpClientRequestInterceptor() {
+		this(false, true);
+	}
+
+	private GzipHttpClientRequestInterceptor(boolean request, boolean response) {
+		this.applyToRequest = request;
+		this.applyToResponse = response;
+	}
+
+	@Override
+	public HttpClientRequest intercepts(HttpClientRequest request) {
+		return applyToRequest || applyToResponse ? new GzipHttpClientRequest(request) : request;
+	}
+
+	private class GzipHttpClientRequest implements HttpClientRequest {
+
+		private final HttpClientRequest source;
+		private final HttpRequestBody body;
+
+		private GzipHttpClientRequest(HttpClientRequest source) {
+			this.source = source;
+			this.body = applyToRequest ? new GzipHttpRequestBody(source.body()) : source.body();
+		}
+
+		@Override
+		public URI uri() {
+			return source.uri();
+		}
+
+		@Override
+		public String method() {
+			return source.method();
+		}
+
+		@Override
+		public HttpRequestBody body() {
+			return body;
+		}
+
+		@Override
+		public Charset charset() {
+			return source.charset();
+		}
+
+		@Override
+		public HttpRequestMessage replace(Header header) {
+			return source.replace(header);
+		}
+
+		@Override
+		public Headers headers() {
+			return source.headers();
+		}
+
+		@Override
+		public HttpClientResponse execute() throws HttpClientException {
+			HttpClientResponse response = applyToRequest ? withGzip(source).execute() : source.execute();
+
+			if (applyToResponse) {
+				String encoding = response.headers().all(Headers.CONTENT_ENCODING)
+						.stream()
+							.map(Header::value)
+								.collect(Collectors.joining(","));
+
+				return encoding.contains(GZIP_ALGORITHM) ? new GzipHttpClientResponse(response) : response;
+
+			} else return response;
+		}
+
+		private HttpClientRequest withGzip(HttpClientRequest request) {
+			if (!body.empty()) {
+				return request.headers().get(Headers.CONTENT_ENCODING)
+					.map(h -> request)
+						.orElseGet(() -> (HttpClientRequest) request.replace(Header.contentEncoding(GZIP_ALGORITHM)));
+
+			} else return request;
+		}
+	}
+
+	private class GzipHttpClientResponse implements HttpClientResponse {
+
+		private final HttpClientResponse source;
+		private final HttpResponseBody body;
+
+		private GzipHttpClientResponse(HttpClientResponse source) {
+			this.source = source;
+			this.body = GzipHttpResponseBody.of(source.body());
+		}
+
+		@Override
+		public StatusCode status() {
+			return source.status();
+		}
+
+		@Override
+		public HttpResponseBody body() {
+			return body;
+		}
+
+		@Override
+		public boolean available() {
+			return source.available();
+		}
+
+		@Override
+		public HttpRequestMessage request() {
+			return source.request();
+		}
+
+		@Override
+		public Headers headers() {
+			return source.headers();
+		}
+
+		@Override
+		public void close() throws IOException {
+			source.close();
+		}
+	}
+
+	public static class Builder {
+
+		private final GzipHttpClientEncodingBuilder encoding = new GzipHttpClientEncodingBuilder();
+
+		public GzipHttpClientEncodingBuilder encoding() {
+			return encoding;
+		}
+
+		public GzipHttpClientRequestInterceptor build() {
+			return new GzipHttpClientRequestInterceptor(encoding.request, encoding.response);
+		}
+
+		public class GzipHttpClientEncodingBuilder {
+
+			private boolean request = false;
+			private boolean response = true;
+
+			public GzipHttpClientEncodingBuilder request() {
+				this.request = true;
+				return this;
+			}
+
+			public GzipHttpClientEncodingBuilder request(boolean enabled) {
+				this.request = enabled;
+				return this;
+			}
+
+			public GzipHttpClientEncodingBuilder response() {
+				this.response = true;
+				return this;
+			}
+
+			public GzipHttpClientEncodingBuilder response(boolean enabled) {
+				this.response = enabled;
+				return this;
+			}
+
+			public Builder both() {
+				this.request = true;
+				this.response = true;
+				return Builder.this;
+			}
+
+			public GzipHttpClientRequestInterceptor build() {
+				return Builder.this.build();
+			}
+		}
+	}
+}

--- a/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/gzip/GzipHttpClientRequestInterceptor.java
+++ b/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/gzip/GzipHttpClientRequestInterceptor.java
@@ -27,7 +27,6 @@ package com.github.ljtfreitas.restify.http.client.request.interceptor.gzip;
 
 import java.net.URI;
 import java.nio.charset.Charset;
-import java.util.stream.Collectors;
 
 import com.github.ljtfreitas.restify.http.client.HttpClientException;
 import com.github.ljtfreitas.restify.http.client.message.Header;
@@ -39,8 +38,6 @@ import com.github.ljtfreitas.restify.http.client.request.interceptor.HttpClientR
 import com.github.ljtfreitas.restify.http.client.response.HttpClientResponse;
 
 public class GzipHttpClientRequestInterceptor implements HttpClientRequestInterceptor {
-
-	private static final String GZIP_ALGORITHM = "gzip";
 
 	private final boolean applyToRequest;
 	private final boolean applyToResponse;
@@ -101,26 +98,11 @@ public class GzipHttpClientRequestInterceptor implements HttpClientRequestInterc
 
 		@Override
 		public HttpClientResponse execute() throws HttpClientException {
-			HttpClientResponse response = applyToRequest ? withGzip(source).execute() : source.execute();
+			Gzip gzip = new Gzip();
+			
+			HttpClientResponse response = applyToRequest ? gzip.applyTo(source).execute() : source.execute();
 
-			if (applyToResponse) {
-				String encoding = response.headers().all(Headers.CONTENT_ENCODING)
-						.stream()
-							.map(Header::value)
-								.collect(Collectors.joining(","));
-
-				return encoding.contains(GZIP_ALGORITHM) ? new GzipHttpClientResponse(response) : response;
-
-			} else return response;
-		}
-
-		private HttpClientRequest withGzip(HttpClientRequest request) {
-			if (!body.empty()) {
-				return request.headers().get(Headers.CONTENT_ENCODING)
-					.map(h -> request)
-						.orElseGet(() -> (HttpClientRequest) request.replace(Header.contentEncoding(GZIP_ALGORITHM)));
-
-			} else return request;
+			return applyToResponse ? gzip.applyTo(response) : response;
 		}
 	}
 

--- a/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/gzip/GzipHttpClientResponse.java
+++ b/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/gzip/GzipHttpClientResponse.java
@@ -25,36 +25,51 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.client.request.interceptor.gzip;
 
-import java.io.OutputStream;
-import java.util.zip.GZIPOutputStream;
+import java.io.IOException;
 
-import com.github.ljtfreitas.restify.http.client.message.converter.HttpMessageWriteException;
-import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.util.Tryable;
+import com.github.ljtfreitas.restify.http.client.message.Headers;
+import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
+import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseBody;
+import com.github.ljtfreitas.restify.http.client.message.response.StatusCode;
+import com.github.ljtfreitas.restify.http.client.response.HttpClientResponse;
 
-public class GzipHttpRequestBody implements HttpRequestBody {
+public class GzipHttpClientResponse implements HttpClientResponse {
 
-	private final HttpRequestBody source;
-	private final GZIPOutputStream output;
+	private final HttpClientResponse source;
+	private final HttpResponseBody body;
 
-	public GzipHttpRequestBody(HttpRequestBody source) {
+	public GzipHttpClientResponse(HttpClientResponse source) {
 		this.source = source;
-		this.output = Tryable.of(() -> new GZIPOutputStream(source.output()), HttpMessageWriteException::new);
+		this.body = GzipHttpResponseBody.of(source.body());
 	}
 
 	@Override
-	public OutputStream output() {
-		return output;
+	public StatusCode status() {
+		return source.status();
 	}
 
 	@Override
-	public byte[] asBytes() {
-		return source.asBytes();
+	public HttpResponseBody body() {
+		return body;
 	}
 
 	@Override
-	public boolean empty() {
-		return source.empty();
+	public boolean available() {
+		return source.available();
 	}
 
+	@Override
+	public HttpRequestMessage request() {
+		return source.request();
+	}
+
+	@Override
+	public Headers headers() {
+		return source.headers();
+	}
+
+	@Override
+	public void close() throws IOException {
+		source.close();
+	}
 }

--- a/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/gzip/GzipHttpRequestBody.java
+++ b/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/gzip/GzipHttpRequestBody.java
@@ -23,27 +23,38 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.client.message.request;
+package com.github.ljtfreitas.restify.http.client.request.interceptor.gzip;
 
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
+import java.util.zip.GZIPOutputStream;
 
+import com.github.ljtfreitas.restify.http.client.message.converter.HttpMessageWriteException;
+import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
 import com.github.ljtfreitas.restify.util.Tryable;
 
-public interface HttpRequestBody {
+class GzipHttpRequestBody implements HttpRequestBody {
 
-	OutputStream output();
+	private final HttpRequestBody source;
+	private final GZIPOutputStream output;
 
-	byte[] asBytes();
-	
-	boolean empty();
-
-	default void writeTo(OutputStream other) {
-		WritableByteChannel channel = Channels.newChannel(other);
-		Tryable.run(() -> {
-			channel.write(ByteBuffer.wrap(asBytes()));
-		});
+	GzipHttpRequestBody(HttpRequestBody source) {
+		this.source = source;
+		this.output = Tryable.of(() -> new GZIPOutputStream(source.output()), HttpMessageWriteException::new);
 	}
+
+	@Override
+	public OutputStream output() {
+		return output;
+	}
+
+	@Override
+	public byte[] asBytes() {
+		return source.asBytes();
+	}
+
+	@Override
+	public boolean empty() {
+		return source.empty();
+	}
+
 }

--- a/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/log/CurlPrinter.java
+++ b/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/interceptor/log/CurlPrinter.java
@@ -25,6 +25,8 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.client.request.interceptor.log;
 
+import com.github.ljtfreitas.restify.http.client.message.response.BufferedHttpResponseBody;
+import com.github.ljtfreitas.restify.http.client.message.response.ByteArrayHttpResponseBody;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
 import com.github.ljtfreitas.restify.http.client.response.HttpClientResponse;
 import com.github.ljtfreitas.restify.util.Tryable;
@@ -39,7 +41,7 @@ public class CurlPrinter {
 		request.headers().forEach(h -> message.append("\n").append("> " + h.toString()));
 
 		if (!request.body().empty()) {
-			message.append("\n").append("> " + Tryable.of(request.body()::asString));
+			message.append("\n").append("> " + new String(request.body().asBytes()));
 		}
 
 		message.append("\n").append(">");
@@ -54,8 +56,10 @@ public class CurlPrinter {
 
 		response.headers().forEach(h -> message.append("\n").append("< " + h.toString()));
 
-		if (response.available() && !response.body().empty()) {
-			message.append("\n").append("< " + Tryable.of(response.body()::asString));
+		BufferedHttpResponseBody bufferedHttpResponseBody = ByteArrayHttpResponseBody.of(response.body());
+
+		if (response.available() && !bufferedHttpResponseBody.empty()) {
+			message.append("\n").append("< " + Tryable.of(bufferedHttpResponseBody::asString));
 		}
 
 		message.append("\n").append("<");

--- a/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/response/BaseHttpClientResponse.java
+++ b/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/response/BaseHttpClientResponse.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
-import com.github.ljtfreitas.restify.http.client.message.response.BufferedHttpResponseBody;
+import com.github.ljtfreitas.restify.http.client.message.response.InputStreamHttpResponseBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseBody;
 import com.github.ljtfreitas.restify.http.client.message.response.StatusCode;
 
@@ -48,7 +48,7 @@ public abstract class BaseHttpClientResponse implements HttpClientResponse {
 			HttpRequestMessage httpRequest) {
 		this.status = status;
 		this.headers = headers;
-		this.body = Optional.ofNullable(body).map(BufferedHttpResponseBody::of).orElseGet(BufferedHttpResponseBody::none);
+		this.body = Optional.ofNullable(body).map(InputStreamHttpResponseBody::new).orElseGet(InputStreamHttpResponseBody::empty);
 		this.httpRequest = httpRequest;
 	}
 

--- a/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/DefaultEndpointRequestExecutorTest.java
+++ b/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/DefaultEndpointRequestExecutorTest.java
@@ -21,7 +21,7 @@ import com.github.ljtfreitas.restify.http.client.HttpClientException;
 import com.github.ljtfreitas.restify.http.client.message.Encoding;
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
@@ -104,7 +104,7 @@ public class DefaultEndpointRequestExecutorTest {
 		private final EndpointRequest source;
 		private final HttpClientResponse response;
 
-		private final HttpRequestBody body = new BufferedHttpRequestBody(Charset.defaultCharset());
+		private final HttpRequestBody body = new BufferedByteArrayHttpRequestBody(Charset.defaultCharset());
 
 		public SimpleHttpClientRequest(EndpointRequest source, HttpClientResponse response) {
 			this.source = source;

--- a/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestWriterTest.java
+++ b/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/EndpointRequestWriterTest.java
@@ -23,7 +23,7 @@ import com.github.ljtfreitas.restify.http.client.message.Headers;
 import com.github.ljtfreitas.restify.http.client.message.converter.HttpMessageConverters;
 import com.github.ljtfreitas.restify.http.client.message.converter.HttpMessageWriter;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EndpointRequestWriterTest {
@@ -59,7 +59,7 @@ public class EndpointRequestWriterTest {
 				String.class);
 
 		when(httpRequestMessage.headers()).thenReturn(headers);
-		when(httpRequestMessage.body()).thenReturn(new BufferedHttpRequestBody());
+		when(httpRequestMessage.body()).thenReturn(new BufferedByteArrayHttpRequestBody());
 
 		endpointRequestWriter.write(endpointRequest, httpRequestMessage);
 

--- a/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/async/interceptor/log/AsyncLogHttpClientRequestInterceptorTest.java
+++ b/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/async/interceptor/log/AsyncLogHttpClientRequestInterceptorTest.java
@@ -24,9 +24,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.response.BufferedHttpResponseBody;
+import com.github.ljtfreitas.restify.http.client.message.response.InputStreamHttpResponseBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseBody;
 import com.github.ljtfreitas.restify.http.client.message.response.StatusCode;
 import com.github.ljtfreitas.restify.http.client.request.async.AsyncHttpClientRequest;
@@ -56,7 +56,7 @@ public class AsyncLogHttpClientRequestInterceptorTest {
 		when(request.headers())
 			.thenReturn(new Headers(Header.host("http://my.api.com"), Header.userAgent("http-java-restify-2.0"), Header.date(Instant.now())));
 		when(request.body())
-			.thenReturn(new BufferedHttpRequestBody());
+			.thenReturn(new BufferedByteArrayHttpRequestBody());
 		when(request.charset())
 			.thenReturn(Charset.forName("UTF-8"));
 		when(request.executeAsync())
@@ -66,6 +66,8 @@ public class AsyncLogHttpClientRequestInterceptorTest {
 			.thenReturn(StatusCode.ok());
 		when(response.headers())
 			.thenReturn(new Headers(Header.date(Instant.now()), Header.contentType("text/plain"), Header.of("Cache-Control", "private, max-age=0")));
+		when(response.body())
+			.thenReturn(InputStreamHttpResponseBody.empty());
 
 		handler = new MyHandler();
 
@@ -106,7 +108,7 @@ public class AsyncLogHttpClientRequestInterceptorTest {
 
 	@Test
 	public void shouldLogHttpRequestWithBody() throws IOException {
-		HttpRequestBody body = new BufferedHttpRequestBody();
+		HttpRequestBody body = new BufferedByteArrayHttpRequestBody();
 		body.output().write("This is a message body".getBytes());
 		body.output().flush();
 
@@ -130,8 +132,7 @@ public class AsyncLogHttpClientRequestInterceptorTest {
 
 	@Test
 	public void shouldLogHttpResponseWithBody() throws IOException {
-		HttpResponseBody body = BufferedHttpResponseBody
-				.of(new ByteArrayInputStream("This is a message body".getBytes()));
+		HttpResponseBody body = new InputStreamHttpResponseBody(new ByteArrayInputStream("This is a message body".getBytes()));
 
 		when(response.body())
 			.thenReturn(body);

--- a/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/interceptor/gzip/GzipHttpClientRequestInterceptorTest.java
+++ b/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/interceptor/gzip/GzipHttpClientRequestInterceptorTest.java
@@ -1,0 +1,217 @@
+package com.github.ljtfreitas.restify.http.client.request.interceptor.gzip;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.message.Header;
+import com.github.ljtfreitas.restify.http.client.message.Headers;
+import com.github.ljtfreitas.restify.http.client.message.io.InputStreamContent;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.response.ByteArrayHttpResponseBody;
+import com.github.ljtfreitas.restify.http.client.message.response.InputStreamHttpResponseBody;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
+import com.github.ljtfreitas.restify.http.client.response.HttpClientResponse;
+import com.github.ljtfreitas.restify.util.Tryable;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GzipHttpClientRequestInterceptorTest {
+
+	@Mock
+	private HttpClientRequest request;
+
+	@Mock
+	private HttpClientResponse response;
+
+	private GzipHttpClientRequestInterceptor interceptor;
+
+	@Before
+	public void setup() throws Exception {
+		interceptor = new GzipHttpClientRequestInterceptor();
+
+		when(response.body())
+			.thenReturn(InputStreamHttpResponseBody.empty());
+
+		when(response.headers())
+			.thenReturn(new Headers(Header.contentEncoding("gzip")));
+
+		when(request.execute())
+			.thenReturn(response);
+	}
+
+	@Test
+	public void shouldReadGzippedResponseBody() throws Exception {
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+		try (GZIPOutputStream gzipContentOutput = Tryable.of(() -> new GZIPOutputStream(output))) {
+			gzipContentOutput.write("http response".getBytes());
+			gzipContentOutput.flush();
+		}
+
+		when(response.body())
+			.thenReturn(new InputStreamHttpResponseBody(new ByteArrayInputStream(output.toByteArray())));
+
+		HttpClientRequest gzipHttpClientRequest = interceptor.intercepts(request);
+
+		HttpClientResponse gzipHttpClientResponse = gzipHttpClientRequest.execute();
+
+		assertTrue(gzipHttpClientResponse.body().input() instanceof GZIPInputStream);
+
+		String responseAsString = ByteArrayHttpResponseBody.of(gzipHttpClientResponse.body()).asString();
+
+		assertEquals("http response", responseAsString);
+	}
+
+	@Test
+	public void shouldNotUseGzipResponseWhenContentEncodingHeaderNotContainsGzip() {
+		when(response.body())
+			.thenReturn(new InputStreamHttpResponseBody(new ByteArrayInputStream("simple http response".getBytes())));
+		when(response.headers())
+			.thenReturn(Headers.empty());
+
+		HttpClientRequest httpClientRequest = interceptor.intercepts(request);
+
+		HttpClientResponse httpClientResponse = httpClientRequest.execute();
+
+		assertSame(response, httpClientResponse);
+
+		assertFalse(httpClientResponse.body().input() instanceof GZIPInputStream);
+
+		String responseAsString = ByteArrayHttpResponseBody.of(httpClientResponse.body()).asString();
+
+		assertEquals("simple http response", responseAsString);
+	}
+
+	@Test
+	public void shouldNotUseGzipResponseWhenContentEncodingHeaderUseOtherAlgorithm() {
+		when(response.body())
+			.thenReturn(new InputStreamHttpResponseBody(new ByteArrayInputStream("simple http response".getBytes())));
+		when(response.headers())
+			.thenReturn(new Headers(Header.contentEncoding("br")));
+
+		HttpClientRequest httpClientRequest = interceptor.intercepts(request);
+
+		HttpClientResponse httpClientResponse = httpClientRequest.execute();
+
+		assertSame(response, httpClientResponse);
+
+		assertFalse(httpClientResponse.body().input() instanceof GZIPInputStream);
+
+		String responseAsString = ByteArrayHttpResponseBody.of(httpClientResponse.body()).asString();
+
+		assertEquals("simple http response", responseAsString);
+	}
+
+	@Test
+	public void shouldNotUseGzipResponseWhenDisabled() {
+		interceptor = new GzipHttpClientRequestInterceptor.Builder()
+				.encoding()
+					.response(false)
+					.build();
+
+		when(response.body())
+			.thenReturn(new InputStreamHttpResponseBody(new ByteArrayInputStream("simple http response".getBytes())));
+
+		HttpClientRequest httpClientRequest = interceptor.intercepts(request);
+
+		HttpClientResponse httpClientResponse = httpClientRequest.execute();
+
+		assertSame(response, httpClientResponse);
+
+		assertFalse(httpClientResponse.body().input() instanceof GZIPInputStream);
+
+		String responseAsString = ByteArrayHttpResponseBody.of(httpClientResponse.body()).asString();
+
+		assertEquals("simple http response", responseAsString);
+	}
+
+	@Test
+	public void shouldWriteGzippedRequestBody() throws Exception {
+		interceptor = new GzipHttpClientRequestInterceptor.Builder()
+				.encoding()
+					.request()
+					.response(false)
+						.build();
+
+		when(request.headers())
+			.thenReturn(Headers.empty());
+
+		when(request.replace(Header.contentEncoding("gzip")))
+			.thenReturn(request);
+
+		BufferedByteArrayHttpRequestBody body = new BufferedByteArrayHttpRequestBody();
+
+		when(request.body())
+			.thenReturn(body);
+
+		HttpClientRequest gzipHttpClientRequest = interceptor.intercepts(request);
+
+		OutputStream outputBody = gzipHttpClientRequest.body().output();
+
+		assertTrue(outputBody instanceof GZIPOutputStream);
+
+		outputBody.write("http request".getBytes());
+		outputBody.flush();
+		outputBody.close();
+
+		HttpClientResponse response = gzipHttpClientRequest.execute();
+		assertNotNull(response);
+
+		verify(request).replace(Header.contentEncoding("gzip"));
+
+		InputStreamContent result = new InputStreamContent(new GZIPInputStream(new ByteArrayInputStream(body.asBytes())));
+
+		assertEquals("http request", result.asString());
+	}
+
+	@Test
+	public void shouldNotWriteGzipRequestBodyWhenDisabled() throws Exception {
+		interceptor = new GzipHttpClientRequestInterceptor.Builder()
+				.encoding()
+					.request(false)
+					.response(false)
+						.build();
+
+		when(request.headers())
+			.thenReturn(Headers.empty());
+
+		BufferedByteArrayHttpRequestBody body = new BufferedByteArrayHttpRequestBody();
+
+		when(request.body())
+			.thenReturn(body);
+
+		HttpClientRequest gzipHttpClientRequest = interceptor.intercepts(request);
+
+		OutputStream outputBody = gzipHttpClientRequest.body().output();
+
+		assertFalse(outputBody instanceof GZIPOutputStream);
+
+		outputBody.write("http request".getBytes());
+		outputBody.flush();
+		outputBody.close();
+
+		HttpClientResponse httpClientResponse = gzipHttpClientRequest.execute();
+
+		assertNotNull(httpClientResponse);
+
+		assertFalse(httpClientResponse.body().input() instanceof GZIPInputStream);
+
+		assertEquals("http request", new String(body.asBytes()));
+	}
+}

--- a/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/interceptor/log/LogHttpClientRequestInterceptorTest.java
+++ b/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/interceptor/log/LogHttpClientRequestInterceptorTest.java
@@ -23,9 +23,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.response.BufferedHttpResponseBody;
+import com.github.ljtfreitas.restify.http.client.message.response.InputStreamHttpResponseBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseBody;
 import com.github.ljtfreitas.restify.http.client.message.response.StatusCode;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
@@ -55,7 +55,7 @@ public class LogHttpClientRequestInterceptorTest {
 		when(request.headers())
 			.thenReturn(new Headers(Header.host("http://my.api.com"), Header.userAgent("http-java-restify-2.0"), Header.date(Instant.now())));
 		when(request.body())
-			.thenReturn(new BufferedHttpRequestBody());
+			.thenReturn(new BufferedByteArrayHttpRequestBody());
 		when(request.charset())
 			.thenReturn(Charset.forName("UTF-8"));
 		when(request.execute())
@@ -65,6 +65,8 @@ public class LogHttpClientRequestInterceptorTest {
 			.thenReturn(StatusCode.ok());
 		when(response.headers())
 			.thenReturn(new Headers(Header.date(Instant.now()), Header.contentType("text/plain"), Header.of("Cache-Control", "private, max-age=0")));
+		when(response.body())
+			.thenReturn(InputStreamHttpResponseBody.empty());
 
 		handler = new MyHandler();
 
@@ -105,7 +107,7 @@ public class LogHttpClientRequestInterceptorTest {
 
 	@Test
 	public void shouldLogHttpRequestWithBody() throws IOException {
-		HttpRequestBody body = new BufferedHttpRequestBody();
+		HttpRequestBody body = new BufferedByteArrayHttpRequestBody();
 		body.output().write("This is a message body".getBytes());
 		body.output().flush();
 
@@ -129,8 +131,7 @@ public class LogHttpClientRequestInterceptorTest {
 
 	@Test
 	public void shouldLogHttpResponseWithBody() throws IOException {
-		HttpResponseBody body = BufferedHttpResponseBody
-				.of(new ByteArrayInputStream("This is a message body".getBytes()));
+		HttpResponseBody body = new InputStreamHttpResponseBody(new ByteArrayInputStream("This is a message body".getBytes()));
 
 		when(response.body())
 			.thenReturn(body);

--- a/java-restify-http-message/src/main/java/com/github/ljtfreitas/restify/http/client/message/Headers.java
+++ b/java-restify-http-message/src/main/java/com/github/ljtfreitas/restify/http/client/message/Headers.java
@@ -165,6 +165,11 @@ public class Headers implements Iterable<Header> {
 	public Collection<Header> all() {
 		return Collections.unmodifiableCollection(headers);
 	}
+	
+	public Collection<Header> all(String name) {
+		return headers.stream().filter(h -> h.name().equalsIgnoreCase(name))
+				.collect(Collectors.toList());
+	}
 
 	public Optional<Header> get(String name) {
 		return headers.stream().filter(h -> h.name().equalsIgnoreCase(name))

--- a/java-restify-http-message/src/main/java/com/github/ljtfreitas/restify/http/client/message/request/BufferedByteArrayHttpRequestBody.java
+++ b/java-restify-http-message/src/main/java/com/github/ljtfreitas/restify/http/client/message/request/BufferedByteArrayHttpRequestBody.java
@@ -29,40 +29,39 @@ import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 import com.github.ljtfreitas.restify.http.client.message.Encoding;
 import com.github.ljtfreitas.restify.util.Tryable;
 
-public class BufferedHttpRequestBody implements HttpRequestBody {
+public class BufferedByteArrayHttpRequestBody implements HttpRequestBody {
 
 	private static final int DEFAULT_BUFFER_SIZE = 1024 * 100;
 
 	private final Charset charset;
 	private final BufferedOutput output;
 
-	public BufferedHttpRequestBody() {
+	public BufferedByteArrayHttpRequestBody() {
 		this(Encoding.UTF_8.charset());
 	}
 
-	public BufferedHttpRequestBody(Charset charset) {
+	public BufferedByteArrayHttpRequestBody(Charset charset) {
 		this(charset, DEFAULT_BUFFER_SIZE);
 	}
 
-	public BufferedHttpRequestBody(Charset charset, int size) {
+	public BufferedByteArrayHttpRequestBody(Charset charset, int size) {
 		this.charset = charset;
 		this.output = new BufferedOutput(size);
 	}
 
 	@Override
-	public ByteBuffer asBuffer() {
-		return ByteBuffer.wrap(output.source.toByteArray());
+	public OutputStream output() {
+		return output;
 	}
 
 	@Override
-	public OutputStream output() {
-		return output;
+	public byte[] asBytes() {
+		return output.source.toByteArray();
 	}
 
 	@Override
@@ -72,15 +71,6 @@ public class BufferedHttpRequestBody implements HttpRequestBody {
 
 	@Override
 	public String toString() {
-		return bufferAsString();
-	}
-
-	@Override
-	public String asString() {
-		return bufferAsString();
-	}
-
-	private String bufferAsString() {
 		return Tryable.of(() -> output.source.toString(charset.name()));
 	}
 

--- a/java-restify-http-message/src/main/java/com/github/ljtfreitas/restify/http/client/message/response/BufferedHttpResponseBody.java
+++ b/java-restify-http-message/src/main/java/com/github/ljtfreitas/restify/http/client/message/response/BufferedHttpResponseBody.java
@@ -25,53 +25,9 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.http.client.message.response;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
+public interface BufferedHttpResponseBody extends HttpResponseBody {
 
-import com.github.ljtfreitas.restify.http.client.message.io.InputStreamContent;
+	boolean empty();
 
-public class BufferedHttpResponseBody implements HttpResponseBody {
-
-	private final byte[] responseAsBytes;
-	private final InputStream stream;
-
-	private BufferedHttpResponseBody(byte[] responseAsBytes) {
-		this.responseAsBytes = responseAsBytes;
-		this.stream = new ByteArrayInputStream(responseAsBytes);
-	}
-
-	@Override
-	public ByteBuffer asBuffer() {
-		return ByteBuffer.wrap(responseAsBytes);
-	}
-
-	@Override
-	public String asString() {
-		return new String(responseAsBytes);
-	}
-
-	@Override
-	public InputStream input() {
-		return stream;
-	}
-
-	@Override
-	public boolean empty() {
-		return responseAsBytes.length == 0;
-	}
-
-	@Override
-	public String toString() {
-		return new String(responseAsBytes);
-	}
-
-	public static HttpResponseBody of(InputStream source) {
-		InputStreamContent content = new InputStreamContent(source);
-		return new BufferedHttpResponseBody(content.asBytes());
-	}
-
-	public static HttpResponseBody none() {
-		return new BufferedHttpResponseBody(new byte[0]);
-	}
+	String asString();
 }

--- a/java-restify-http-message/src/main/java/com/github/ljtfreitas/restify/http/client/message/response/ByteArrayHttpResponseBody.java
+++ b/java-restify-http-message/src/main/java/com/github/ljtfreitas/restify/http/client/message/response/ByteArrayHttpResponseBody.java
@@ -23,27 +23,40 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.client.message.request;
+package com.github.ljtfreitas.restify.http.client.message.response;
 
-import java.io.OutputStream;
-import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
-import com.github.ljtfreitas.restify.util.Tryable;
+import com.github.ljtfreitas.restify.http.client.message.io.InputStreamContent;
 
-public interface HttpRequestBody {
+public class ByteArrayHttpResponseBody implements BufferedHttpResponseBody {
 
-	OutputStream output();
+	private final byte[] contentAsBytes;
+	private final ByteArrayInputStream input;
 
-	byte[] asBytes();
-	
-	boolean empty();
+	private ByteArrayHttpResponseBody(byte[] contentAsBytes) {
+		this.contentAsBytes = contentAsBytes;
+		this.input = new ByteArrayInputStream(contentAsBytes);
+	}
 
-	default void writeTo(OutputStream other) {
-		WritableByteChannel channel = Channels.newChannel(other);
-		Tryable.run(() -> {
-			channel.write(ByteBuffer.wrap(asBytes()));
-		});
+	@Override
+	public InputStream input() {
+		return input;
+	}
+
+	@Override
+	public boolean empty() {
+		return contentAsBytes.length == 0;
+	}
+
+	@Override
+	public String asString() {
+		return new String(contentAsBytes);
+	}
+
+	public static BufferedHttpResponseBody of(HttpResponseBody source) {
+		InputStreamContent content = new InputStreamContent(source.input());
+		return new ByteArrayHttpResponseBody(content.asBytes());
 	}
 }

--- a/java-restify-http-message/src/main/java/com/github/ljtfreitas/restify/http/client/message/response/HttpResponseBody.java
+++ b/java-restify-http-message/src/main/java/com/github/ljtfreitas/restify/http/client/message/response/HttpResponseBody.java
@@ -26,15 +26,9 @@
 package com.github.ljtfreitas.restify.http.client.message.response;
 
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 
 public interface HttpResponseBody {
 
-	public ByteBuffer asBuffer();
-
-	public String asString();
-
 	public InputStream input();
 
-	public boolean empty();
 }

--- a/java-restify-http-message/src/main/java/com/github/ljtfreitas/restify/http/client/message/response/InputStreamHttpResponseBody.java
+++ b/java-restify-http-message/src/main/java/com/github/ljtfreitas/restify/http/client/message/response/InputStreamHttpResponseBody.java
@@ -23,27 +23,25 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.http.client.message.request;
+package com.github.ljtfreitas.restify.http.client.message.response;
 
-import java.io.OutputStream;
-import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
-import com.github.ljtfreitas.restify.util.Tryable;
+public class InputStreamHttpResponseBody implements HttpResponseBody {
 
-public interface HttpRequestBody {
+	private final InputStream input;
 
-	OutputStream output();
+	public InputStreamHttpResponseBody(InputStream input) {
+		this.input = input;
+	}
 
-	byte[] asBytes();
-	
-	boolean empty();
+	@Override
+	public InputStream input() {
+		return input;
+	}
 
-	default void writeTo(OutputStream other) {
-		WritableByteChannel channel = Channels.newChannel(other);
-		Tryable.run(() -> {
-			channel.write(ByteBuffer.wrap(asBytes()));
-		});
+	public static InputStreamHttpResponseBody empty() {
+		return new InputStreamHttpResponseBody(new ByteArrayInputStream(new byte[0]));
 	}
 }

--- a/java-restify-http-message/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/text/StringMessageConverterTest.java
+++ b/java-restify-http-message/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/text/StringMessageConverterTest.java
@@ -18,7 +18,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import com.github.ljtfreitas.restify.http.client.message.ContentType;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -71,13 +71,13 @@ public class StringMessageConverterTest {
 
 	@Test
 	public void shouldWriteStringMessage() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 
 		converter.write(message, request);
 
-		assertEquals(message, output.asString());
+		assertEquals(message, new String(output.asBytes()));
 	}
 
 	@Test

--- a/java-restify-json-gson-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/GsonMessageConverterTest.java
+++ b/java-restify-json-gson-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/GsonMessageConverterTest.java
@@ -18,7 +18,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 import com.github.ljtfreitas.restify.reflection.SimpleParameterizedType;
 import com.google.gson.internal.LinkedTreeMap;
@@ -68,13 +68,13 @@ public class GsonMessageConverterTest {
 
 	@Test
 	public void shouldWriteJsonMessage() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 		
 		converter.write(new MyJsonModel("Tiago de Freitas Lima", 31), request);
 
-		assertEquals(json, output.asString());
+		assertEquals(json, new String(output.asBytes()));
 	}
 
 	@Test

--- a/java-restify-json-jackson-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JacksonMessageConverterTest.java
+++ b/java-restify-json-jackson-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JacksonMessageConverterTest.java
@@ -20,7 +20,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import com.github.ljtfreitas.restify.http.client.message.Encoding;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 import com.github.ljtfreitas.restify.reflection.SimpleParameterizedType;
 
@@ -69,18 +69,18 @@ public class JacksonMessageConverterTest {
 
 	@Test
 	public void shouldWriteJsonMessage() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 		
 		converter.write(new MyJsonModel("Tiago de Freitas Lima", 31), request);
 
-		assertEquals(json, output.asString());
+		assertEquals(json, new String(output.asBytes()));
 	}
 
 	@Test
 	public void shouldWriteCollectionOfJsonMessage() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 		
@@ -88,7 +88,7 @@ public class JacksonMessageConverterTest {
 
 		converter.write(collection, request);
 
-		assertEquals(collectionOfJson, output.asString());
+		assertEquals(collectionOfJson, new String(output.asBytes()));
 	}
 
 	@Test

--- a/java-restify-json-jsonb-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonBMessageConverterTest.java
+++ b/java-restify-json-jsonb-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonBMessageConverterTest.java
@@ -17,7 +17,7 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
@@ -68,13 +68,13 @@ public class JsonBMessageConverterTest {
 
 	@Test
 	public void shouldWriteJsonMessage() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 
 		converter.write(new MyJsonModel("Tiago de Freitas Lima", 31), request);
 
-		assertEquals(json, output.asString());
+		assertEquals(json, new String(output.asBytes()));
 	}
 
 	@Test

--- a/java-restify-json-jsonp-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonpMessageConverterTest.java
+++ b/java-restify-json-jsonp-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonpMessageConverterTest.java
@@ -18,7 +18,7 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
@@ -64,13 +64,13 @@ public class JsonpMessageConverterTest {
 
 	@Test
 	public void shouldWriteJsonObject() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 
 		converter.write(jsonObject, request);
 
-		assertEquals(jsonObject.toString(), output.asString());
+		assertEquals(jsonObject.toString(), new String(output.asBytes()));
 	}
 
 	@Test
@@ -97,13 +97,13 @@ public class JsonpMessageConverterTest {
 
 	@Test
 	public void shouldWriteJsonArray() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 
 		converter.write(jsonArray, request);
 
-		assertEquals(jsonArray.toString(), output.asString());
+		assertEquals(jsonArray.toString(), new String(output.asBytes()));
 	}
 
 	@Test

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/DefaultRibbonHttpClientRequest.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/DefaultRibbonHttpClientRequest.java
@@ -34,7 +34,7 @@ import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
 import com.github.ljtfreitas.restify.http.client.response.HttpClientResponse;
@@ -49,7 +49,7 @@ public class DefaultRibbonHttpClientRequest extends BaseRibbonHttpClientRequest 
 	private final HttpRequestBody body;
 
 	public DefaultRibbonHttpClientRequest(EndpointRequest endpointRequest, RibbonLoadBalancedClient ribbonLoadBalancedClient, Charset charset) {
-		this(endpointRequest, ribbonLoadBalancedClient, charset, new BufferedHttpRequestBody(charset));
+		this(endpointRequest, ribbonLoadBalancedClient, charset, new BufferedByteArrayHttpRequestBody(charset));
 	}
 
 	private DefaultRibbonHttpClientRequest(EndpointRequest endpointRequest, RibbonLoadBalancedClient ribbonLoadBalancedClient, Charset charset,

--- a/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/async/AsyncRibbonHttpClientRequest.java
+++ b/java-restify-netflix/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/async/AsyncRibbonHttpClientRequest.java
@@ -33,7 +33,7 @@ import com.github.ljtfreitas.restify.http.client.HttpClientException;
 import com.github.ljtfreitas.restify.http.client.HttpException;
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
@@ -55,7 +55,7 @@ public class AsyncRibbonHttpClientRequest extends BaseRibbonHttpClientRequest im
 	private final HttpRequestBody body;
 
 	public AsyncRibbonHttpClientRequest(EndpointRequest endpointRequest, AsyncRibbonLoadBalancedClient ribbonLoadBalancedClient, Charset charset) {
-		this(endpointRequest, ribbonLoadBalancedClient, charset, new BufferedHttpRequestBody(charset));
+		this(endpointRequest, ribbonLoadBalancedClient, charset, new BufferedByteArrayHttpRequestBody(charset));
 	}
 
 	private AsyncRibbonHttpClientRequest(EndpointRequest endpointRequest, AsyncRibbonLoadBalancedClient ribbonLoadBalancedClient, Charset charset,

--- a/java-restify-octet-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/octet/OctetByteArrayMessageConverterTest.java
+++ b/java-restify-octet-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/octet/OctetByteArrayMessageConverterTest.java
@@ -17,7 +17,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -73,12 +73,12 @@ public class OctetByteArrayMessageConverterTest {
 	public void shouldWriteByteArrayBodyToOutputStream() {
 		String body = "request body";
 
-		HttpRequestBody buffer = new BufferedHttpRequestBody();
+		HttpRequestBody buffer = new BufferedByteArrayHttpRequestBody();
 		when(request.body()).thenReturn(buffer);
 
 		converter.write(body.getBytes(), request);
 
-		String output = buffer.asString();
+		String output = new String(buffer.asBytes());
 
 		assertEquals(body, output);
 	}

--- a/java-restify-octet-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/octet/OctetInputStreamMessageConverterTest.java
+++ b/java-restify-octet-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/octet/OctetInputStreamMessageConverterTest.java
@@ -20,7 +20,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -78,13 +78,13 @@ public class OctetInputStreamMessageConverterTest {
 	public void shouldWriteInputStreamBodyToOutputStream() {
 		String body = "request body";
 
-		HttpRequestBody buffer = new BufferedHttpRequestBody();
+		HttpRequestBody buffer = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(buffer);
 
 		converter.write(new ByteArrayInputStream(body.getBytes()), request);
 
-		String output = buffer.asString();
+		String output = new String(buffer.asBytes());
 
 		assertEquals(body, output);
 	}

--- a/java-restify-octet-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/octet/OctetSerializableMessageConverterTest.java
+++ b/java-restify-octet-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/octet/OctetSerializableMessageConverterTest.java
@@ -20,7 +20,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -79,12 +79,12 @@ public class OctetSerializableMessageConverterTest {
 	public void shouldSerializeStringBodyToOutputStream() throws Exception {
 		String body = "request body";
 
-		HttpRequestBody buffer = new BufferedHttpRequestBody();
+		HttpRequestBody buffer = new BufferedByteArrayHttpRequestBody();
 		when(request.body()).thenReturn(buffer);
 
 		converter.write(body, request);
 
-		ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(buffer.asBuffer().array()));
+		ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(buffer.asBytes()));
 		Object output = objectInputStream.readObject();
 
 		assertEquals(body, output);

--- a/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/client/request/HttpErrorResponse.java
+++ b/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/client/request/HttpErrorResponse.java
@@ -36,7 +36,7 @@ import org.springframework.web.client.RestClientResponseException;
 
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.response.StatusCode;
 import com.github.ljtfreitas.restify.http.client.response.BaseHttpClientResponse;
@@ -86,7 +86,7 @@ public class HttpErrorResponse extends BaseHttpClientResponse {
 		}
 
 		@Override
-		public BufferedHttpRequestBody body() {
+		public BufferedByteArrayHttpRequestBody body() {
 			throw new UnsupportedOperationException();
 		}
 

--- a/java-restify-text-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/text/ScalarMessageConverterTest.java
+++ b/java-restify-text-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/text/ScalarMessageConverterTest.java
@@ -16,7 +16,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -58,13 +58,13 @@ public class ScalarMessageConverterTest {
 
 	@Test
 	public void shouldWriteByteValue() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 
 		converter.write((byte) 1, request);
 
-		assertEquals("1", output.asString());
+		assertEquals("1", new String(output.asBytes()));
 	}
 
 	@Test
@@ -90,12 +90,12 @@ public class ScalarMessageConverterTest {
 
 	@Test
 	public void shouldWriteShortValue() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 		converter.write((short) 1, request);
 
-		assertEquals("1", output.asString());
+		assertEquals("1", new String(output.asBytes()));
 	}
 
 	@Test
@@ -120,12 +120,12 @@ public class ScalarMessageConverterTest {
 
 	@Test
 	public void shouldWriteIntegerValue() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 		converter.write((int) 1, request);
 
-		assertEquals("1", output.asString());
+		assertEquals("1", new String(output.asBytes()));
 	}
 
 	@Test
@@ -150,12 +150,12 @@ public class ScalarMessageConverterTest {
 
 	@Test
 	public void shouldWriteLongValue() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 		converter.write((long) 1, request);
 
-		assertEquals("1", output.asString());
+		assertEquals("1", new String(output.asBytes()));
 	}
 
 	@Test
@@ -180,12 +180,12 @@ public class ScalarMessageConverterTest {
 
 	@Test
 	public void shouldWriteFloatValue() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 		converter.write((float) 1.1, request);
 
-		assertEquals("1.1", output.asString());
+		assertEquals("1.1", new String(output.asBytes()));
 	}
 
 	@Test
@@ -210,12 +210,12 @@ public class ScalarMessageConverterTest {
 
 	@Test
 	public void shouldWriteDoubleValue() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 		converter.write((double) 2.2, request);
 
-		assertEquals("2.2", output.asString());
+		assertEquals("2.2", new String(output.asBytes()));
 	}
 
 	@Test
@@ -240,12 +240,12 @@ public class ScalarMessageConverterTest {
 
 	@Test
 	public void shouldWriteBooleanValue() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 		converter.write((boolean) false, request);
 
-		assertEquals("false", output.asString());
+		assertEquals("false", new String(output.asBytes()));
 	}
 
 	@Test
@@ -270,11 +270,11 @@ public class ScalarMessageConverterTest {
 
 	@Test
 	public void shouldWriteCharacterValue() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 		converter.write((char) 'a', request);
 
-		assertEquals("a", output.asString());
+		assertEquals("a", new String(output.asBytes()));
 	}
 }

--- a/java-restify-xml-jaxb-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/xml/JaxbXmlMessageConverterTest.java
+++ b/java-restify-xml-jaxb-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/xml/JaxbXmlMessageConverterTest.java
@@ -21,7 +21,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import com.github.ljtfreitas.restify.http.client.message.Encoding;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
-import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -63,13 +63,13 @@ public class JaxbXmlMessageConverterTest {
 
 	@Test
 	public void shouldWriteXmlMessage() {
-		HttpRequestBody output = new BufferedHttpRequestBody();
+		HttpRequestBody output = new BufferedByteArrayHttpRequestBody();
 
 		when(request.body()).thenReturn(output);
 
 		converter.write(new MyXmlModel("Tiago de Freitas Lima", 31), request);
 
-		assertEquals(xml, output.asString());
+		assertEquals(xml, new String(output.asBytes()));
 	}
 
 	@Test


### PR DESCRIPTION
## Suporte para compressao e descompressao gzip

### Descrição
- Implementa suporte para compressao e descompressao gzip

### Changelog
- Cria novo interceptor *GzipHttpClientRequestInterceptor*. Esse objeto permite comprimir o corpo da requisição e descomprimir o corpo da resposta. Através de um objeto *Builder* é possível ao usuário configurar em quais momentos (requisição, resposta ou ambos) o *gzip* deve ser aplicado. Por padrão o interceptor não irá comprimir o corpo da requisição e tentará descomprimir o corpo da resposta (se o cabeçalho *Content-Encoding* estiver presente)
- Refatora objeto *HttpResponseBody* para expor apenas o *InputStream* de resposta; foi criada uma nova especialização chamada *BufferedHttpResponseBody* para implementações que permite bufferizar a leitura do InputStream (e ler a resposta repetidamente)
