### PR TITLE
[refactor-reactive-collection-types] Tipos reativos - sequências e respostas únicas

### DIFF
--- a/java-restify-reactor/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/reactor/MonoEndpointCallHandlerAdapterTest.java
+++ b/java-restify-reactor/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/reactor/MonoEndpointCallHandlerAdapterTest.java
@@ -115,6 +115,24 @@ public class MonoEndpointCallHandlerAdapterTest {
 			.verify();
 	}
 
+	@Test
+	public void shouldCreateSyncHandlerFromEndpointMethodWithMonoReturnType() throws Exception {
+		EndpointCallHandler<Mono<String>, String> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("mono")), delegate);
+
+		when(asyncEndpointCall.execute())
+			.thenReturn(asyncResult);
+
+		Mono<String> mono = handler.handle(asyncEndpointCall, null);
+
+		assertNotNull(mono);
+
+		StepVerifier.create(mono)
+			.expectNext(asyncResult)
+			.expectComplete()
+			.verify();
+	}
+
 	interface SomeType {
 
 		Mono<String> mono();

--- a/java-restify-rxjava-2/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava2/RxJava2FlowableEndpointCallHandlerAdapter.java
+++ b/java-restify-rxjava-2/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava2/RxJava2FlowableEndpointCallHandlerAdapter.java
@@ -27,6 +27,9 @@ package com.github.ljtfreitas.restify.http.client.call.handler.rxjava2;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
 import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
 import com.github.ljtfreitas.restify.http.client.call.async.AsyncEndpointCall;
@@ -40,7 +43,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Scheduler;
 import io.reactivex.schedulers.Schedulers;
 
-public class RxJava2FlowableEndpointCallHandlerAdapter<T, O> implements AsyncEndpointCallHandlerAdapter<Flowable<T>, T, O> {
+public class RxJava2FlowableEndpointCallHandlerAdapter<T, O> implements AsyncEndpointCallHandlerAdapter<Flowable<T>, Collection<T>, O> {
 
 	public final Scheduler scheduler;
 
@@ -59,7 +62,7 @@ public class RxJava2FlowableEndpointCallHandlerAdapter<T, O> implements AsyncEnd
 
 	@Override
 	public JavaType returnType(EndpointMethod endpointMethod) {
-		return JavaType.of(unwrap(endpointMethod.returnType()));
+		return JavaType.of(JavaType.parameterizedType(Collection.class, unwrap(endpointMethod.returnType())));
 	}
 
 	private Type unwrap(JavaType declaredReturnType) {
@@ -69,34 +72,43 @@ public class RxJava2FlowableEndpointCallHandlerAdapter<T, O> implements AsyncEnd
 	}
 
 	@Override
-	public AsyncEndpointCallHandler<Flowable<T>, O> adaptAsync(EndpointMethod endpointMethod, EndpointCallHandler<T, O> handler) {
+	public AsyncEndpointCallHandler<Flowable<T>, O> adaptAsync(EndpointMethod endpointMethod, EndpointCallHandler<Collection<T>, O> handler) {
 		return new RxJava2FlowableEndpointCallHandler(handler);
 	}
 
 	private class RxJava2FlowableEndpointCallHandler implements AsyncEndpointCallHandler<Flowable<T>, O> {
 
-		private EndpointCallHandler<T, O> delegate;
+		private EndpointCallHandler<Collection<T>, O> delegate;
 
-		public RxJava2FlowableEndpointCallHandler(EndpointCallHandler<T, O> delegate) {
-			this.delegate = delegate;
+		public RxJava2FlowableEndpointCallHandler(EndpointCallHandler<Collection<T>, O> handler) {
+			this.delegate = handler;
 		}
 
 		@Override
 		public JavaType returnType() {
 			return delegate.returnType();
 		}
-
+		
 		@Override
 		public Flowable<T> handle(EndpointCall<O> call, Object[] args) {
-			return Flowable.fromCallable(() -> delegate.handle(call, args))
+			return Flowable.defer(() -> Flowable.fromIterable(delegate.handle(call, args)))
 					.subscribeOn(scheduler);
 		}
 
 		@Override
 		public Flowable<T> handleAsync(AsyncEndpointCall<O> call, Object[] args) {
 			return Flowable.fromFuture(call.executeAsync().toCompletableFuture())
-					.map(o -> delegate.handle(() -> o, args))
-						.subscribeOn(scheduler);
+					.onErrorResumeNext(this::handleAsyncException)
+						.map(o -> delegate.handle(() -> o, args))
+							.flatMap(Flowable::fromIterable)
+								.subscribeOn(scheduler);
+		}
+
+		private Flowable<O> handleAsyncException(Throwable throwable) {
+			return Flowable.error(() ->
+				(ExecutionException.class.equals(throwable.getClass()) || CompletionException.class.equals(throwable.getClass())) ?
+						throwable.getCause() :
+							throwable);
 		}
 	}
 }

--- a/java-restify-rxjava-2/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava2/RxJava2MaybeEndpointCallHandlerAdapter.java
+++ b/java-restify-rxjava-2/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava2/RxJava2MaybeEndpointCallHandlerAdapter.java
@@ -27,7 +27,10 @@ package com.github.ljtfreitas.restify.http.client.call.handler.rxjava2;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
 import com.github.ljtfreitas.restify.http.client.call.async.AsyncEndpointCall;
 import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
 import com.github.ljtfreitas.restify.http.client.call.handler.async.AsyncEndpointCallHandler;
@@ -86,10 +89,24 @@ public class RxJava2MaybeEndpointCallHandlerAdapter<T, O> implements AsyncEndpoi
 		}
 
 		@Override
+		public Maybe<T> handle(EndpointCall<O> call, Object[] args) {
+			return Maybe.fromCallable(() -> delegate.handle(call, args))
+				.subscribeOn(scheduler);
+		}
+
+		@Override
 		public Maybe<T> handleAsync(AsyncEndpointCall<O> call, Object[] args) {
 			return Maybe.fromFuture(call.executeAsync().toCompletableFuture())
+					.onErrorResumeNext(this::handleAsyncException)
 					.map(o -> delegate.handle(() -> o, args))
 						.subscribeOn(scheduler);
+		}
+
+		private Maybe<O> handleAsyncException(Throwable throwable) {
+			return Maybe.error(() ->
+				(ExecutionException.class.equals(throwable.getClass()) || CompletionException.class.equals(throwable.getClass())) ?
+						throwable.getCause() :
+							throwable);
 		}
 	}
 }

--- a/java-restify-rxjava-2/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava2/RxJava2ObservableEndpointCallHandlerAdapter.java
+++ b/java-restify-rxjava-2/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava2/RxJava2ObservableEndpointCallHandlerAdapter.java
@@ -27,7 +27,11 @@ package com.github.ljtfreitas.restify.http.client.call.handler.rxjava2;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
 import com.github.ljtfreitas.restify.http.client.call.async.AsyncEndpointCall;
 import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
 import com.github.ljtfreitas.restify.http.client.call.handler.async.AsyncEndpointCallHandler;
@@ -39,7 +43,7 @@ import io.reactivex.Observable;
 import io.reactivex.Scheduler;
 import io.reactivex.schedulers.Schedulers;
 
-public class RxJava2ObservableEndpointCallHandlerAdapter<T, O> implements AsyncEndpointCallHandlerAdapter<Observable<T>, T, O> {
+public class RxJava2ObservableEndpointCallHandlerAdapter<T, O> implements AsyncEndpointCallHandlerAdapter<Observable<T>, Collection<T>, O> {
 
 	public final Scheduler scheduler;
 
@@ -58,7 +62,7 @@ public class RxJava2ObservableEndpointCallHandlerAdapter<T, O> implements AsyncE
 
 	@Override
 	public JavaType returnType(EndpointMethod endpointMethod) {
-		return JavaType.of(unwrap(endpointMethod.returnType()));
+		return JavaType.of(JavaType.parameterizedType(Collection.class, unwrap(endpointMethod.returnType())));
 	}
 
 	private Type unwrap(JavaType declaredReturnType) {
@@ -68,16 +72,16 @@ public class RxJava2ObservableEndpointCallHandlerAdapter<T, O> implements AsyncE
 	}
 
 	@Override
-	public AsyncEndpointCallHandler<Observable<T>, O> adaptAsync(EndpointMethod endpointMethod, EndpointCallHandler<T, O> handler) {
+	public AsyncEndpointCallHandler<Observable<T>, O> adaptAsync(EndpointMethod endpointMethod, EndpointCallHandler<Collection<T>, O> handler) {
 		return new RxJava2ObservableEndpointCallHandler(handler);
 	}
 
 	private class RxJava2ObservableEndpointCallHandler implements AsyncEndpointCallHandler<Observable<T>, O> {
 
-		private EndpointCallHandler<T, O> delegate;
+		private EndpointCallHandler<Collection<T>, O> delegate;
 
-		public RxJava2ObservableEndpointCallHandler(EndpointCallHandler<T, O> delegate) {
-			this.delegate = delegate;
+		public RxJava2ObservableEndpointCallHandler(EndpointCallHandler<Collection<T>, O> handler) {
+			this.delegate = handler;
 		}
 
 		@Override
@@ -86,10 +90,25 @@ public class RxJava2ObservableEndpointCallHandlerAdapter<T, O> implements AsyncE
 		}
 
 		@Override
+		public Observable<T> handle(EndpointCall<O> call, Object[] args) {
+			return Observable.defer(() -> Observable.fromIterable(delegate.handle(call, args)))
+				.subscribeOn(scheduler);
+		}
+
+		@Override
 		public Observable<T> handleAsync(AsyncEndpointCall<O> call, Object[] args) {
 			return Observable.fromFuture(call.executeAsync().toCompletableFuture())
+				.onErrorResumeNext(this::handleAsyncException)
 				.map(o -> delegate.handle(() -> o, args))
-					.subscribeOn(scheduler);
+					.flatMap(Observable::fromIterable)
+						.subscribeOn(scheduler);
+		}
+
+		private Observable<O> handleAsyncException(Throwable throwable) {
+			return Observable.error(() ->
+				(ExecutionException.class.equals(throwable.getClass()) || CompletionException.class.equals(throwable.getClass())) ?
+						throwable.getCause() :
+							throwable);
 		}
 	}
 }

--- a/java-restify-rxjava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaSingleEndpointCallHandlerAdapter.java
+++ b/java-restify-rxjava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaSingleEndpointCallHandlerAdapter.java
@@ -27,7 +27,10 @@ package com.github.ljtfreitas.restify.http.client.call.handler.rxjava;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
 import com.github.ljtfreitas.restify.http.client.call.async.AsyncEndpointCall;
 import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
 import com.github.ljtfreitas.restify.http.client.call.handler.async.AsyncEndpointCallHandler;
@@ -86,10 +89,24 @@ public class RxJavaSingleEndpointCallHandlerAdapter<T, O> implements AsyncEndpoi
 		}
 
 		@Override
+		public Single<T> handle(EndpointCall<O> call, Object[] args) {
+			return Single.fromCallable(() -> delegate.handle(call, args))
+					.subscribeOn(scheduler);
+		}
+
+		@Override
 		public Single<T> handleAsync(AsyncEndpointCall<O> call, Object[] args) {
 			return Single.from(call.executeAsync().toCompletableFuture())
-				.map(o -> delegate.handle(() -> o, args))
-					.subscribeOn(scheduler);
+				.onErrorResumeNext(this::handleAsyncException)
+					.map(o -> delegate.handle(() -> o, args))
+						.subscribeOn(scheduler);
+		}
+
+		private Single<O> handleAsyncException(Throwable throwable) {
+			return Single.error(
+					(ExecutionException.class.equals(throwable.getClass()) || CompletionException.class.equals(throwable.getClass())) ?
+						throwable.getCause() :
+							throwable);
 		}
 	}
 }

