### PR TITLE
[vavr-support] Suporte ao vavr

### DIFF
--- a/java-restify-reactor/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/reactor/FluxEndpointCallHandlerAdapterTest.java
+++ b/java-restify-reactor/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/reactor/FluxEndpointCallHandlerAdapterTest.java
@@ -91,7 +91,7 @@ public class FluxEndpointCallHandlerAdapterTest {
 	}
 
 	@Test
-	public void shouldSubscribeErrorOnObservableWhenCreatedHandlerWithRxJava2ObservableReturnTypeThrowException() throws Exception {
+	public void shouldSubscribeErrorOnFluxWhenCreatedHandlerWithFluxReturnTypeThrowException() throws Exception {
 		AsyncEndpointCallHandler<Flux<String>, Collection<String>> handler = adapter
 				.adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("flux")), delegate);
 

--- a/java-restify-reactor/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/reactor/ReactorEndpointCallHandlerProviderSpiTest.java
+++ b/java-restify-reactor/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/reactor/ReactorEndpointCallHandlerProviderSpiTest.java
@@ -7,12 +7,9 @@ import static org.junit.Assert.assertThat;
 import java.util.ServiceLoader;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerProvider;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ReactorEndpointCallHandlerProviderSpiTest {
 
 	@SuppressWarnings("unchecked")

--- a/java-restify-vavr/pom.xml
+++ b/java-restify-vavr/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.github.ljtfreitas</groupId>
+		<artifactId>java-restify-group</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>java-restify-vavr</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-call-handler</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-contract</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-reflection</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-util</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-util-async</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.vavr</groupId>
+			<artifactId>vavr</artifactId>
+			<version>0.10.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.vavr</groupId>
+			<artifactId>vavr-test</artifactId>
+			<version>0.10.0</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/ArrayEndpointCallHandlerAdapter.java
+++ b/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/ArrayEndpointCallHandlerAdapter.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.Array;
+
+public class ArrayEndpointCallHandlerAdapter<T, O> implements EndpointCallHandlerAdapter<Array<T>, Collection<T>, O> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Array.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.parameterizedType(Collection.class, unwrap(endpointMethod.returnType()));
+	}
+
+	private Type unwrap(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[0] :
+					Object.class;
+	}
+
+	@Override
+	public EndpointCallHandler<Array<T>, O> adapt(EndpointMethod endpointMethod, EndpointCallHandler<Collection<T>, O> handler) {
+		return new ArrayEndpointCallHandler(handler);
+	}
+
+	private class ArrayEndpointCallHandler implements EndpointCallHandler<Array<T>, O> {
+
+		private final EndpointCallHandler<Collection<T>, O> delegate;
+
+		private ArrayEndpointCallHandler(EndpointCallHandler<Collection<T>, O> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Array<T> handle(EndpointCall<O> call, Object[] args) {
+			Collection<T> collection = delegate.handle(call, args);
+
+			return Optional.ofNullable(collection)
+					.map(c -> Array.ofAll(collection))
+						.orElseGet(() -> Array.empty());
+		}
+
+	}
+}

--- a/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/EitherWithStringEndpointCallHandlerAdapter.java
+++ b/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/EitherWithStringEndpointCallHandlerAdapter.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.control.Either;
+import io.vavr.control.Try;
+
+public class EitherWithStringEndpointCallHandlerAdapter<T, O> implements EndpointCallHandlerAdapter<Either<String, T>, T, O> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Either.class) && supportedLeftType(endpointMethod.returnType());
+	}
+
+	private boolean supportedLeftType(JavaType returnType) {
+		if (!returnType.parameterized()) return false;
+
+		ParameterizedType parameterizedType = returnType.as(ParameterizedType.class);
+
+		if (parameterizedType.getActualTypeArguments().length == 0) return false;
+
+		JavaType leftType = JavaType.of(parameterizedType.getActualTypeArguments()[0]);
+
+		return String.class.isAssignableFrom(leftType.classType());
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.of(rightType(endpointMethod.returnType()));
+	}
+
+	private Type rightType(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[1] :
+					Object.class;
+	}
+
+	@Override
+	public EndpointCallHandler<Either<String, T>, O> adapt(EndpointMethod endpointMethod, EndpointCallHandler<T, O> handler) {
+		return new EitherWithStringEndpointMethodHandler(handler);
+	}
+
+	private class EitherWithStringEndpointMethodHandler implements EndpointCallHandler<Either<String, T>, O> {
+
+		private final EndpointCallHandler<T, O> delegate;
+
+		private EitherWithStringEndpointMethodHandler(EndpointCallHandler<T, O> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Either<String, T> handle(EndpointCall<O> call, Object[] args) {
+			return Try.of(() -> delegate.handle(call, args))
+					.fold(e -> left(e), r -> right(r));
+		}
+
+		private Either<String, T> right(T response) {
+			return Either.right(response);
+		}
+
+		private Either<String, T> left(Throwable e) {
+			return Either.left(e.getMessage());
+		}
+	}
+}

--- a/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/EitherWithThrowableEndpointCallHandlerAdapter.java
+++ b/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/EitherWithThrowableEndpointCallHandlerAdapter.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.control.Either;
+import io.vavr.control.Try;
+
+public class EitherWithThrowableEndpointCallHandlerAdapter<L extends Throwable, T, O> implements EndpointCallHandlerAdapter<Either<L, T>, T, O> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Either.class) && supportedLeftType(endpointMethod.returnType());
+	}
+
+	private boolean supportedLeftType(JavaType returnType) {
+		if (!returnType.parameterized()) return false;
+
+		ParameterizedType parameterizedType = returnType.as(ParameterizedType.class);
+
+		if (parameterizedType.getActualTypeArguments().length == 0) return false;
+
+		JavaType leftType = JavaType.of(parameterizedType.getActualTypeArguments()[0]);
+
+		return Throwable.class.isAssignableFrom(leftType.classType());
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.of(rightType(endpointMethod.returnType()));
+	}
+
+	private Type rightType(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[1] :
+					Object.class;
+	}
+
+	@Override
+	public EndpointCallHandler<Either<L, T>, O> adapt(EndpointMethod endpointMethod, EndpointCallHandler<T, O> handler) {
+		return new EitherWithExceptionEndpointMethodHandler(handler);
+	}
+
+	private class EitherWithExceptionEndpointMethodHandler implements EndpointCallHandler<Either<L, T>, O> {
+
+		private final EndpointCallHandler<T, O> delegate;
+
+		private EitherWithExceptionEndpointMethodHandler(EndpointCallHandler<T, O> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Either<L, T> handle(EndpointCall<O> call, Object[] args) {
+			return Try.of(() -> delegate.handle(call, args))
+					.fold(e -> left(e), r -> right(r));
+		}
+
+		private Either<L, T> right(T body) {
+			return Either.right(body);
+		}
+
+		@SuppressWarnings("unchecked")
+		private Either<L, T> left(Throwable e) {
+			return (Either<L, T>) Either.left(e);
+		}
+	}
+}

