### PR TITLE
[minor-refactor-jsonp-jackson] Rename do conversor JsonP e modificação da implementação padrão do Jackson

### DIFF
--- a/java-restify-json-jackson-converter/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JacksonMessageConverter.java
+++ b/java-restify-json-jackson-converter/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JacksonMessageConverter.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.github.ljtfreitas.restify.http.client.message.converter.HttpMessageReadException;
@@ -43,7 +44,12 @@ public class JacksonMessageConverter<T> implements JsonMessageConverter<T> {
 	private final ObjectMapper objectMapper;
 
 	public JacksonMessageConverter() {
-		this(new ObjectMapper());
+		this(configure(new ObjectMapper()));
+	}
+
+	private static ObjectMapper configure(ObjectMapper objectMapper) {
+		objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+		return objectMapper;
 	}
 
 	public JacksonMessageConverter(ObjectMapper objectMapper) {

--- a/java-restify-json-jackson-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JacksonMessageConverterTest.java
+++ b/java-restify-json-jackson-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JacksonMessageConverterTest.java
@@ -1,6 +1,8 @@
 package com.github.ljtfreitas.restify.http.client.message.converter.json;
 
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
@@ -18,9 +20,9 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.message.Encoding;
-import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
-import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
 import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 import com.github.ljtfreitas.restify.reflection.SimpleParameterizedType;
 
@@ -130,6 +132,30 @@ public class JacksonMessageConverterTest {
 		assertEquals(2, collectionOfMyJsonModel.size());
 
 		Iterator<MyJsonModel> iterator = collectionOfMyJsonModel.iterator();
+
+		MyJsonModel myJsonModel = iterator.next();
+		assertEquals("Tiago de Freitas Lima 1", myJsonModel.name);
+		assertEquals(31, myJsonModel.age);
+
+		myJsonModel = iterator.next();
+		assertEquals("Tiago de Freitas Lima 2", myJsonModel.name);
+		assertEquals(32, myJsonModel.age);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void shouldReadIterableOfJsonMessage() throws Exception {
+		ByteArrayInputStream input = new ByteArrayInputStream(collectionOfJson.getBytes());
+
+		when(response.body().input()).thenReturn(input);
+
+		Type genericIterableType = new SimpleParameterizedType(Iterable.class, null, MyJsonModel.class);
+
+		Iterable<MyJsonModel> iterableOfMyJsonModel = (Iterable<MyJsonModel>) converter.read(response, genericIterableType);
+
+		assertThat(iterableOfMyJsonModel, iterableWithSize(2));
+
+		Iterator<MyJsonModel> iterator = iterableOfMyJsonModel.iterator();
 
 		MyJsonModel myJsonModel = iterator.next();
 		assertEquals("Tiago de Freitas Lima 1", myJsonModel.name);

--- a/java-restify-json-jsonp-converter/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonPMessageConverter.java
+++ b/java-restify-json-jsonp-converter/src/main/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonPMessageConverter.java
@@ -44,16 +44,16 @@ import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMess
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 import com.github.ljtfreitas.restify.util.Tryable;
 
-public class JsonpMessageConverter implements JsonMessageConverter<JsonStructure> {
+public class JsonPMessageConverter implements JsonMessageConverter<JsonStructure> {
 
 	private final JsonReaderFactory jsonReaderFactory;
 	private final JsonWriterFactory jsonWriterFactory;
 
-	public JsonpMessageConverter() {
+	public JsonPMessageConverter() {
 		this(Collections.emptyMap());
 	}
 
-	public JsonpMessageConverter(Map<String, ?> configuration) {
+	public JsonPMessageConverter(Map<String, ?> configuration) {
 		this.jsonReaderFactory = Json.createReaderFactory(configuration);
 		this.jsonWriterFactory = Json.createWriterFactory(configuration);
 	}

--- a/java-restify-json-jsonp-converter/src/main/resources/META-INF/services/com.github.ljtfreitas.restify.http.client.message.converter.json.JsonMessageConverter
+++ b/java-restify-json-jsonp-converter/src/main/resources/META-INF/services/com.github.ljtfreitas.restify.http.client.message.converter.json.JsonMessageConverter
@@ -1,2 +1,2 @@
-com.github.ljtfreitas.restify.http.client.message.converter.json.JsonpMessageConverter
+com.github.ljtfreitas.restify.http.client.message.converter.json.JsonPMessageConverter
 

--- a/java-restify-json-jsonp-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonPMessageConverterSpiTest.java
+++ b/java-restify-json-jsonp-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonPMessageConverterSpiTest.java
@@ -8,7 +8,7 @@ import java.util.ServiceLoader;
 
 import org.junit.Test;
 
-public class JsonpMessageConverterSpiTest {
+public class JsonPMessageConverterSpiTest {
 
 	@SuppressWarnings({ "rawtypes" })
 	@Test
@@ -16,6 +16,6 @@ public class JsonpMessageConverterSpiTest {
 		Iterable<JsonMessageConverter> services = ServiceLoader.load(JsonMessageConverter.class);
 
 		assertThat(services, contains(
-				instanceOf(JsonpMessageConverter.class)));
+				instanceOf(JsonPMessageConverter.class)));
 	}
 }

--- a/java-restify-json-jsonp-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonPMessageConverterTest.java
+++ b/java-restify-json-jsonp-converter/src/test/java/com/github/ljtfreitas/restify/http/client/message/converter/json/JsonPMessageConverterTest.java
@@ -24,7 +24,7 @@ import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
 
 @RunWith(MockitoJUnitRunner.class)
-public class JsonpMessageConverterTest {
+public class JsonPMessageConverterTest {
 
 	@Mock
 	private HttpRequestMessage request;
@@ -32,7 +32,7 @@ public class JsonpMessageConverterTest {
 	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
 	private HttpResponseMessage response;
 
-	private JsonpMessageConverter converter = new JsonpMessageConverter();
+	private JsonPMessageConverter converter = new JsonPMessageConverter();
 
 	private JsonObject jsonObject;
 


### PR DESCRIPTION
## Rename do conversor JsonP e modificação da implementação padrão do Jackson

### Descrição
- Renomeia conversor Json-P (*JsonPMessageConverter*)
- Modifica implementação padrão do Jackson para desabilitar a feature *FAIL_ON_UNKNOWN_PROPERTIES*