--- a/java-restify-rxjava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaCompletableEndpointCallHandlerFactoryTest.java
+++ b/java-restify-rxjava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaCompletableEndpointCallHandlerFactoryTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -15,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.call.async.AsyncEndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
 import com.github.ljtfreitas.restify.http.client.call.handler.async.AsyncEndpointCallHandler;
 
 import rx.Completable;
@@ -23,7 +23,7 @@ import rx.observers.AssertableSubscriber;
 import rx.schedulers.Schedulers;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RxJavaCompletableEndpointCallHandlerAdapterTest {
+public class RxJavaCompletableEndpointCallHandlerFactoryTest {
 
 	@Mock
 	private AsyncEndpointCall<Void> endpointCall;
@@ -81,13 +81,32 @@ public class RxJavaCompletableEndpointCallHandlerAdapterTest {
 		when(endpointCall.executeAsync())
 			.thenReturn(future);
 
+		Completable completable = handler.handleAsync(endpointCall, null);
+
+		assertNotNull(completable);
+
+		AssertableSubscriber<Void> subscriber = completable.subscribeOn(scheduler).test();
+
+		subscriber.assertError(exception);
+	}
+	
+	@Test
+	public void shouldCreateSyncHandlerFromEndpointMethodWithRxJavaCompletableReturnType() throws Exception {
+		EndpointCallHandler<Completable, Void> handler = adapter
+				.create(new SimpleEndpointMethod(SomeType.class.getMethod("completable")));
+
+		when(endpointCall.execute())
+			.thenReturn(null);
+
 		Completable completable = handler.handle(endpointCall, null);
 
 		assertNotNull(completable);
 
 		AssertableSubscriber<Void> subscriber = completable.subscribeOn(scheduler).test();
 
-		subscriber.assertError(ExecutionException.class);
+		subscriber.assertCompleted()
+			.assertNoErrors()
+			.assertNoValues();
 	}
 
 	interface SomeType {

--- a/java-restify-rxjava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaObservableEndpointCallHandlerAdapterTest.java
+++ b/java-restify-rxjava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaObservableEndpointCallHandlerAdapterTest.java
@@ -4,8 +4,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -14,7 +22,9 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.async.AsyncEndpointCall;
 import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.async.AsyncEndpointCallHandler;
 import com.github.ljtfreitas.restify.reflection.JavaType;
 
 import rx.Observable;
@@ -26,12 +36,12 @@ import rx.schedulers.Schedulers;
 public class RxJavaObservableEndpointCallHandlerAdapterTest {
 
 	@Mock
-	private EndpointCallHandler<String, String> delegate;
+	private AsyncEndpointCallHandler<Collection<String>, Collection<String>> delegate;
 
 	@Mock
-	private EndpointCall<String> endpointCallMock;
+	private AsyncEndpointCall<Collection<String>> endpointCallMock;
 
-	private RxJavaObservableEndpointCallHandlerAdapter<String, String> adapter;
+	private RxJavaObservableEndpointCallHandlerAdapter<String, Collection<String>> adapter;
 
 	private Scheduler scheduler;
 
@@ -56,49 +66,56 @@ public class RxJavaObservableEndpointCallHandlerAdapterTest {
 	}
 
 	@Test
-	public void shouldReturnArgumentTypeOfRxJavObservable() throws Exception {
-		assertEquals(JavaType.of(String.class), adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("observable"))));
+	public void shouldReturnCollectionWithArgumentTypeOfRxJavObservable() throws Exception {
+		assertEquals(JavaType.of(JavaType.parameterizedType(Collection.class, String.class)), adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("observable"))));
 	}
 
 	@Test
-	public void shouldReturnObjectTypeWhenRxJavaObservableIsNotParameterized() throws Exception {
-		assertEquals(JavaType.of(Object.class), adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbObservable"))));
+	public void shouldReturnCollectionWithObjectTypeWhenRxJavaObservableIsNotParameterized() throws Exception {
+		assertEquals(JavaType.of(JavaType.parameterizedType(Collection.class, Object.class)), adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbObservable"))));
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void shouldCreateHandlerFromEndpointMethodWithRxJavaObservableReturnType() throws Exception {
-		EndpointCallHandler<Observable<String>, String> handler = adapter
-				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("observable")), delegate);
+		AsyncEndpointCallHandler<Observable<String>, Collection<String>> handler = adapter
+				.adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("observable")), delegate);
 
 		String result = "observable result";
 
-		when(delegate.handle(endpointCallMock, null))
-			.thenReturn(result);
+		when(endpointCallMock.executeAsync())
+			.thenReturn(CompletableFuture.completedFuture(Arrays.asList(result)));
 
-		Observable<String> observable = handler.handle(endpointCallMock, null);
+		when(delegate.handle(notNull(EndpointCall.class), anyVararg()))
+			.then(i -> i.getArgumentAt(0, EndpointCall.class).execute());
+
+		Observable<String> observable = handler.handleAsync(endpointCallMock, null);
 
 		assertNotNull(observable);
 
 		AssertableSubscriber<String> subscriber = observable.subscribeOn(scheduler).test();
 
-		subscriber.assertCompleted()
-			.assertNoErrors()
-			.assertValue(result);
+		subscriber.assertValue(result)
+			.assertCompleted()
+			.assertNoErrors();
 
-		verify(delegate).handle(endpointCallMock, null);
+		verify(delegate).handle(notNull(EndpointCall.class), anyVararg());
 	}
 
 	@Test
 	public void shouldSubscribeErrorOnObservableWhenCreatedHandlerWithRxJavaObservableReturnTypeThrowException() throws Exception {
-		EndpointCallHandler<Observable<String>, String> handler = adapter
-				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("observable")), delegate);
+		AsyncEndpointCallHandler<Observable<String>, Collection<String>> handler = adapter
+				.adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("observable")), delegate);
 
 		RuntimeException exception = new RuntimeException();
 