--- a/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/FutureEndpointCallHandlerAdapter.java
+++ b/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/FutureEndpointCallHandlerAdapter.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import com.github.ljtfreitas.restify.http.client.call.async.AsyncEndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.async.AsyncEndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.async.AsyncEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
+
+import io.vavr.concurrent.Future;
+
+public class FutureEndpointCallHandlerAdapter<T, O> implements AsyncEndpointCallHandlerAdapter<Future<T>, T, O> {
+
+	private final Executor executor;
+
+	public FutureEndpointCallHandlerAdapter() {
+		this(DisposableExecutors.newCachedThreadPool());
+	}
+
+	public FutureEndpointCallHandlerAdapter(Executor executor) {
+		this.executor = executor;
+	}
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Future.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.of(unwrap(endpointMethod.returnType()));
+	}
+
+	private Type unwrap(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[0] :
+					Object.class;
+	}
+
+	@Override
+	public AsyncEndpointCallHandler<Future<T>, O> adaptAsync(EndpointMethod endpointMethod, EndpointCallHandler<T, O> handler) {
+		return new FutureEndpointMethodHandler(handler);
+	}
+
+	private class FutureEndpointMethodHandler implements AsyncEndpointCallHandler<Future<T>, O> {
+
+		private final EndpointCallHandler<T, O> delegate;
+
+		private FutureEndpointMethodHandler(EndpointCallHandler<T, O> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Future<T> handleAsync(AsyncEndpointCall<O> call, Object[] args) {
+			CompletableFuture<T> completableFuture = call.executeAsync()
+					.thenApplyAsync(o -> delegate.handle(() -> o, args), executor)
+						.toCompletableFuture();
+
+			return Future.fromCompletableFuture(executor, completableFuture);
+		}
+	}
+}

--- a/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/IndexedSeqEndpointCallHandlerAdapter.java
+++ b/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/IndexedSeqEndpointCallHandlerAdapter.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.Array;
+import io.vavr.collection.IndexedSeq;
+
+public class IndexedSeqEndpointCallHandlerAdapter<T, O> implements EndpointCallHandlerAdapter<IndexedSeq<T>, Collection<T>, O> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(IndexedSeq.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.parameterizedType(Collection.class, unwrap(endpointMethod.returnType()));
+	}
+
+	private Type unwrap(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[0] :
+					Object.class;
+	}
+
+	@Override
+	public EndpointCallHandler<IndexedSeq<T>, O> adapt(EndpointMethod endpointMethod, EndpointCallHandler<Collection<T>, O> handler) {
+		return new IndexedSeqEndpointCallHandler(handler);
+	}
+
+	private class IndexedSeqEndpointCallHandler implements EndpointCallHandler<IndexedSeq<T>, O> {
+
+		private final EndpointCallHandler<Collection<T>, O> delegate;
+
+		private IndexedSeqEndpointCallHandler(EndpointCallHandler<Collection<T>, O> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public IndexedSeq<T> handle(EndpointCall<O> call, Object[] args) {
+			Collection<T> collection = delegate.handle(call, args);
+
+			return Optional.ofNullable(collection)
+					.map(c -> Array.ofAll(collection))
+						.orElseGet(() -> Array.empty());
+		}
+
+	}
+}

--- a/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/LazyEndpointCallHandlerAdapter.java
+++ b/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/LazyEndpointCallHandlerAdapter.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.Lazy;
+
+public class LazyEndpointCallHandlerAdapter<T, O> implements EndpointCallHandlerAdapter<Lazy<T>, T, O> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Lazy.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.of(unwrap(endpointMethod.returnType()));
+	}
+
+	private Type unwrap(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[0] :
+					Object.class;
+	}
+
+	@Override
+	public EndpointCallHandler<Lazy<T>, O> adapt(EndpointMethod endpointMethod, EndpointCallHandler<T, O> handler) {
+		return new LazyEndpointMethodHandler(handler);
+	}
+
+	private class LazyEndpointMethodHandler implements EndpointCallHandler<Lazy<T>, O> {
+
+		private final EndpointCallHandler<T, O> delegate;
+
+		private LazyEndpointMethodHandler(EndpointCallHandler<T, O> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Lazy<T> handle(EndpointCall<O> call, Object[] args) {
+			return Lazy.of(() -> delegate.handle(call, args));
+		}
+	}
+}

--- a/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/ListEndpointCallHandlerAdapter.java
+++ b/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/ListEndpointCallHandlerAdapter.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.List;
+
+public class ListEndpointCallHandlerAdapter<T, O> implements EndpointCallHandlerAdapter<List<T>, Collection<T>, O> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(List.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.parameterizedType(Collection.class, unwrap(endpointMethod.returnType()));
+	}
+
+	private Type unwrap(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[0] :
+					Object.class;
+	}
+
+	@Override
+	public EndpointCallHandler<List<T>, O> adapt(EndpointMethod endpointMethod, EndpointCallHandler<Collection<T>, O> handler) {
+		return new ListEndpointCallHandler(handler);
+	}
+
+	private class ListEndpointCallHandler implements EndpointCallHandler<List<T>, O> {
+
+		private final EndpointCallHandler<Collection<T>, O> delegate;
+
+		private ListEndpointCallHandler(EndpointCallHandler<Collection<T>, O> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public List<T> handle(EndpointCall<O> call, Object[] args) {
+			Collection<T> collection = delegate.handle(call, args);
+
+			return Optional.ofNullable(collection)
+					.map(c -> List.ofAll(collection))
+						.orElseGet(() -> List.empty());
+		}
+
+	}
+}

--- a/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/OptionEndpointCallHandlerFactory.java
+++ b/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/OptionEndpointCallHandlerFactory.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerFactory;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.control.Option;
+
+public class OptionEndpointCallHandlerFactory<T> implements EndpointCallHandlerFactory<Option<T>, T> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Option.class);
+	}
+
+	@Override
+	public EndpointCallHandler<Option<T>, T> create(EndpointMethod endpointMethod) {
+		JavaType type = endpointMethod.returnType();
+
+		Type responseType = type.parameterized() ? type.as(ParameterizedType.class).getActualTypeArguments()[0] : Object.class;
+
+		return new OptionEndpointMethodHandler(JavaType.of(responseType));
+	}
+
+	private class OptionEndpointMethodHandler implements EndpointCallHandler<Option<T>, T> {
+
+		private final JavaType returnType;
+
+		public OptionEndpointMethodHandler(JavaType returnType) {
+			this.returnType = returnType;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return returnType;
+		}
+
+		@Override
+		public Option<T> handle(EndpointCall<T> call, Object[] args) {
+			return Option.of(call.execute());
+		}
+	}
+}

--- a/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/QueueEndpointCallHandlerAdapter.java
+++ b/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/QueueEndpointCallHandlerAdapter.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.Queue;
+
+public class QueueEndpointCallHandlerAdapter<T, O> implements EndpointCallHandlerAdapter<Queue<T>, Collection<T>, O> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Queue.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.parameterizedType(Collection.class, unwrap(endpointMethod.returnType()));
+	}
+
+	private Type unwrap(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[0] :
+					Object.class;
+	}
+
+	@Override
+	public EndpointCallHandler<Queue<T>, O> adapt(EndpointMethod endpointMethod, EndpointCallHandler<Collection<T>, O> handler) {
+		return new QueueEndpointCallHandler(handler);
+	}
+
+	private class QueueEndpointCallHandler implements EndpointCallHandler<Queue<T>, O> {
+
+		private final EndpointCallHandler<Collection<T>, O> delegate;
+
+		private QueueEndpointCallHandler(EndpointCallHandler<Collection<T>, O> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Queue<T> handle(EndpointCall<O> call, Object[] args) {
+			Collection<T> collection = delegate.handle(call, args);
+
+			return Optional.ofNullable(collection)
+					.map(c -> Queue.ofAll(collection))
+						.orElseGet(() -> Queue.empty());
+		}
+
+	}
+}

