### PR TITLE
[daemon-threa-executor] Daemon threads para requisições assíncronas

### DIFF
--- a/java-restify-call-handler/pom.xml
+++ b/java-restify-call-handler/pom.xml
@@ -38,5 +38,11 @@
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-util-async</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/java-restify-call-handler/src/main/java/com/github/ljtfreitas/restify/http/client/call/async/ExecutorAsyncEndpointCall.java
+++ b/java-restify-call-handler/src/main/java/com/github/ljtfreitas/restify/http/client/call/async/ExecutorAsyncEndpointCall.java
@@ -28,13 +28,14 @@ package com.github.ljtfreitas.restify.http.client.call.async;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
 
 import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 
 public class ExecutorAsyncEndpointCall<T> implements AsyncEndpointCall<T> {
 
-	private static final Executor DEFAULT_EXECUTOR = Executors.newCachedThreadPool();
+	private static final ExecutorService DEFAULT_EXECUTOR = DisposableExecutors.newCachedThreadPool();
 
 	private final Executor executor;
 	private final EndpointCall<T> source;

--- a/java-restify-cdi/src/main/java/com/github/ljtfreitas/restify/cdi/RestifyProxyCdiBeanFactory.java
+++ b/java-restify-cdi/src/main/java/com/github/ljtfreitas/restify/cdi/RestifyProxyCdiBeanFactory.java
@@ -29,7 +29,6 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 import javax.enterprise.inject.Instance;
@@ -46,6 +45,7 @@ import com.github.ljtfreitas.restify.http.client.request.interceptor.EndpointReq
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponseErrorFallback;
 import com.github.ljtfreitas.restify.http.contract.metadata.ContractExpressionResolver;
 import com.github.ljtfreitas.restify.http.contract.metadata.ContractReader;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 
 class RestifyProxyCdiBeanFactory {
 
@@ -97,7 +97,7 @@ class RestifyProxyCdiBeanFactory {
 	}
 
 	private Executor executor() {
-		return get(Executor.class, new AsyncAnnotationLiteral(), () -> Executors.newCachedThreadPool());
+		return get(Executor.class, new AsyncAnnotationLiteral(), DisposableExecutors::newCachedThreadPool);
 	}
 
 

--- a/java-restify-guava/pom.xml
+++ b/java-restify-guava/pom.xml
@@ -33,6 +33,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-util-async</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>26.0-jre</version>

--- a/java-restify-guava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureCallbackEndpointCallHandlerAdapter.java
+++ b/java-restify-guava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureCallbackEndpointCallHandlerAdapter.java
@@ -28,7 +28,6 @@ package com.github.ljtfreitas.restify.http.client.call.handler.guava;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import com.github.ljtfreitas.restify.http.client.call.async.AsyncEndpointCall;
@@ -39,6 +38,7 @@ import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameter;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameters;
 import com.github.ljtfreitas.restify.reflection.JavaType;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.JdkFutureAdapters;
@@ -51,7 +51,7 @@ public class ListenableFutureCallbackEndpointCallHandlerAdapter<T, O> implements
 	private final ListeningExecutorService executorService;
 
 	public ListenableFutureCallbackEndpointCallHandlerAdapter() {
-		this(MoreExecutors.listeningDecorator(Executors.newCachedThreadPool()));
+		this(MoreExecutors.listeningDecorator(DisposableExecutors.newCachedThreadPool()));
 	}
 
 	public ListenableFutureCallbackEndpointCallHandlerAdapter(ListeningExecutorService executorService) {
@@ -104,8 +104,8 @@ public class ListenableFutureCallbackEndpointCallHandlerAdapter<T, O> implements
 			FutureCallback<T> callback = callbackParameter(args);
 
 			Future<T> future = call.executeAsync()
-					.toCompletableFuture()
-						.thenApplyAsync(o -> delegate.handle(() -> o, args), executorService);
+					.thenApplyAsync(o -> delegate.handle(() -> o, args), executorService)
+						.toCompletableFuture();
 
 			ListenableFuture<T> listenableFuture = JdkFutureAdapters.listenInPoolThread(future, executorService);
 			Futures.addCallback(listenableFuture, callback, executorService);

--- a/java-restify-guava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureEndpointCallHandlerAdapter.java
+++ b/java-restify-guava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureEndpointCallHandlerAdapter.java
@@ -27,7 +27,6 @@ package com.github.ljtfreitas.restify.http.client.call.handler.guava;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
@@ -37,6 +36,7 @@ import com.github.ljtfreitas.restify.http.client.call.handler.async.AsyncEndpoin
 import com.github.ljtfreitas.restify.http.client.call.handler.async.AsyncEndpointCallHandlerAdapter;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
 import com.github.ljtfreitas.restify.reflection.JavaType;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 import com.google.common.util.concurrent.JdkFutureAdapters;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -47,7 +47,7 @@ public class ListenableFutureEndpointCallHandlerAdapter<T, O> implements AsyncEn
 	private final ListeningExecutorService executorService;
 
 	public ListenableFutureEndpointCallHandlerAdapter() {
-		this(MoreExecutors.listeningDecorator(Executors.newCachedThreadPool()));
+		this(MoreExecutors.listeningDecorator(DisposableExecutors.newCachedThreadPool()));
 	}
 
 	public ListenableFutureEndpointCallHandlerAdapter(ListeningExecutorService executorService) {

--- a/java-restify-guava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureTaskEndpointCallHandlerAdapter.java
+++ b/java-restify-guava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureTaskEndpointCallHandlerAdapter.java
@@ -27,13 +27,13 @@ package com.github.ljtfreitas.restify.http.client.call.handler.guava;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.concurrent.Executors;
 
 import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
 import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
 import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
 import com.github.ljtfreitas.restify.reflection.JavaType;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 import com.google.common.util.concurrent.ListenableFutureTask;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -43,7 +43,7 @@ public class ListenableFutureTaskEndpointCallHandlerAdapter<T, O> implements End
 	private final ListeningExecutorService executorService;
 
 	public ListenableFutureTaskEndpointCallHandlerAdapter() {
-		this(MoreExecutors.listeningDecorator(Executors.newCachedThreadPool()));
+		this(MoreExecutors.listeningDecorator(DisposableExecutors.newCachedThreadPool()));
 	}
 
 	public ListenableFutureTaskEndpointCallHandlerAdapter(ListeningExecutorService executorService) {

--- a/java-restify-guava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureCallbackEndpointCallHandlerAdapterTest.java
+++ b/java-restify-guava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureCallbackEndpointCallHandlerAdapterTest.java
@@ -52,9 +52,9 @@ public class ListenableFutureCallbackEndpointCallHandlerAdapterTest {
 		when(delegate.returnType())
 			.thenReturn(JavaType.of(String.class));
 
-		EndpointMethodParameters parameters = new EndpointMethodParameters();
-		parameters.put(new EndpointMethodParameter(0, "callback",
-				new SimpleParameterizedType(FutureCallback.class, null, String.class), EndpointMethodParameterType.ENDPOINT_CALLBACK));
+		EndpointMethodParameters parameters = new EndpointMethodParameters()
+				.put(new EndpointMethodParameter(0, "callback",
+						new SimpleParameterizedType(FutureCallback.class, null, String.class), EndpointMethodParameterType.ENDPOINT_CALLBACK));
 
 		futureWithCallbackEndpointMethod = new SimpleEndpointMethod(SomeType.class.getMethod("futureWithCallback", FutureCallback.class), 
 				parameters);

--- a/java-restify-hateoas/pom.xml
+++ b/java-restify-hateoas/pom.xml
@@ -32,6 +32,12 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-util-async</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>java-restify-reflection</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>

--- a/java-restify-hateoas/src/main/java/com/github/ljtfreitas/restify/http/client/hateoas/browser/HypermediaBrowserBuilder.java
+++ b/java-restify-hateoas/src/main/java/com/github/ljtfreitas/restify/http/client/hateoas/browser/HypermediaBrowserBuilder.java
@@ -35,7 +35,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import javax.net.ssl.HostnameVerifier;
@@ -78,6 +77,7 @@ import com.github.ljtfreitas.restify.http.client.retry.RetryCondition.ThrowableR
 import com.github.ljtfreitas.restify.http.client.retry.RetryConfiguration;
 import com.github.ljtfreitas.restify.http.client.retry.async.AsyncRetryableEndpointRequestExecutor;
 import com.github.ljtfreitas.restify.util.Tryable;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 
 public class HypermediaBrowserBuilder {
 
@@ -665,7 +665,7 @@ public class HypermediaBrowserBuilder {
 
 			private final RetryBuilder context;
 
-			private ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(10);
+			private ScheduledExecutorService scheduler = DisposableExecutors.newScheduledThreadPool(10);
 
 			private AsyncRetryConfigurationBuilder(RetryBuilder context) {
 				this.context = context;
@@ -682,7 +682,7 @@ public class HypermediaBrowserBuilder {
 
 		private final HypermediaBrowserBuilder context;
 
-		private Executor pool = Executors.newCachedThreadPool();
+		private Executor pool = DisposableExecutors.newCachedThreadPool();
 
 		private AsyncBuilder(HypermediaBrowserBuilder context) {
 			this.context = context;

--- a/java-restify-http-client/pom.xml
+++ b/java-restify-http-client/pom.xml
@@ -32,5 +32,11 @@
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-util-async</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/async/AsyncHttpClientRequestAdapter.java
+++ b/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/async/AsyncHttpClientRequestAdapter.java
@@ -30,7 +30,6 @@ import java.nio.charset.Charset;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 
 import com.github.ljtfreitas.restify.http.client.HttpClientException;
 import com.github.ljtfreitas.restify.http.client.message.Header;
@@ -39,10 +38,11 @@ import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
 import com.github.ljtfreitas.restify.http.client.response.HttpClientResponse;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 
 public class AsyncHttpClientRequestAdapter implements AsyncHttpClientRequest  {
 
-	private static final Executor DEFAULT_EXECUTOR = Executors.newCachedThreadPool();
+	private static final Executor DEFAULT_EXECUTOR = DisposableExecutors.newCachedThreadPool();
 
 	private final HttpClientRequest source;
 	private final Executor executor;

--- a/java-restify-netflix/pom.xml
+++ b/java-restify-netflix/pom.xml
@@ -50,6 +50,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-util-async</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.netflix.ribbon</groupId>
 			<artifactId>ribbon-core</artifactId>
 			<version>${netflix.ribbon.version}</version>

--- a/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/async/AsyncRibbonHttpClientRequestFactoryTest.java
+++ b/java-restify-netflix/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/async/AsyncRibbonHttpClientRequestFactoryTest.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -47,7 +46,7 @@ import com.github.ljtfreitas.restify.http.client.request.async.DefaultAsyncEndpo
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponseReader;
 import com.github.ljtfreitas.restify.http.client.response.HttpClientResponse;
-import com.github.ljtfreitas.restify.http.netflix.client.request.ribbon.async.AsyncRibbonHttpClientRequestFactory;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.BaseLoadBalancer;
@@ -80,7 +79,7 @@ public class AsyncRibbonHttpClientRequestFactoryTest {
 
 		HttpMessageConverters messageConverters = new HttpMessageConverters(Arrays.asList(new JacksonMessageConverter<>(), new JaxBXmlMessageConverter<>()));
 
-		executor = Executors.newCachedThreadPool();
+		executor = DisposableExecutors.newSingleThreadExecutor();
 
 		requestExecutor = new DefaultAsyncEndpointRequestExecutor(executor, asyncRibbonHttpClientRequestFactory, new EndpointRequestWriter(messageConverters),
 				new EndpointResponseReader(messageConverters), null);

--- a/java-restify-oauth2-access-token-cache-jcache/pom.xml
+++ b/java-restify-oauth2-access-token-cache-jcache/pom.xml
@@ -21,6 +21,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-util-async</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>javax.cache</groupId>
 			<artifactId>cache-api</artifactId>
 			<version>1.1.0</version>

--- a/java-restify-oauth2-access-token-cache-jcache/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/async/JCacheAsyncAccessTokenStorageTest.java
+++ b/java-restify-oauth2-access-token-cache-jcache/src/test/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/async/JCacheAsyncAccessTokenStorageTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 import java.net.URI;
 import java.security.Principal;
 import java.time.Duration;
-import java.util.concurrent.Executors;
 
 import javax.cache.CacheManager;
 import javax.cache.Caching;
@@ -23,6 +22,7 @@ import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.C
 import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.GrantProperties;
 import com.github.ljtfreitas.restify.http.client.request.authentication.oauth2.OAuth2AuthenticatedEndpointRequest;
 import com.github.ljtfreitas.restify.util.Tryable;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 
 public class JCacheAsyncAccessTokenStorageTest {
 
@@ -49,7 +49,7 @@ public class JCacheAsyncAccessTokenStorageTest {
 
 		cacheManager = Caching.getCachingProvider().getCacheManager();
 
-		jCacheAsyncAccessTokenStorage = new JCacheAsyncAccessTokenStorage(Executors.newSingleThreadExecutor(), cacheManager);
+		jCacheAsyncAccessTokenStorage = new JCacheAsyncAccessTokenStorage(DisposableExecutors.newSingleThreadExecutor(), cacheManager);
 	}
 
 	@After

--- a/java-restify-oauth2-authentication/pom.xml
+++ b/java-restify-oauth2-authentication/pom.xml
@@ -41,6 +41,12 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-util-async</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>java-restify-form-encoded-multipart-converter</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AuthorizationServerHttpClientFactory.java
+++ b/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AuthorizationServerHttpClientFactory.java
@@ -28,7 +28,6 @@ package com.github.ljtfreitas.restify.http.client.request.authentication.oauth2;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import com.github.ljtfreitas.restify.http.client.jdk.HttpClientRequestConfiguration;
 import com.github.ljtfreitas.restify.http.client.jdk.JdkHttpClientRequestFactory;
@@ -48,6 +47,7 @@ import com.github.ljtfreitas.restify.http.client.request.async.AsyncHttpClientRe
 import com.github.ljtfreitas.restify.http.client.request.async.DefaultAsyncEndpointRequestExecutor;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponseReader;
 import com.github.ljtfreitas.restify.spi.Provider;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 
 public class AuthorizationServerHttpClientFactory {
 
@@ -78,7 +78,7 @@ public class AuthorizationServerHttpClientFactory {
 	}
 
 	public AsyncEndpointRequestExecutor createAsync() {
-		ExecutorService threadPool = Executors.newCachedThreadPool();
+		ExecutorService threadPool = DisposableExecutors.newCachedThreadPool();
 		return httpClientRequestFactory instanceof AsyncHttpClientRequestFactory ?
 			new DefaultAsyncEndpointRequestExecutor(threadPool, (AsyncHttpClientRequestFactory) httpClientRequestFactory,
 					endpointRequestWriter(converters), endpointResponseReader(converters), doCreate()) :

--- a/java-restify-retry/pom.xml
+++ b/java-restify-retry/pom.xml
@@ -34,6 +34,12 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-util-async</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>java-restify-reflection</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/java-restify-retry/src/test/java/com/github/ljtfreitas/restify/http/client/retry/async/AsyncRetryableEndpointRequestExecutorTest.java
+++ b/java-restify-retry/src/test/java/com/github/ljtfreitas/restify/http/client/retry/async/AsyncRetryableEndpointRequestExecutorTest.java
@@ -16,7 +16,6 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.hamcrest.BaseMatcher;
@@ -43,6 +42,7 @@ import com.github.ljtfreitas.restify.http.client.response.EndpointResponseUnauth
 import com.github.ljtfreitas.restify.http.client.retry.BackOff;
 import com.github.ljtfreitas.restify.http.client.retry.Retry;
 import com.github.ljtfreitas.restify.http.client.retry.RetryConfiguration;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AsyncRetryableEndpointRequestExecutorTest {
@@ -59,7 +59,7 @@ public class AsyncRetryableEndpointRequestExecutorTest {
 
 	@Before
 	public void setup() {
-		scheduler = Executors.newSingleThreadScheduledExecutor();
+		scheduler = DisposableExecutors.newSingleThreadScheduledExecutor();
 
 		executor = new AsyncRetryableEndpointRequestExecutor(asyncEndpointRequestExecutor, scheduler);
 	}

--- a/java-restify-retry/src/test/java/com/github/ljtfreitas/restify/http/client/retry/async/AsyncRetryableLoopTest.java
+++ b/java-restify-retry/src/test/java/com/github/ljtfreitas/restify/http/client/retry/async/AsyncRetryableLoopTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executors;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -29,6 +28,7 @@ import com.github.ljtfreitas.restify.http.client.response.EndpointResponseIntern
 import com.github.ljtfreitas.restify.http.client.retry.BackOffPolicy;
 import com.github.ljtfreitas.restify.http.client.retry.RetryConditionMatcher;
 import com.github.ljtfreitas.restify.http.client.retry.RetryConfiguration;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AsyncRetryableLoopTest {
@@ -53,7 +53,7 @@ public class AsyncRetryableLoopTest {
 
 		when(backOffPolicy.backOff(anyInt())).thenReturn(Duration.ZERO);
 
-		asyncRetryableLoop = new AsyncRetryableLoop(Executors.newSingleThreadScheduledExecutor(), new RetryConditionMatcher(configuration.conditions()),
+		asyncRetryableLoop = new AsyncRetryableLoop(DisposableExecutors.newSingleThreadScheduledExecutor(), new RetryConditionMatcher(configuration.conditions()),
 				backOffPolicy);
 	}
 

--- a/java-restify-rxjava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaSingleEndpointCallHandlerAdapterTest.java
+++ b/java-restify-rxjava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaSingleEndpointCallHandlerAdapterTest.java
@@ -8,14 +8,17 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
-import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.async.AsyncEndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.async.AsyncEndpointCallHandler;
 import com.github.ljtfreitas.restify.reflection.JavaType;
 
 import rx.Scheduler;
@@ -27,10 +30,10 @@ import rx.schedulers.Schedulers;
 public class RxJavaSingleEndpointCallHandlerAdapterTest {
 
 	@Mock
-	private EndpointCallHandler<String, String> delegate;
+	private AsyncEndpointCallHandler<String, String> delegate;
 
 	@Mock
-	private EndpointCall<String> endpointCallMock;
+	private AsyncEndpointCall<String> asyncEndpointCall;
 
 	private RxJavaSingleEndpointCallHandlerAdapter<String, String> adapter;
 
@@ -69,15 +72,20 @@ public class RxJavaSingleEndpointCallHandlerAdapterTest {
 
 	@Test
 	public void shouldCreateHandlerFromEndpointMethodWithRxJavaSingleReturnType() throws Exception {
-		EndpointCallHandler<Single<String>, String> handler = adapter
-				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("single")), delegate);
+		AsyncEndpointCallHandler<Single<String>, String> handler = adapter
+				.adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("single")), delegate);
 
 		String result = "single result";
 
-		when(delegate.handle(any(), anyVararg()))
-			.thenReturn(result);
+		CompletableFuture<String> resultAsFuture = CompletableFuture.completedFuture(result);
 
-		Single<String> single = handler.handle(endpointCallMock, null);
+		when(asyncEndpointCall.executeAsync())
+			.thenReturn(resultAsFuture);
+		
+		when(delegate.handle(any(), anyVararg()))
+			.thenReturn(resultAsFuture.join());
+
+		Single<String> single = handler.handleAsync(asyncEndpointCall, null);
 
 		assertNotNull(single);
 
@@ -92,15 +100,18 @@ public class RxJavaSingleEndpointCallHandlerAdapterTest {
 
 	@Test
 	public void shouldSubscribeErrorOnSingleWhenCreatedHandlerWithRxJavaSingleReturnTypeThrowException() throws Exception {
-		EndpointCallHandler<Single<String>, String> handler = adapter
-				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("single")), delegate);
+		AsyncEndpointCallHandler<Single<String>, String> handler = adapter
+				.adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("single")), delegate);
 
 		RuntimeException exception = new RuntimeException();
 
-		when(delegate.handle(any(), anyVararg()))
-			.thenThrow(exception);
+		CompletableFuture<String> resultAsFuture = new CompletableFuture<>();
+		resultAsFuture.completeExceptionally(exception);
 
-		Single<String> single = handler.handle(endpointCallMock, null);
+		when(asyncEndpointCall.executeAsync())
+			.thenReturn(resultAsFuture);
+
+		Single<String> single = handler.handleAsync(asyncEndpointCall, null);
 
 		assertNotNull(single);
 
@@ -108,7 +119,7 @@ public class RxJavaSingleEndpointCallHandlerAdapterTest {
 
 		single.subscribeOn(scheduler).subscribe(subscriber);
 
-		subscriber.assertError(exception);
+		subscriber.assertError(ExecutionException.class);
 	}
 
 	interface SomeType {

--- a/java-restify-util-async/pom.xml
+++ b/java-restify-util-async/pom.xml
@@ -1,0 +1,9 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.github.ljtfreitas</groupId>
+		<artifactId>java-restify-group</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>java-restify-util-async</artifactId>
+</project>

--- a/java-restify-util-async/src/main/java/com/github/ljtfreitas/restify/util/async/DaemonThreadFactory.java
+++ b/java-restify-util-async/src/main/java/com/github/ljtfreitas/restify/util/async/DaemonThreadFactory.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.util.async;
+
+import java.util.concurrent.ThreadFactory;
+
+public class DaemonThreadFactory implements ThreadFactory {
+
+	private static final DaemonThreadFactory INSTANCE = new DaemonThreadFactory();
+
+	@Override
+	public Thread newThread(Runnable r) {
+		Thread newThread = new Thread(r);
+		newThread.setDaemon(true);
+		return newThread;
+	}
+
+	public static ThreadFactory instance() {
+		return INSTANCE;
+	}
+}

--- a/java-restify-util-async/src/main/java/com/github/ljtfreitas/restify/util/async/DisposableExecutors.java
+++ b/java-restify-util-async/src/main/java/com/github/ljtfreitas/restify/util/async/DisposableExecutors.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.util.async;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class DisposableExecutors {
+
+	public static ExecutorService newCachedThreadPool() {
+		return disposable(Executors.newCachedThreadPool(DaemonThreadFactory.instance()));
+	}
+
+	public static ExecutorService newSingleThreadExecutor() {
+		return disposable(Executors.newSingleThreadExecutor(DaemonThreadFactory.instance()));
+	}
+
+	public static ScheduledExecutorService newSingleThreadScheduledExecutor() {
+		return (ScheduledExecutorService) disposable(Executors.newSingleThreadScheduledExecutor(DaemonThreadFactory.instance()));
+	}
+
+	public static ScheduledExecutorService newScheduledThreadPool(int size) {
+		return (ScheduledExecutorService) disposable(Executors.newScheduledThreadPool(size, DaemonThreadFactory.instance()));
+	}
+
+	private static ExecutorService disposable(ExecutorService executorService) {
+		Runtime.getRuntime().addShutdownHook(new Thread(executorService::shutdownNow));
+		return executorService;
+	}
+}

--- a/java-restify/pom.xml
+++ b/java-restify/pom.xml
@@ -24,6 +24,11 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-util-async</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>java-restify-reflection</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
@@ -36,7 +36,6 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import javax.net.ssl.HostnameVerifier;
@@ -120,6 +119,7 @@ import com.github.ljtfreitas.restify.http.contract.metadata.DefaultContractReade
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointTarget;
 import com.github.ljtfreitas.restify.http.contract.metadata.SimpleContractExpressionResolver;
 import com.github.ljtfreitas.restify.spi.Provider;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 
 public class RestifyProxyBuilder {
 
@@ -904,7 +904,7 @@ public class RestifyProxyBuilder {
 
 			private final RetryBuilder context;
 
-			private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+			private ScheduledExecutorService scheduler = DisposableExecutors.newSingleThreadScheduledExecutor();
 
 			private AsyncRetryConfigurationBuilder(RetryBuilder context) {
 				this.context = context;

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/jdk/FutureTaskEndpointCallHandlerAdapterTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/jdk/FutureTaskEndpointCallHandlerAdapterTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
 
 import org.junit.Before;
@@ -22,6 +21,7 @@ import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
 import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
 import com.github.ljtfreitas.restify.http.client.call.handler.SimpleEndpointMethod;
 import com.github.ljtfreitas.restify.reflection.JavaType;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FutureTaskEndpointCallHandlerAdapterTest {
@@ -33,7 +33,7 @@ public class FutureTaskEndpointCallHandlerAdapterTest {
 
 	@Before
 	public void setup() {
-		ExecutorService executor = Executors.newSingleThreadExecutor();
+		ExecutorService executor = DisposableExecutors.newSingleThreadExecutor();
 
 		adapter = new FutureTaskEndpointCallHandlerAdapter<>(executor);
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
 		<module>java-restify-oauth2-access-token-cache-caffeine</module>
 
 		<module>java-restify-util</module>
+		<module>java-restify-util-async</module>
 	</modules>
 
 	<dependencies>


### PR DESCRIPTION
## Descrição

- Implementa o uso de *daemon threads* para requisições assíncronas

## Changelog

- Implementa fábrica para criação de *daemon threads*, utilizada em todos os processamentos assíncronos
- Implementa *shutdown hook* para as threads criadas pelo *java-restify*