-		when(delegate.handle(endpointCallMock, null))
-			.thenThrow(exception);
+		CompletableFuture<Collection<String>> futureAsException = new CompletableFuture<>();
+		futureAsException.completeExceptionally(exception);
+		
+		when(endpointCallMock.executeAsync())
+			.thenReturn(futureAsException);
 
-		Observable<String> observable = handler.handle(endpointCallMock, null);
+		Observable<String> observable = handler.handleAsync(endpointCallMock, null);
 
 		assertNotNull(observable);
 
@@ -106,9 +123,37 @@ public class RxJavaObservableEndpointCallHandlerAdapterTest {
 
 		subscriber.assertError(exception);
 
-		verify(delegate).handle(endpointCallMock, null);
+		verify(delegate, never()).handle(any(), anyVararg());
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	public void shouldCreateSyncHandlerFromEndpointMethodWithRxJavaObservableReturnType() throws Exception {
+		EndpointCallHandler<Observable<String>, Collection<String>> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("observable")), delegate);
+
+		String result = "observable result";
+
+		when(endpointCallMock.execute())
+			.thenReturn(Arrays.asList(result));
+
+		when(delegate.handle(notNull(EndpointCall.class), anyVararg()))
+			.then(i -> i.getArgumentAt(0, EndpointCall.class).execute());
+
+		Observable<String> observable = handler.handle(endpointCallMock, null);
+
+		assertNotNull(observable);
+
+		AssertableSubscriber<String> subscriber = observable.subscribeOn(scheduler).test();
+
+		subscriber.assertValue(result)
+			.assertCompleted()
+			.assertNoErrors();
+
+		verify(delegate).handle(notNull(EndpointCall.class), anyVararg());
+	}
+
+	
 	interface SomeType {
 
 		Observable<String> observable();

--- a/java-restify-rxjava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaSingleEndpointCallHandlerAdapterTest.java
+++ b/java-restify-rxjava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaSingleEndpointCallHandlerAdapterTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -18,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.call.async.AsyncEndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
 import com.github.ljtfreitas.restify.http.client.call.handler.async.AsyncEndpointCallHandler;
 import com.github.ljtfreitas.restify.reflection.JavaType;
 
@@ -81,7 +81,7 @@ public class RxJavaSingleEndpointCallHandlerAdapterTest {
 
 		when(asyncEndpointCall.executeAsync())
 			.thenReturn(resultAsFuture);
-		
+
 		when(delegate.handle(any(), anyVararg()))
 			.thenReturn(resultAsFuture.join());
 
@@ -119,9 +119,32 @@ public class RxJavaSingleEndpointCallHandlerAdapterTest {
 
 		single.subscribeOn(scheduler).subscribe(subscriber);
 
-		subscriber.assertError(ExecutionException.class);
+		subscriber.assertError(exception);
 	}
 
+	@Test
+	public void shouldCreateSyncHandlerFromEndpointMethodWithRxJavaSingleReturnType() throws Exception {
+		EndpointCallHandler<Single<String>, String> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("single")), delegate);
+
+		String result = "single result";
+
+		when(delegate.handle(any(), anyVararg()))
+			.thenReturn(result);
+
+		Single<String> single = handler.handle(asyncEndpointCall, null);
+
+		assertNotNull(single);
+
+		TestSubscriber<String> subscriber = TestSubscriber.create();
+
+		single.subscribeOn(scheduler).subscribe(subscriber);
+
+		subscriber.assertCompleted();
+		subscriber.assertNoErrors();
+		subscriber.assertValue(result);
+	}
+	
 	interface SomeType {
 
 		Single<String> single();


### PR DESCRIPTION
## Tipos reativos - sequências e respostas únicas

### Descrição
- Refatora handlers de tipos reativos para diferenciar de maneira mais coerente objetos que representam sequências (coleções) e respostas únicas (um único elemento)

### Changelog
- Handlers dos tipos *Flux*, *Observable* e *Flowable* passam a ser compatíveis apenas com respostas do tipo *Iterable*
- Melhora o tratamento de erro para processamentos assíncronos, quando objetos reativos são usados