--- a/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/SeqEndpointCallHandlerAdapter.java
+++ b/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/SeqEndpointCallHandlerAdapter.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.List;
+import io.vavr.collection.Seq;
+
+public class SeqEndpointCallHandlerAdapter<T, O> implements EndpointCallHandlerAdapter<Seq<T>, Collection<T>, O> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Seq.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.parameterizedType(Collection.class, unwrap(endpointMethod.returnType()));
+	}
+
+	private Type unwrap(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[0] :
+					Object.class;
+	}
+
+	@Override
+	public EndpointCallHandler<Seq<T>, O> adapt(EndpointMethod endpointMethod, EndpointCallHandler<Collection<T>, O> handler) {
+		return new SeqEndpointCallHandler(handler);
+	}
+
+	private class SeqEndpointCallHandler implements EndpointCallHandler<Seq<T>, O> {
+
+		private final EndpointCallHandler<Collection<T>, O> delegate;
+
+		private SeqEndpointCallHandler(EndpointCallHandler<Collection<T>, O> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Seq<T> handle(EndpointCall<O> call, Object[] args) {
+			Collection<T> collection = delegate.handle(call, args);
+
+			return Optional.ofNullable(collection)
+					.map(c -> List.ofAll(collection))
+						.orElseGet(() -> List.empty());
+		}
+
+	}
+}

--- a/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/SetEndpointCallHandlerAdapter.java
+++ b/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/SetEndpointCallHandlerAdapter.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.HashSet;
+import io.vavr.collection.Set;
+
+public class SetEndpointCallHandlerAdapter<T, O> implements EndpointCallHandlerAdapter<Set<T>, Collection<T>, O> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Set.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.parameterizedType(Collection.class, unwrap(endpointMethod.returnType()));
+	}
+
+	private Type unwrap(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[0] :
+					Object.class;
+	}
+
+	@Override
+	public EndpointCallHandler<Set<T>, O> adapt(EndpointMethod endpointMethod, EndpointCallHandler<Collection<T>, O> handler) {
+		return new SetEndpointCallHandler(handler);
+	}
+
+	private class SetEndpointCallHandler implements EndpointCallHandler<Set<T>, O> {
+
+		private final EndpointCallHandler<Collection<T>, O> delegate;
+
+		private SetEndpointCallHandler(EndpointCallHandler<Collection<T>, O> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Set<T> handle(EndpointCall<O> call, Object[] args) {
+			Collection<T> collection = delegate.handle(call, args);
+
+			return Optional.ofNullable(collection)
+					.map(c -> HashSet.ofAll(collection))
+						.orElseGet(() -> HashSet.empty());
+		}
+
+	}
+}

--- a/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/TraversableEndpointCallHandlerAdapter.java
+++ b/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/TraversableEndpointCallHandlerAdapter.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Optional;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.List;
+import io.vavr.collection.Traversable;
+
+public class TraversableEndpointCallHandlerAdapter<T, O> implements EndpointCallHandlerAdapter<Traversable<T>, Collection<T>, O> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Traversable.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.parameterizedType(Collection.class, unwrap(endpointMethod.returnType()));
+	}
+
+	private Type unwrap(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[0] :
+					Object.class;
+	}
+
+	@Override
+	public EndpointCallHandler<Traversable<T>, O> adapt(EndpointMethod endpointMethod, EndpointCallHandler<Collection<T>, O> handler) {
+		return new TraversableEndpointCallHandler(handler);
+	}
+
+	private class TraversableEndpointCallHandler implements EndpointCallHandler<Traversable<T>, O> {
+
+		private final EndpointCallHandler<Collection<T>, O> delegate;
+
+		private TraversableEndpointCallHandler(EndpointCallHandler<Collection<T>, O> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Traversable<T> handle(EndpointCall<O> call, Object[] args) {
+			Collection<T> collection = delegate.handle(call, args);
+
+			return Optional.ofNullable(collection)
+					.map(c -> List.ofAll(collection))
+						.orElseGet(() -> List.empty());
+		}
+
+	}
+}

--- a/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/TryEndpointCallHandlerAdapter.java
+++ b/java-restify-vavr/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/TryEndpointCallHandlerAdapter.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.control.Try;
+
+public class TryEndpointCallHandlerAdapter<T, O> implements EndpointCallHandlerAdapter<Try<T>, T, O> {
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Try.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return JavaType.of(unwrap(endpointMethod.returnType()));
+	}
+
+	private Type unwrap(JavaType declaredReturnType) {
+		return declaredReturnType.parameterized() ?
+				declaredReturnType.as(ParameterizedType.class).getActualTypeArguments()[0] :
+					Object.class;
+	}
+
+	@Override
+	public EndpointCallHandler<Try<T>, O> adapt(EndpointMethod endpointMethod, EndpointCallHandler<T, O> handler) {
+		return new TryEndpointMethodHandler(handler);
+	}
+
+	private class TryEndpointMethodHandler implements EndpointCallHandler<Try<T>, O> {
+
+		private final EndpointCallHandler<T, O> delegate;
+
+		private TryEndpointMethodHandler(EndpointCallHandler<T, O> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Try<T> handle(EndpointCall<O> call, Object[] args) {
+			return Try.of(() -> delegate.handle(call, args));
+		}
+	}
+}

--- a/java-restify-vavr/src/main/resources/META-INF/services/com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerProvider
+++ b/java-restify-vavr/src/main/resources/META-INF/services/com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerProvider
@@ -1,0 +1,13 @@
+com.github.ljtfreitas.restify.http.client.call.handler.vavr.ArrayEndpointCallHandlerAdapter
+com.github.ljtfreitas.restify.http.client.call.handler.vavr.EitherWithStringEndpointCallHandlerAdapter
+com.github.ljtfreitas.restify.http.client.call.handler.vavr.EitherWithThrowableEndpointCallHandlerAdapter
+com.github.ljtfreitas.restify.http.client.call.handler.vavr.FutureEndpointCallHandlerAdapter
+com.github.ljtfreitas.restify.http.client.call.handler.vavr.IndexedSeqEndpointCallHandlerAdapter
+com.github.ljtfreitas.restify.http.client.call.handler.vavr.LazyEndpointCallHandlerAdapter
+com.github.ljtfreitas.restify.http.client.call.handler.vavr.ListEndpointCallHandlerAdapter
+com.github.ljtfreitas.restify.http.client.call.handler.vavr.OptionEndpointCallHandlerFactory
+com.github.ljtfreitas.restify.http.client.call.handler.vavr.QueueEndpointCallHandlerAdapter
+com.github.ljtfreitas.restify.http.client.call.handler.vavr.SeqEndpointCallHandlerAdapter
+com.github.ljtfreitas.restify.http.client.call.handler.vavr.SetEndpointCallHandlerAdapter
+com.github.ljtfreitas.restify.http.client.call.handler.vavr.TraversableEndpointCallHandlerAdapter
+com.github.ljtfreitas.restify.http.client.call.handler.vavr.TryEndpointCallHandlerAdapter

--- a/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/ArrayEndpointCallHandlerAdapterTest.java
+++ b/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/ArrayEndpointCallHandlerAdapterTest.java
@@ -1,0 +1,103 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.ArrayEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.Array;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Property;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ArrayEndpointCallHandlerAdapterTest {
+
+	@Mock
+	private EndpointCallHandler<Collection<String>, Collection<String>> delegate;
+
+	@Mock
+	private EndpointCall<Collection<String>> endpointCall;
+
+	private ArrayEndpointCallHandlerAdapter<String, Collection<String>> adapter;
+
+	private String expectedResult;
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void setup() {
+		adapter = new ArrayEndpointCallHandlerAdapter<>();
+
+		expectedResult = "array result";
+
+		when(endpointCall.execute())
+			.thenReturn(Arrays.asList(expectedResult));
+
+		when(delegate.handle(notNull(EndpointCall.class), anyVararg()))
+			.then(i -> i.getArgumentAt(0, EndpointCall.class).execute());
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsArray() throws Exception {
+		assertTrue(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("array"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotArray() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithArgumentTypeOfArray() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, String.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("array"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithObjectTypeWhenArrayIsNotParameterized() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, Object.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbArray"))));
+	}
+
+	@Test
+	public void shouldCreateHandlerFromEndpointMethodWithArrayReturnType() throws Exception {
+		EndpointCallHandler<Array<String>, Collection<String>> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("array")), delegate);
+
+		Array<String> array = handler.handle(endpointCall, null);
+
+		assertNotNull(array);
+
+		Property.def("contains endpoint call result on array")
+				.forAll(Arbitrary.of(expectedResult))
+				.suchThat(value -> array.contains(value))
+					.check()
+						.assertIsSatisfied();
+	}
+
+	interface SomeType {
+
+		Array<String> array();
+
+		@SuppressWarnings("rawtypes")
+		Array dumbArray();
+
+		String string();
+	}
+}

--- a/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/EitherWithStringEndpointCallHandlerAdapterTest.java
+++ b/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/EitherWithStringEndpointCallHandlerAdapterTest.java
@@ -1,0 +1,121 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.control.Either;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EitherWithStringEndpointCallHandlerAdapterTest {
+
+	@Mock
+	private EndpointCallHandler<String, String> delegate;
+
+	@Mock
+	private EndpointCall<String> endpointCall;
+
+	private EitherWithStringEndpointCallHandlerAdapter<String, String> adapter;
+
+	private String expectedResult;
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void setup() {
+		adapter = new EitherWithStringEndpointCallHandlerAdapter<>();
+
+		expectedResult = "result";
+
+		when(endpointCall.execute())
+			.thenReturn(expectedResult);
+
+		when(delegate.handle(notNull(EndpointCall.class), anyVararg()))
+			.then(i -> i.getArgumentAt(0, EndpointCall.class).execute());
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsEither() throws Exception {
+		assertTrue(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("either"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotEither() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenLeftTypeOfEitherIsNotString() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("eitherWithThrowable"))));
+	}
+
+	@Test
+	public void shouldReturnParameterizedTypeWithRightArgumentTypeOfEither() throws Exception {
+		assertEquals(JavaType.of(String.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("either"))));
+	}
+
+	@Test
+	public void shouldReturnObjectTypeWhenEitherIsNotParameterized() throws Exception {
+		assertEquals(JavaType.of(Object.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbEither"))));
+	}
+
+	@Test
+	public void shouldCreateHandlerFromEndpointMethodWithEitherReturnType() throws Exception {
+		EndpointCallHandler<Either<String, String>, String> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("either")), delegate);
+
+		Either<String, String> either = handler.handle(endpointCall, null);
+
+		assertThat(either, notNullValue());
+
+		assertThat(either.isRight(), is(true));
+		assertThat(either.contains(expectedResult), is(true));
+	}
+
+	@Test
+	public void shouldReturnLeftEitherWithExceptionMessageFromHandlerWhenEndpointCallThrowException() throws Exception {
+		EndpointCallHandler<Either<String, String>, String> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("either")), delegate);
+
+		String message = "ops...";
+
+		when(endpointCall.execute())
+			.thenThrow(new RuntimeException(message));
+
+		Either<String, String> either = handler.handle(endpointCall, null);
+
+		assertThat(either, notNullValue());
+
+		assertThat(either.isLeft(), is(true));
+		assertThat(either.getLeft(), is(message));
+	}
+
+	interface SomeType {
+
+		Either<String, String> either();
+
+		Either<Throwable, String> eitherWithThrowable();
+
+		@SuppressWarnings("rawtypes")
+		Either dumbEither();
+
+		String string();
+	}
+}

--- a/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/EitherWithThrowableEndpointCallHandlerAdapterTest.java
+++ b/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/EitherWithThrowableEndpointCallHandlerAdapterTest.java
@@ -1,0 +1,123 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.control.Either;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EitherWithThrowableEndpointCallHandlerAdapterTest {
+
+	@Mock
+	private EndpointCallHandler<String, String> delegate;
+
+	@Mock
+	private EndpointCall<String> endpointCall;
+
+	private EitherWithThrowableEndpointCallHandlerAdapter<RuntimeException, String, String> adapter;
+
+	private String expectedResult;
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void setup() {
+		adapter = new EitherWithThrowableEndpointCallHandlerAdapter<>();
+
+		expectedResult = "result";
+
+		when(endpointCall.execute())
+			.thenReturn(expectedResult);
+
+		when(delegate.handle(notNull(EndpointCall.class), anyVararg()))
+			.then(i -> i.getArgumentAt(0, EndpointCall.class).execute());
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsEither() throws Exception {
+		assertTrue(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("either"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotEither() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenLeftTypeOfEitherIsNotThrowable() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("eitherWithString"))));
+	}
+
+	@Test
+	public void shouldReturnParameterizedTypeWithRightArgumentTypeOfEither() throws Exception {
+		assertEquals(JavaType.of(String.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("either"))));
+	}
+
+	@Test
+	public void shouldReturnObjectTypeWhenEitherIsNotParameterized() throws Exception {
+		assertEquals(JavaType.of(Object.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbEither"))));
+	}
+
+	@Test
+	public void shouldCreateHandlerFromEndpointMethodWithEitherReturnType() throws Exception {
+		EndpointCallHandler<Either<RuntimeException, String>, String> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("either")), delegate);
+
+		Either<RuntimeException, String> either = handler.handle(endpointCall, null);
+
+		assertThat(either, notNullValue());
+
+		assertThat(either.isRight(), is(true));
+		assertThat(either.contains(expectedResult), is(true));
+	}
+
+	@Test
+	public void shouldReturnLeftEitherWithExceptionFromHandlerWhenEndpointCallThrowException() throws Exception {
+		EndpointCallHandler<Either<RuntimeException, String>, String> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("either")), delegate);
+
+		RuntimeException exception = new RuntimeException("ops...");
+
+		when(endpointCall.execute())
+			.thenThrow(exception);
+
+		Either<RuntimeException, String> either = handler.handle(endpointCall, null);
+
+		assertThat(either, notNullValue());
+
+		assertThat(either.isLeft(), is(true));
+		assertThat(either.getLeft(), is(exception));
+	}
+
+	interface SomeType {
+
+		Either<IOException, String> either();
+
+		Either<String, String> eitherWithString();
+
+		@SuppressWarnings("rawtypes")
+		Either dumbEither();
+
+		String string();
+	}
+}

--- a/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/IndexedSeqEndpointCallHandlerAdapterTest.java
+++ b/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/IndexedSeqEndpointCallHandlerAdapterTest.java
@@ -1,0 +1,103 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.IndexedSeqEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.IndexedSeq;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Property;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IndexedSeqEndpointCallHandlerAdapterTest {
+
+	@Mock
+	private EndpointCallHandler<Collection<String>, Collection<String>> delegate;
+
+	@Mock
+	private EndpointCall<Collection<String>> endpointCall;
+
+	private IndexedSeqEndpointCallHandlerAdapter<String, Collection<String>> adapter;
+
+	private String expectedResult;
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void setup() {
+		adapter = new IndexedSeqEndpointCallHandlerAdapter<>();
+
+		expectedResult = "indexedSeq result";
+
+		when(endpointCall.execute())
+			.thenReturn(Arrays.asList(expectedResult));
+
+		when(delegate.handle(notNull(EndpointCall.class), anyVararg()))
+			.then(i -> i.getArgumentAt(0, EndpointCall.class).execute());
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsIndexedSeq() throws Exception {
+		assertTrue(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("indexedSeq"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotIndexedSeq() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithArgumentTypeOfIndexedSeq() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, String.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("indexedSeq"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithObjectTypeWhenIndexedSeqIsNotParameterized() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, Object.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbIndexedSeq"))));
+	}
+
+	@Test
+	public void shouldCreateHandlerFromEndpointMethodWithIndexedSeqReturnType() throws Exception {
+		EndpointCallHandler<IndexedSeq<String>, Collection<String>> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("indexedSeq")), delegate);
+
+		IndexedSeq<String> indexedSeq = handler.handle(endpointCall, null);
+
+		assertNotNull(indexedSeq);
+
+		Property.def("contains endpoint call result on indexedSeq")
+				.forAll(Arbitrary.of(expectedResult))
+				.suchThat(value -> indexedSeq.contains(value))
+					.check()
+						.assertIsSatisfied();
+	}
+
+	interface SomeType {
+
+		IndexedSeq<String> indexedSeq();
+
+		@SuppressWarnings("rawtypes")
+		IndexedSeq dumbIndexedSeq();
+
+		String string();
+	}
+}

--- a/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/ListEndpointCallHandlerAdapterTest.java
+++ b/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/ListEndpointCallHandlerAdapterTest.java
@@ -1,0 +1,102 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.ListEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.List;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Property;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ListEndpointCallHandlerAdapterTest {
+
+	@Mock
+	private EndpointCallHandler<Collection<String>, Collection<String>> delegate;
+
+	@Mock
+	private EndpointCall<Collection<String>> endpointCall;
+
+	private ListEndpointCallHandlerAdapter<String, Collection<String>> adapter;
+
+	private String expectedResult;
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void setup() {
+		adapter = new ListEndpointCallHandlerAdapter<>();
+
+		expectedResult = "list result";
+
+		when(endpointCall.execute())
+			.thenReturn(Arrays.asList(expectedResult));
+
+		when(delegate.handle(notNull(EndpointCall.class), anyVararg()))
+			.then(i -> i.getArgumentAt(0, EndpointCall.class).execute());
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsList() throws Exception {
+		assertTrue(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("list"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotList() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithArgumentTypeOfList() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, String.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("list"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithObjectTypeWhenListIsNotParameterized() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, Object.class), adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbList"))));
+	}
+
+	@Test
+	public void shouldCreateHandlerFromEndpointMethodWithListReturnType() throws Exception {
+		EndpointCallHandler<List<String>, Collection<String>> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("list")), delegate);
+
+		List<String> list = handler.handle(endpointCall, null);
+
+		assertNotNull(list);
+
+		Property.def("contains endpoint call result on list")
+				.forAll(Arbitrary.of(expectedResult))
+				.suchThat(value -> list.contains(value))
+					.check()
+						.assertIsSatisfied();
+	}
+
+	interface SomeType {
+
+		List<String> list();
+
+		@SuppressWarnings("rawtypes")
+		List dumbList();
+
+		String string();
+	}
+}

--- a/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/QueueEndpointCallHandlerAdapterTest.java
+++ b/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/QueueEndpointCallHandlerAdapterTest.java
@@ -1,0 +1,103 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.QueueEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.Queue;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Property;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueueEndpointCallHandlerAdapterTest {
+
+	@Mock
+	private EndpointCallHandler<Collection<String>, Collection<String>> delegate;
+
+	@Mock
+	private EndpointCall<Collection<String>> endpointCall;
+
+	private QueueEndpointCallHandlerAdapter<String, Collection<String>> adapter;
+
+	private String expectedResult;
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void setup() {
+		adapter = new QueueEndpointCallHandlerAdapter<>();
+
+		expectedResult = "queue result";
+
+		when(endpointCall.execute())
+			.thenReturn(Arrays.asList(expectedResult));
+
+		when(delegate.handle(notNull(EndpointCall.class), anyVararg()))
+			.then(i -> i.getArgumentAt(0, EndpointCall.class).execute());
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsQueue() throws Exception {
+		assertTrue(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("queue"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotQueue() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithArgumentTypeOfQueue() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, String.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("queue"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithObjectTypeWhenQueueIsNotParameterized() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, Object.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbQueue"))));
+	}
+
+	@Test
+	public void shouldCreateHandlerFromEndpointMethodWithQueueReturnType() throws Exception {
+		EndpointCallHandler<Queue<String>, Collection<String>> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("queue")), delegate);
+
+		Queue<String> queue = handler.handle(endpointCall, null);
+
+		assertNotNull(queue);
+
+		Property.def("contains endpoint call result on queue")
+				.forAll(Arbitrary.of(expectedResult))
+				.suchThat(value -> queue.contains(value))
+					.check()
+						.assertIsSatisfied();
+	}
+
+	interface SomeType {
+
+		Queue<String> queue();
+
+		@SuppressWarnings("rawtypes")
+		Queue dumbQueue();
+
+		String string();
+	}
+}

--- a/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/SeqEndpointCallHandlerAdapterTest.java
+++ b/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/SeqEndpointCallHandlerAdapterTest.java
@@ -1,0 +1,103 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.SeqEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.Seq;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Property;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SeqEndpointCallHandlerAdapterTest {
+
+	@Mock
+	private EndpointCallHandler<Collection<String>, Collection<String>> delegate;
+
+	@Mock
+	private EndpointCall<Collection<String>> endpointCall;
+
+	private SeqEndpointCallHandlerAdapter<String, Collection<String>> adapter;
+
+	private String expectedResult;
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void setup() {
+		adapter = new SeqEndpointCallHandlerAdapter<>();
+
+		expectedResult = "seq result";
+
+		when(endpointCall.execute())
+			.thenReturn(Arrays.asList(expectedResult));
+
+		when(delegate.handle(notNull(EndpointCall.class), anyVararg()))
+			.then(i -> i.getArgumentAt(0, EndpointCall.class).execute());
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsSeq() throws Exception {
+		assertTrue(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("seq"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotSeq() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithArgumentTypeOfSeq() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, String.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("seq"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithObjectTypeWhenSeqIsNotParameterized() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, Object.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbSeq"))));
+	}
+
+	@Test
+	public void shouldCreateHandlerFromEndpointMethodWithSeqReturnType() throws Exception {
+		EndpointCallHandler<Seq<String>, Collection<String>> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("seq")), delegate);
+
+		Seq<String> seq = handler.handle(endpointCall, null);
+
+		assertNotNull(seq);
+
+		Property.def("contains endpoint call result on seq")
+				.forAll(Arbitrary.of(expectedResult))
+				.suchThat(value -> seq.contains(value))
+					.check()
+						.assertIsSatisfied();
+	}
+
+	interface SomeType {
+
+		Seq<String> seq();
+
+		@SuppressWarnings("rawtypes")
+		Seq dumbSeq();
+
+		String string();
+	}
+}

--- a/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/SetEndpointCallHandlerAdapterTest.java
+++ b/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/SetEndpointCallHandlerAdapterTest.java
@@ -1,0 +1,103 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.SetEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.Set;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Property;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SetEndpointCallHandlerAdapterTest {
+
+	@Mock
+	private EndpointCallHandler<Collection<String>, Collection<String>> delegate;
+
+	@Mock
+	private EndpointCall<Collection<String>> endpointCall;
+
+	private SetEndpointCallHandlerAdapter<String, Collection<String>> adapter;
+
+	private String expectedResult;
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void setup() {
+		adapter = new SetEndpointCallHandlerAdapter<>();
+
+		expectedResult = "set result";
+
+		when(endpointCall.execute())
+			.thenReturn(Arrays.asList(expectedResult));
+
+		when(delegate.handle(notNull(EndpointCall.class), anyVararg()))
+			.then(i -> i.getArgumentAt(0, EndpointCall.class).execute());
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsSet() throws Exception {
+		assertTrue(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("set"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotSet() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithArgumentTypeOfSet() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, String.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("set"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithObjectTypeWhenSetIsNotParameterized() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, Object.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbSet"))));
+	}
+
+	@Test
+	public void shouldCreateHandlerFromEndpointMethodWithSetReturnType() throws Exception {
+		EndpointCallHandler<Set<String>, Collection<String>> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("set")), delegate);
+
+		Set<String> set = handler.handle(endpointCall, null);
+
+		assertNotNull(set);
+
+		Property.def("contains endpoint call result on set")
+				.forAll(Arbitrary.of(expectedResult))
+				.suchThat(value -> set.contains(value))
+					.check()
+						.assertIsSatisfied();
+	}
+
+	interface SomeType {
+
+		Set<String> set();
+
+		@SuppressWarnings("rawtypes")
+		Set dumbSet();
+
+		String string();
+	}
+}

--- a/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/SimpleEndpointMethod.java
+++ b/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/SimpleEndpointMethod.java
@@ -1,0 +1,17 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import java.lang.reflect.Method;
+
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethodParameters;
+
+class SimpleEndpointMethod extends EndpointMethod {
+
+	public SimpleEndpointMethod(Method javaMethod) {
+		super(javaMethod, "/", "GET");
+	}
+
+	public SimpleEndpointMethod(Method javaMethod, EndpointMethodParameters parameters) {
+		super(javaMethod, "/", "GET", parameters);
+	}
+}

--- a/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/TraversableEndpointCallHandlerAdapterTest.java
+++ b/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/TraversableEndpointCallHandlerAdapterTest.java
@@ -1,0 +1,103 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.TraversableEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.collection.Traversable;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Property;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TraversableEndpointCallHandlerAdapterTest {
+
+	@Mock
+	private EndpointCallHandler<Collection<String>, Collection<String>> delegate;
+
+	@Mock
+	private EndpointCall<Collection<String>> endpointCall;
+
+	private TraversableEndpointCallHandlerAdapter<String, Collection<String>> adapter;
+
+	private String expectedResult;
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void setup() {
+		adapter = new TraversableEndpointCallHandlerAdapter<>();
+
+		expectedResult = "traversable result";
+
+		when(endpointCall.execute())
+			.thenReturn(Arrays.asList(expectedResult));
+
+		when(delegate.handle(notNull(EndpointCall.class), anyVararg()))
+			.then(i -> i.getArgumentAt(0, EndpointCall.class).execute());
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsTraversable() throws Exception {
+		assertTrue(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("traversable"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotTraversable() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithArgumentTypeOfTraversable() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, String.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("traversable"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionWithObjectTypeWhenTraversableIsNotParameterized() throws Exception {
+		assertEquals(JavaType.parameterizedType(Collection.class, Object.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbTraversable"))));
+	}
+
+	@Test
+	public void shouldCreateHandlerFromEndpointMethodWithTraversableReturnType() throws Exception {
+		EndpointCallHandler<Traversable<String>, Collection<String>> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("traversable")), delegate);
+
+		Traversable<String> traversable = handler.handle(endpointCall, null);
+
+		assertNotNull(traversable);
+
+		Property.def("contains endpoint call result on traversable")
+				.forAll(Arbitrary.of(expectedResult))
+				.suchThat(value -> traversable.contains(value))
+					.check()
+						.assertIsSatisfied();
+	}
+
+	interface SomeType {
+
+		Traversable<String> traversable();
+
+		@SuppressWarnings("rawtypes")
+		Traversable dumbTraversable();
+
+		String string();
+	}
+}

--- a/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/TryEndpointCallHandlerAdapterTest.java
+++ b/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/TryEndpointCallHandlerAdapterTest.java
@@ -1,0 +1,115 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+
+import io.vavr.control.Try;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TryEndpointCallHandlerAdapterTest {
+
+	@Mock
+	private EndpointCallHandler<String, String> delegate;
+
+	@Mock
+	private EndpointCall<String> endpointCall;
+
+	private TryEndpointCallHandlerAdapter<String, String> adapter;
+
+	private String expectedResult;
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void setup() {
+		adapter = new TryEndpointCallHandlerAdapter<>();
+
+		expectedResult = "result";
+
+		when(endpointCall.execute())
+			.thenReturn(expectedResult);
+
+		when(delegate.handle(notNull(EndpointCall.class), anyVararg()))
+			.then(i -> i.getArgumentAt(0, EndpointCall.class).execute());
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsTry() throws Exception {
+		assertTrue(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("aTry"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotTry() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnParameterizedTypeWithArgumentTypeOfTry() throws Exception {
+		assertEquals(JavaType.of(String.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("aTry"))));
+	}
+
+	@Test
+	public void shouldReturnObjectTypeWhenTryIsNotParameterized() throws Exception {
+		assertEquals(JavaType.of(Object.class),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbTry"))));
+	}
+
+	@Test
+	public void shouldCreateHandlerFromEndpointMethodWithTryReturnType() throws Exception {
+		EndpointCallHandler<Try<String>, String> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("aTry")), delegate);
+
+		Try<String> aTry = handler.handle(endpointCall, null);
+
+		assertThat(aTry, notNullValue());
+
+		assertThat(aTry.isSuccess(), is(true));
+		assertThat(aTry.get(), equalTo(expectedResult));
+	}
+
+	@Test
+	public void shouldReturnFailureTryFromHandlerWhenEndpointCallThrowException() throws Exception {
+		EndpointCallHandler<Try<String>, String> handler = adapter
+				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("aTry")), delegate);
+
+		RuntimeException exception = new RuntimeException("ops...");
+
+		when(endpointCall.execute())
+			.thenThrow(exception);
+
+		Try<String> aTry = handler.handle(endpointCall, null);
+
+		assertThat(aTry, notNullValue());
+
+		assertThat(aTry.isFailure(), is(true));
+		assertThat(aTry.getCause(), is(exception));
+	}
+
+	interface SomeType {
+
+		Try<String> aTry();
+
+		@SuppressWarnings("rawtypes")
+		Try dumbTry();
+
+		String string();
+	}
+}

--- a/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/VavrEndpointCallHandlerProviderSpiTest.java
+++ b/java-restify-vavr/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/vavr/VavrEndpointCallHandlerProviderSpiTest.java
@@ -1,0 +1,35 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.vavr;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import java.util.ServiceLoader;
+
+import org.junit.Test;
+
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerProvider;
+
+public class VavrEndpointCallHandlerProviderSpiTest {
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void shouldDiscoveryServiceProviders() {
+		Iterable<EndpointCallHandlerProvider> services = ServiceLoader.load(EndpointCallHandlerProvider.class);
+
+		assertThat(services, contains(
+				instanceOf(ArrayEndpointCallHandlerAdapter.class),
+				instanceOf(EitherWithStringEndpointCallHandlerAdapter.class),
+				instanceOf(EitherWithThrowableEndpointCallHandlerAdapter.class),
+				instanceOf(FutureEndpointCallHandlerAdapter.class),
+				instanceOf(IndexedSeqEndpointCallHandlerAdapter.class),
+				instanceOf(LazyEndpointCallHandlerAdapter.class),
+				instanceOf(ListEndpointCallHandlerAdapter.class),
+				instanceOf(OptionEndpointCallHandlerFactory.class),
+				instanceOf(QueueEndpointCallHandlerAdapter.class),
+				instanceOf(SeqEndpointCallHandlerAdapter.class),
+				instanceOf(SetEndpointCallHandlerAdapter.class),
+				instanceOf(TraversableEndpointCallHandlerAdapter.class),
+				instanceOf(TryEndpointCallHandlerAdapter.class)));
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
@@ -63,7 +63,9 @@ import com.github.ljtfreitas.restify.http.client.call.handler.jdk.IterableEndpoi
 import com.github.ljtfreitas.restify.http.client.call.handler.jdk.IteratorEndpointCallHandlerAdapter;
 import com.github.ljtfreitas.restify.http.client.call.handler.jdk.ListIteratorEndpointCallHandlerAdapter;
 import com.github.ljtfreitas.restify.http.client.call.handler.jdk.OptionalEndpointCallHandlerFactory;
+import com.github.ljtfreitas.restify.http.client.call.handler.jdk.QueueEndpointCallHandlerAdapter;
 import com.github.ljtfreitas.restify.http.client.call.handler.jdk.RunnableEndpointCallHandlerFactory;
+import com.github.ljtfreitas.restify.http.client.call.handler.jdk.StreamEndpointCallHandlerAdapter;
 import com.github.ljtfreitas.restify.http.client.jdk.HttpClientRequestConfiguration;
 import com.github.ljtfreitas.restify.http.client.jdk.JdkHttpClientRequestFactory;
 import com.github.ljtfreitas.restify.http.client.message.Header;
@@ -514,6 +516,8 @@ public class RestifyProxyBuilder {
 			this.built.add(IteratorEndpointCallHandlerAdapter.instance());
 			this.built.add(ListIteratorEndpointCallHandlerAdapter.instance());
 			this.built.add(IterableEndpointCallHandlerAdapter.instance());
+			this.built.add(QueueEndpointCallHandlerAdapter.instance());
+			this.built.add(StreamEndpointCallHandlerAdapter.instance());
 			this.built.add(EndpointCallObjectHandlerAdapter.instance());
 			this.built.add(HeadersEndpointCallHandlerAdapter.instance());
 			this.built.add(StatusCodeEndpointCallHandlerAdapter.instance());

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/jdk/QueueEndpointCallHandlerAdapter.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/jdk/QueueEndpointCallHandlerAdapter.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.jdk;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Optional;
+import java.util.Queue;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+import com.github.ljtfreitas.restify.reflection.SimpleParameterizedType;
+
+public class QueueEndpointCallHandlerAdapter<T> implements EndpointCallHandlerAdapter<Queue<T>, Collection<T>, Collection<T>> {
+
+	private static final QueueEndpointCallHandlerAdapter<Object> DEFAULT_INSTANCE = new QueueEndpointCallHandlerAdapter<>();
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return Queue.class.isAssignableFrom(endpointMethod.returnType().classType());
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return collectionTypeOf(endpointMethod.returnType());
+	}
+
+	private JavaType collectionTypeOf(JavaType type) {
+		Type responseType = type.parameterized() ? type.as(ParameterizedType.class).getActualTypeArguments()[0] : Object.class;
+		return JavaType.of(new SimpleParameterizedType(Collection.class, null, responseType));
+	}
+
+	@Override
+	public EndpointCallHandler<Queue<T>, Collection<T>> adapt(EndpointMethod endpointMethod, EndpointCallHandler<Collection<T>, Collection<T>> delegate) {
+		return new QueueEndpointCallHandler(delegate);
+	}
+
+	private class QueueEndpointCallHandler implements EndpointCallHandler<Queue<T>, Collection<T>> {
+
+		private final EndpointCallHandler<Collection<T>, Collection<T>> delegate;
+
+		public QueueEndpointCallHandler(EndpointCallHandler<Collection<T>, Collection<T>> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Queue<T> handle(EndpointCall<Collection<T>> call, Object[] args) {
+			return Optional.ofNullable(delegate.handle(call, args))
+					.map(c -> new LinkedList<>(c))
+						.orElseGet(() -> new LinkedList<>());
+		}
+	}
+
+	public static QueueEndpointCallHandlerAdapter<Object> instance() {
+		return DEFAULT_INSTANCE;
+	}
+}

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/jdk/StreamEndpointCallHandlerAdapter.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/jdk/StreamEndpointCallHandlerAdapter.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.call.handler.jdk;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+import com.github.ljtfreitas.restify.reflection.SimpleParameterizedType;
+
+public class StreamEndpointCallHandlerAdapter<T> implements EndpointCallHandlerAdapter<Stream<T>, Collection<T>, Collection<T>> {
+
+	private static final StreamEndpointCallHandlerAdapter<Object> DEFAULT_INSTANCE = new StreamEndpointCallHandlerAdapter<>();
+
+	@Override
+	public boolean supports(EndpointMethod endpointMethod) {
+		return endpointMethod.returnType().is(Stream.class);
+	}
+
+	@Override
+	public JavaType returnType(EndpointMethod endpointMethod) {
+		return collectionTypeOf(endpointMethod.returnType());
+	}
+
+	private JavaType collectionTypeOf(JavaType type) {
+		Type responseType = type.parameterized() ? type.as(ParameterizedType.class).getActualTypeArguments()[0] : Object.class;
+		return JavaType.of(new SimpleParameterizedType(Collection.class, null, responseType));
+	}
+
+	@Override
+	public EndpointCallHandler<Stream<T>, Collection<T>> adapt(EndpointMethod endpointMethod, EndpointCallHandler<Collection<T>, Collection<T>> delegate) {
+		return new StreamEndpointCallHandler(delegate);
+	}
+
+	private class StreamEndpointCallHandler implements EndpointCallHandler<Stream<T>, Collection<T>> {
+
+		private final EndpointCallHandler<Collection<T>, Collection<T>> delegate;
+
+		public StreamEndpointCallHandler(EndpointCallHandler<Collection<T>, Collection<T>> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public JavaType returnType() {
+			return delegate.returnType();
+		}
+
+		@Override
+		public Stream<T> handle(EndpointCall<Collection<T>> call, Object[] args) {
+			return Optional.ofNullable(delegate.handle(call, args))
+					.map(Collection::stream)
+						.orElseGet(Stream::empty);
+		}
+	}
+
+	public static StreamEndpointCallHandlerAdapter<Object> instance() {
+		return DEFAULT_INSTANCE;
+	}
+}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/jdk/QueueEndpointCallHandlerAdapterTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/jdk/QueueEndpointCallHandlerAdapterTest.java
@@ -1,0 +1,100 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.jdk;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.Queue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.SimpleEndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+import com.github.ljtfreitas.restify.reflection.SimpleParameterizedType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueueEndpointCallHandlerAdapterTest {
+
+	@Mock
+	private EndpointCallHandler<Collection<String>, Collection<String>> delegate;
+
+	private QueueEndpointCallHandlerAdapter<String> adapter;
+
+	@Before
+	public void setup() {
+		adapter = new QueueEndpointCallHandlerAdapter<>();
+
+		when(delegate.handle(any(), anyVararg()))
+			.then(invocation -> invocation.getArgumentAt(0, EndpointCall.class).execute());
+
+		when(delegate.returnType())
+			.thenReturn(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)));
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsQueue() throws Exception {
+		assertTrue(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("queue"))));
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsSubTypeOfQueue() throws Exception {
+		assertTrue(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("deque"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotQueue() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionParameterizedWithArgumentTypeOfQueue() throws Exception {
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("queue"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionParameterizedWithObjectWhenQueueIsNotParameterized() throws Exception {
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, Object.class)),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbQueue"))));
+	}
+
+	@Test
+	public void shouldCreateHandlerFromEndpointMethodWithIteratorReturnType() throws Exception {
+		EndpointCallHandler<Queue<String>, Collection<String>> handler = adapter.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("queue")), delegate);
+
+		Collection<String> result = Arrays.asList("result");
+
+		Queue<String> queue = handler.handle(() -> result, null);
+
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)), handler.returnType());
+
+		assertThat(queue, contains("result"));
+	}
+
+	private interface SomeType {
+
+		Queue<String> queue();
+
+		Deque<String> deque();
+
+		@SuppressWarnings("rawtypes")
+		Queue dumbQueue();
+
+		String string();
+	}
+
+}

--- a/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/jdk/StreamEndpointCallHandlerAdapterTest.java
+++ b/java-restify/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/jdk/StreamEndpointCallHandlerAdapterTest.java
@@ -1,0 +1,92 @@
+package com.github.ljtfreitas.restify.http.client.call.handler.jdk;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
+import com.github.ljtfreitas.restify.http.client.call.handler.SimpleEndpointMethod;
+import com.github.ljtfreitas.restify.reflection.JavaType;
+import com.github.ljtfreitas.restify.reflection.SimpleParameterizedType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StreamEndpointCallHandlerAdapterTest {
+
+	@Mock
+	private EndpointCallHandler<Collection<String>, Collection<String>> delegate;
+
+	private StreamEndpointCallHandlerAdapter<String> adapter;
+
+	@Before
+	public void setup() {
+		adapter = new StreamEndpointCallHandlerAdapter<>();
+
+		when(delegate.handle(any(), anyVararg()))
+			.then(invocation -> invocation.getArgumentAt(0, EndpointCall.class).execute());
+
+		when(delegate.returnType())
+			.thenReturn(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)));
+	}
+
+	@Test
+	public void shouldSupportsWhenEndpointMethodReturnTypeIsStream() throws Exception {
+		assertTrue(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("stream"))));
+	}
+
+	@Test
+	public void shouldNotSupportsWhenEndpointMethodReturnTypeIsNotStream() throws Exception {
+		assertFalse(adapter.supports(new SimpleEndpointMethod(SomeType.class.getMethod("string"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionParameterizedWithArgumentTypeOfStream() throws Exception {
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("stream"))));
+	}
+
+	@Test
+	public void shouldReturnCollectionParameterizedWithObjectWhenStreamIsNotParameterized() throws Exception {
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, Object.class)),
+				adapter.returnType(new SimpleEndpointMethod(SomeType.class.getMethod("dumbStream"))));
+	}
+
+	@Test
+	public void shouldCreateHandlerFromEndpointMethodWithIteratorReturnType() throws Exception {
+		EndpointCallHandler<Stream<String>, Collection<String>> handler = adapter.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("stream")), delegate);
+
+		String result = "result";
+
+		Stream<String> stream = handler.handle(() -> Arrays.asList(result), null);
+
+		assertEquals(JavaType.of(new SimpleParameterizedType(Collection.class, null, String.class)), handler.returnType());
+
+		assertThat(stream.anyMatch(result::equals), is(true));
+	}
+
+	private interface SomeType {
+
+		Stream<String> stream();
+
+		@SuppressWarnings("rawtypes")
+		Stream dumbStream();
+
+		String string();
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<module>java-restify-reflection</module>
 		<module>java-restify-contract</module>
 		<module>java-restify-call-handler</module>
-		
+
 		<module>java-restify-http-client</module>
 		<module>java-restify-http-client-apache-httpclient</module>
 		<module>java-restify-http-client-okhttp</module>
@@ -38,6 +38,7 @@
 		<module>java-restify-jsoup</module>
 		<module>java-restify-reactor</module>
 		<module>java-restify-reactor-hystrix</module>
+		<module>java-restify-vavr</module>
 
 		<module>java-restify-http-message</module>
 		<module>java-restify-wildcard-converter</module>
@@ -65,7 +66,7 @@
 		<module>java-restify-netflix-spring-autoconfigure</module>
 		<module>java-restify-netflix-spring-starter</module>
 
-		<module>java-restify-cdi</module>		
+		<module>java-restify-cdi</module>
 		<module>java-restify-jaxrs-contract</module>
 
 		<module>java-restify-hateoas</module>


### PR DESCRIPTION
## Suporte ao vavr
- Implementa suporte ao [vavr](http://www.vavr.io/)

## Changelog
- Implementa suporte ao vavr. Os seguintes objetos são suportados
  - Coleções (List, Sequence, Stream, etc)
  - Option
  - Try
  - Either
  - Future
- Implementa suporte a retornos do tipo `Queue` e `Stream` do Java

