### PR TITLE
[spring-configure-customize] Configuração de bean do Spring/CDI

### DIFF
--- a/java-restify-call-handler/src/main/java/com/github/ljtfreitas/restify/http/client/call/async/ExecutorAsyncEndpointCall.java
+++ b/java-restify-call-handler/src/main/java/com/github/ljtfreitas/restify/http/client/call/async/ExecutorAsyncEndpointCall.java
@@ -64,7 +64,6 @@ public class ExecutorAsyncEndpointCall<T> implements AsyncEndpointCall<T> {
 	}
 
 	private CompletionStage<T> doExecuteAsync() {
-		return CompletableFuture
-				.supplyAsync(() -> source.execute(), executor);
+		return CompletableFuture.supplyAsync(source::execute, executor);
 	}
 }

--- a/java-restify-call-handler/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/async/AsyncEndpointCallAdapter.java
+++ b/java-restify-call-handler/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/async/AsyncEndpointCallAdapter.java
@@ -38,7 +38,7 @@ import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 
 class AsyncEndpointCallAdapter<T> implements AsyncEndpointCall<T> {
 
-	private static final Executor DEFAULT_EXECUTOR = DisposableExecutors.immediate();
+	private static final Executor DEFAULT_EXECUTOR = DisposableExecutors.newCachedThreadPool();
 
 	private final ExecutorAsyncEndpointCall<T> delegate;
 

--- a/java-restify-cdi/src/main/java/com/github/ljtfreitas/restify/cdi/RestifyProxyCdiBean.java
+++ b/java-restify-cdi/src/main/java/com/github/ljtfreitas/restify/cdi/RestifyProxyCdiBean.java
@@ -28,6 +28,7 @@ package com.github.ljtfreitas.restify.cdi;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -40,7 +41,10 @@ import javax.enterprise.inject.Stereotype;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
 import javax.inject.Scope;
+
+import com.github.ljtfreitas.restify.reflection.JavaAnnotationScanner;
 
 class RestifyProxyCdiBean implements Bean<Object> {
 
@@ -67,7 +71,13 @@ class RestifyProxyCdiBean implements Bean<Object> {
 	@Override
 	public Set<Annotation> getQualifiers() {
 		Set<Annotation> qualifiers = new LinkedHashSet<>();
-		qualifiers.add(new DefaultLiteral());
+
+		JavaAnnotationScanner scanner = new JavaAnnotationScanner(javaType);
+		
+		Collection<Annotation> annotations = scanner.allWith(Qualifier.class);
+
+		if (annotations.isEmpty()) qualifiers.add(new DefaultLiteral()); else qualifiers.addAll(annotations);
+
 		return qualifiers;
 	}
 

--- a/java-restify-cdi/src/main/java/com/github/ljtfreitas/restify/cdi/RestifyProxyCdiBeanFactory.java
+++ b/java-restify-cdi/src/main/java/com/github/ljtfreitas/restify/cdi/RestifyProxyCdiBeanFactory.java
@@ -63,7 +63,10 @@ class RestifyProxyCdiBeanFactory {
 		builder.client(httpClientRequestFactory())
 			.contract(contractReader())
 			.expression(expressionResolver())
-			.executor(endpointRequestExecutor())
+			.executor()
+				.using(endpointRequestExecutor())
+				.interceptors(endpointRequestInterceptors())
+				.and()
 			.retry()
 				.enabled()
 				.and()
@@ -79,8 +82,7 @@ class RestifyProxyCdiBeanFactory {
 				.discovery()
 					.disabled()
 				.and()
-			.error(endpointResponseErrorFallback())
-			.interceptors(endpointRequestInterceptors());
+			.error(endpointResponseErrorFallback());
 
 		return builder.target(javaType, restifyable.endpoint()).build();
 	}

--- a/java-restify-cdi/src/main/java/com/github/ljtfreitas/restify/cdi/RestifyProxyCdiBeanFactory.java
+++ b/java-restify-cdi/src/main/java/com/github/ljtfreitas/restify/cdi/RestifyProxyCdiBeanFactory.java
@@ -26,10 +26,15 @@
 package com.github.ljtfreitas.restify.cdi;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
@@ -37,12 +42,16 @@ import javax.enterprise.util.AnnotationLiteral;
 
 import com.github.ljtfreitas.restify.http.RestifyProxyBuilder;
 import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerProvider;
+import com.github.ljtfreitas.restify.http.client.jdk.HttpClientRequestConfiguration;
 import com.github.ljtfreitas.restify.http.client.jdk.JdkHttpClientRequestFactory;
 import com.github.ljtfreitas.restify.http.client.message.converter.HttpMessageConverter;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequestExecutor;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequestFactory;
+import com.github.ljtfreitas.restify.http.client.request.authentication.Authentication;
 import com.github.ljtfreitas.restify.http.client.request.interceptor.EndpointRequestInterceptor;
+import com.github.ljtfreitas.restify.http.client.request.interceptor.HttpClientRequestInterceptor;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponseErrorFallback;
+import com.github.ljtfreitas.restify.http.client.retry.RetryConfiguration;
 import com.github.ljtfreitas.restify.http.contract.metadata.ContractExpressionResolver;
 import com.github.ljtfreitas.restify.http.contract.metadata.ContractReader;
 import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
@@ -51,77 +60,151 @@ class RestifyProxyCdiBeanFactory {
 
 	private final Class<?> javaType;
 	private final Restifyable restifyable;
+	private final Collection<RestifyProxyConfiguration> configurations;
 	
 	public RestifyProxyCdiBeanFactory(Class<?> javaType) {
 		this.javaType = javaType;
 		this.restifyable = javaType.getAnnotation(Restifyable.class);
+		this.configurations = configurationsOf(restifyable.configuration());
+	}
+
+	private Collection<RestifyProxyConfiguration> configurationsOf(Class<? extends RestifyProxyConfiguration>[] configurations) {
+		return Arrays.stream(configurations)
+				.map(c -> get(c))
+				.filter(Objects::nonNull)
+				.collect(Collectors.toList());
 	}
 
 	public Object create() {
 		RestifyProxyBuilder builder = new RestifyProxyBuilder();
 
-		builder.client(httpClientRequestFactory())
-			.contract(contractReader())
-			.expression(expressionResolver())
+		builder
+			.client()
+				.using(httpClientRequestFactory())
+				.interceptors(httpClientRequestInterceptors())
+				.configure()
+					.using(httpClientRequestConfiguration())
+				.and()
+			.contract()
+				.using(contractReader())
+				.resolver(contractExpressionResolver())
+				.and()
 			.executor()
 				.using(endpointRequestExecutor())
 				.interceptors(endpointRequestInterceptors())
 				.and()
 			.retry()
-				.enabled()
-				.and()
+				.enabled(withRetry())
+				.using(retry())
 			.handlers()
 				.add(handlers())
-					.async(executor())
 				.discovery()
 					.disabled()
 				.and()
 			.converters()
 				.wildcard()
-				.add(httpMessageConverters())
+				.add(converters())
 				.discovery()
 					.disabled()
 				.and()
+			.async(asyncExecutorService())
 			.error(endpointResponseErrorFallback());
 
-		return builder.target(javaType, restifyable.endpoint()).build();
-	}
+		authentication()
+			.ifPresent(a -> builder
+								.executor()
+									.interceptors()
+										.authentication(a));
 
-	private EndpointRequestInterceptor[] endpointRequestInterceptors() {
-		return all(EndpointRequestInterceptor.class).toArray(new EndpointRequestInterceptor[0]);
-	}
-
-	private EndpointResponseErrorFallback endpointResponseErrorFallback() {
-		return get(EndpointResponseErrorFallback.class, () -> null);
-	}
-
-	private HttpMessageConverter[] httpMessageConverters() {
-		return all(HttpMessageConverter.class).toArray(new HttpMessageConverter[0]);
-	}
-
-	private Executor executor() {
-		return get(Executor.class, new AsyncAnnotationLiteral(), DisposableExecutors::newCachedThreadPool);
-	}
-
-
-	private EndpointCallHandlerProvider[] handlers() {
-		return all(EndpointCallHandlerProvider.class).toArray(new EndpointCallHandlerProvider[0]);
-	}
-
-	private EndpointRequestExecutor endpointRequestExecutor() {
-		return get(EndpointRequestExecutor.class, () -> null);
-	}
-
-	private ContractReader contractReader() {
-		return get(ContractReader.class, () -> null);
-	}
-
-	private ContractExpressionResolver expressionResolver() {
-		return get(ContractExpressionResolver.class, () -> null);
+		return builder.target(javaType, endpoint())
+				.build();
 	}
 
 	private HttpClientRequestFactory httpClientRequestFactory() {
-		return get(HttpClientRequestFactory.class, () -> new JdkHttpClientRequestFactory());
+		return configured(RestifyProxyConfiguration::httpClientRequestFactory)
+				.orElseGet(() -> get(HttpClientRequestFactory.class, () -> new JdkHttpClientRequestFactory()));
+	}
+	
+	private HttpClientRequestInterceptor[] httpClientRequestInterceptors() {
+		return Stream.concat(configurations.stream()
+				.map(RestifyProxyConfiguration::httpClientRequestInterceptors)
+				.flatMap(Collection::stream), all(HttpClientRequestInterceptor.class))
+					.toArray(HttpClientRequestInterceptor[]::new);
+	}
+	
+	private HttpClientRequestConfiguration httpClientRequestConfiguration() {
+		return configured(RestifyProxyConfiguration::httpClientRequestConfiguration)
+				.orElseGet(() -> get(HttpClientRequestConfiguration.class));
+	}
+
+	private ContractReader contractReader() {
+		return configured(RestifyProxyConfiguration::contractReader)
+				.orElseGet(() -> get(ContractReader.class));
+	}
+
+	private ContractExpressionResolver contractExpressionResolver() {
+		return configured(RestifyProxyConfiguration::contractExpressionResolver)
+				.orElseGet(() -> get(ContractExpressionResolver.class));
+	}
+
+
+	private EndpointRequestExecutor endpointRequestExecutor() {
+		return configured(RestifyProxyConfiguration::endpointRequestExecutor)
+				.orElseGet(() -> get(EndpointRequestExecutor.class));
+	}
+
+	private EndpointRequestInterceptor[] endpointRequestInterceptors() {
+		return Stream.concat(configurations.stream()
+				.map(RestifyProxyConfiguration::endpointRequestInterceptors)
+				.flatMap(Collection::stream), all(EndpointRequestInterceptor.class))
+					.toArray(EndpointRequestInterceptor[]::new);
+	}
+
+	private boolean withRetry() {
+		return retry() != null;
+	}
+	
+	private RetryConfiguration retry() {
+		return configured(RestifyProxyConfiguration::retry)
+				.orElseGet(() -> get(RetryConfiguration.class));
+	}
+
+	private EndpointCallHandlerProvider[] handlers() {
+		return Stream.concat(configurations.stream()
+				.map(RestifyProxyConfiguration::handlers)
+				.flatMap(Collection::stream), all(EndpointCallHandlerProvider.class))
+					.toArray(EndpointCallHandlerProvider[]::new);
+	}
+
+	private Executor asyncExecutorService() {
+		return configured(RestifyProxyConfiguration::asyncExecutor)
+				.orElseGet(() -> get(Executor.class, new AsyncAnnotationLiteral(), DisposableExecutors::newCachedThreadPool));
+	}
+
+	private HttpMessageConverter[] converters() {
+		return Stream.concat(configurations.stream()
+				.map(RestifyProxyConfiguration::converters)
+				.flatMap(Collection::stream), all(HttpMessageConverter.class))
+					.toArray(HttpMessageConverter[]::new);
+	}
+
+	private EndpointResponseErrorFallback endpointResponseErrorFallback() {
+		return configured(RestifyProxyConfiguration::endpointResponseErrorFallback)
+				.orElseGet(() -> get(EndpointResponseErrorFallback.class));
+	}
+
+	private Optional<Authentication> authentication() {
+		return Optional.ofNullable(configured(RestifyProxyConfiguration::authentication)
+				.orElseGet(() -> get(Authentication.class)));
+	}
+
+	private String endpoint() {
+		return configured(RestifyProxyConfiguration::endpoint)
+				.orElseGet(restifyable::endpoint);
+	}
+
+	private <T> T get(Class<? extends T> type) {
+		return get(type, () -> null);
 	}
 
 	private <T> T get(Class<? extends T> type, Supplier<T> supplier) {
@@ -136,16 +219,18 @@ class RestifyProxyCdiBeanFactory {
 		return instance.isUnsatisfied() ? supplier.get() : instance.get();
 	}
 
-	private <T> Collection<T> all(Class<? extends T> type) {
+	private <T> Stream<? extends T> all(Class<? extends T> type) {
 		Instance<? extends T> instance = CDI.current().select(type);
-
-		Collection<T> types = new ArrayList<>();
-
-		instance.forEach(types::add);
-
-		return types;
+		return instance.stream();
 	}
 
+	private <T> Optional<T> configured(Function<RestifyProxyConfiguration, T> function) {
+		return configurations.stream()
+				.map(function)
+				.filter(Objects::nonNull)
+				.findFirst();
+	}
+	
 	@SuppressWarnings("serial")
 	private static final class AsyncAnnotationLiteral extends AnnotationLiteral<Async> implements Async {
 	}

--- a/java-restify-cdi/src/main/java/com/github/ljtfreitas/restify/cdi/RestifyProxyConfiguration.java
+++ b/java-restify-cdi/src/main/java/com/github/ljtfreitas/restify/cdi/RestifyProxyConfiguration.java
@@ -23,7 +23,7 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.spring.configure;
+package com.github.ljtfreitas.restify.cdi;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -44,6 +44,10 @@ import com.github.ljtfreitas.restify.http.contract.metadata.ContractReader;
 
 public interface RestifyProxyConfiguration {
 
+	public default String endpoint() {
+		return null;
+	}
+	
 	public default HttpClientRequestFactory httpClientRequestFactory() {
 		return null;
 	}

--- a/java-restify-cdi/src/main/java/com/github/ljtfreitas/restify/cdi/Restifyable.java
+++ b/java-restify-cdi/src/main/java/com/github/ljtfreitas/restify/cdi/Restifyable.java
@@ -39,4 +39,6 @@ public @interface Restifyable {
 	String description() default "";
 
 	String endpoint() default "";
+
+	Class<? extends RestifyProxyConfiguration>[] configuration() default {};
 }

--- a/java-restify-cdi/src/test/java/com/github/ljtfreitas/restify/cdi/TestComponentFactory.java
+++ b/java-restify-cdi/src/test/java/com/github/ljtfreitas/restify/cdi/TestComponentFactory.java
@@ -32,15 +32,15 @@ import javax.enterprise.inject.Produces;
 import com.github.ljtfreitas.restify.http.client.message.converter.wildcard.SimpleTextMessageConverter;
 import com.github.ljtfreitas.restify.http.client.request.interceptor.EndpointRequestInterceptor;
 
-public class TestComponentFactory {
+class TestComponentFactory {
 
 	@Produces
-	public SimpleTextMessageConverter simpleTextMessageConverter() {
+	SimpleTextMessageConverter simpleTextMessageConverter() {
 		return new SimpleTextMessageConverter();
 	}
 	
 	@Produces
-	public EndpointRequestInterceptor simpleEndpointRequestInterceptor() {
+	EndpointRequestInterceptor simpleEndpointRequestInterceptor() {
 		final Logger log = Logger.getLogger(SimpleEndpointRequestInterceptor.class.getCanonicalName());
 
 		return request -> {

--- a/java-restify-guava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureCallbackEndpointCallHandlerAdapter.java
+++ b/java-restify-guava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureCallbackEndpointCallHandlerAdapter.java
@@ -28,6 +28,7 @@ package com.github.ljtfreitas.restify.http.client.call.handler.guava;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 import com.github.ljtfreitas.restify.http.client.call.async.AsyncEndpointCall;
@@ -51,7 +52,11 @@ public class ListenableFutureCallbackEndpointCallHandlerAdapter<T, O> implements
 	private final ListeningExecutorService executorService;
 
 	public ListenableFutureCallbackEndpointCallHandlerAdapter() {
-		this(MoreExecutors.listeningDecorator(DisposableExecutors.newCachedThreadPool()));
+		this(DisposableExecutors.newCachedThreadPool());
+	}
+
+	public ListenableFutureCallbackEndpointCallHandlerAdapter(ExecutorService executorService) {
+		this(MoreExecutors.listeningDecorator(executorService));
 	}
 
 	public ListenableFutureCallbackEndpointCallHandlerAdapter(ListeningExecutorService executorService) {

--- a/java-restify-guava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureEndpointCallHandlerAdapter.java
+++ b/java-restify-guava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureEndpointCallHandlerAdapter.java
@@ -27,6 +27,7 @@ package com.github.ljtfreitas.restify.http.client.call.handler.guava;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 import com.github.ljtfreitas.restify.http.client.call.async.AsyncEndpointCall;
@@ -46,7 +47,11 @@ public class ListenableFutureEndpointCallHandlerAdapter<T, O> implements AsyncEn
 	private final ListeningExecutorService executorService;
 
 	public ListenableFutureEndpointCallHandlerAdapter() {
-		this(MoreExecutors.listeningDecorator(DisposableExecutors.newCachedThreadPool()));
+		this(DisposableExecutors.newCachedThreadPool());
+	}
+
+	public ListenableFutureEndpointCallHandlerAdapter(ExecutorService executorService) {
+		this(MoreExecutors.listeningDecorator(executorService));
 	}
 
 	public ListenableFutureEndpointCallHandlerAdapter(ListeningExecutorService executorService) {

--- a/java-restify-guava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureTaskEndpointCallHandlerAdapter.java
+++ b/java-restify-guava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/guava/ListenableFutureTaskEndpointCallHandlerAdapter.java
@@ -27,6 +27,7 @@ package com.github.ljtfreitas.restify.http.client.call.handler.guava;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.concurrent.ExecutorService;
 
 import com.github.ljtfreitas.restify.http.client.call.EndpointCall;
 import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandler;
@@ -43,7 +44,11 @@ public class ListenableFutureTaskEndpointCallHandlerAdapter<T, O> implements End
 	private final ListeningExecutorService executorService;
 
 	public ListenableFutureTaskEndpointCallHandlerAdapter() {
-		this(MoreExecutors.listeningDecorator(DisposableExecutors.newCachedThreadPool()));
+		this(DisposableExecutors.newCachedThreadPool());
+	}
+
+	public ListenableFutureTaskEndpointCallHandlerAdapter(ExecutorService executorService) {
+		this(MoreExecutors.listeningDecorator(executorService));
 	}
 
 	public ListenableFutureTaskEndpointCallHandlerAdapter(ListeningExecutorService executorService) {

--- a/java-restify-hateoas/src/test/java/com/github/ljtfreitas/restify/http/client/hateoas/browser/HypermediaBrowserTest.java
+++ b/java-restify-hateoas/src/test/java/com/github/ljtfreitas/restify/http/client/hateoas/browser/HypermediaBrowserTest.java
@@ -608,8 +608,10 @@ public class HypermediaBrowserTest {
 					.withBody(json("{\"name\":\"Tiago de Freitas Lima\",\"birth_date\":\"1985-07-02\"}")));
 
 		hypermediaBrowser = new HypermediaBrowserBuilder()
-				.interceptors()
-					.add(r -> r.add(header))
+				.executor()
+					.interceptors()
+						.add(r -> r.add(header))
+						.and()
 					.and()
 				.build();
 

--- a/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/async/interceptor/AsyncEndpointRequestInterceptorChainTest.java
+++ b/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/async/interceptor/AsyncEndpointRequestInterceptorChainTest.java
@@ -18,6 +18,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
 import com.github.ljtfreitas.restify.http.client.request.interceptor.EndpointRequestInterceptor;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AsyncEndpointRequestInterceptorChainTest {
@@ -49,7 +50,7 @@ public class AsyncEndpointRequestInterceptorChainTest {
 		when(syncInterceptor.intercepts(notNull(EndpointRequest.class)))
 			.then(returnsFirstArg());
 
-		AsyncEndpointRequestInterceptorChain chain = AsyncEndpointRequestInterceptorChain.of(Arrays.asList(syncInterceptor));
+		AsyncEndpointRequestInterceptorChain chain = AsyncEndpointRequestInterceptorChain.of(Arrays.asList(syncInterceptor), DisposableExecutors.immediate());
 
 		EndpointRequest request = new EndpointRequest(URI.create("http://whatever"), "GET");
 

--- a/java-restify-reflection/src/main/java/com/github/ljtfreitas/restify/reflection/JavaType.java
+++ b/java-restify-reflection/src/main/java/com/github/ljtfreitas/restify/reflection/JavaType.java
@@ -89,7 +89,7 @@ public class JavaType {
 
 	@Override
 	public String toString() {
-		return "JavaType:[" + type + "]";
+		return type.toString();
 	}
 
 	public static JavaType parameterizedType(Class<?> rawType, Type... typeArguments) {

--- a/java-restify-rxjava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaCompletableEndpointCallHandlerFactoryTest.java
+++ b/java-restify-rxjava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaCompletableEndpointCallHandlerFactoryTest.java
@@ -103,6 +103,8 @@ public class RxJavaCompletableEndpointCallHandlerFactoryTest {
 
 		AssertableSubscriber<Void> subscriber = completable.test();
 
+		Thread.sleep(1000);
+		
 		subscriber.assertCompleted()
 			.assertNoErrors()
 			.assertNoValues();

--- a/java-restify-spring-autoconfigure/pom.xml
+++ b/java-restify-spring-autoconfigure/pom.xml
@@ -122,6 +122,41 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-guava</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-jsoup</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-rxjava</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-rxjava-2</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-vavr</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/autoconfigure/RestifyAutoConfiguration.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/autoconfigure/RestifyAutoConfiguration.java
@@ -41,6 +41,7 @@ import com.github.ljtfreitas.restify.spring.configure.BaseRestifyConfigurationRe
 import com.github.ljtfreitas.restify.spring.configure.RestifyAsyncConfiguration;
 import com.github.ljtfreitas.restify.spring.configure.RestifyConfigurationProperties;
 import com.github.ljtfreitas.restify.spring.configure.RestifyDefaultConfiguration;
+import com.github.ljtfreitas.restify.spring.configure.RestifyEndpointCallHandlersConfiguration;
 import com.github.ljtfreitas.restify.spring.configure.RestifyHttpMessageConvertersConfiguration;
 import com.github.ljtfreitas.restify.spring.configure.RestifyContractConfiguration;
 import com.github.ljtfreitas.restify.spring.configure.RestifyProxyFactoryBean;
@@ -52,7 +53,7 @@ import com.github.ljtfreitas.restify.spring.configure.RestifyableTypeScanner;
 @EnableConfigurationProperties(RestifyConfigurationProperties.class)
 @Import({RestifyDefaultConfiguration.class, RestifyAsyncConfiguration.class, RestifySpringWebFluxConfiguration.class,
 	RestifySpringWebConfiguration.class, RestifyContractConfiguration.class, RestifyHttpMessageConvertersConfiguration.class,
-	RestifyAutoConfigurationRegistrar.class})
+	RestifyEndpointCallHandlersConfiguration.class, RestifyAutoConfigurationRegistrar.class})
 @ConditionalOnMissingBean(RestifyProxyFactoryBean.class)
 @AutoConfigureAfter({RestTemplateAutoConfiguration.class, WebClientAutoConfiguration.class})
 public class RestifyAutoConfiguration {

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/BaseRestifyConfigurationRegistrar.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/BaseRestifyConfigurationRegistrar.java
@@ -25,8 +25,10 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.spring.configure;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,11 +41,6 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.env.Environment;
-
-import com.github.ljtfreitas.restify.http.client.request.authentication.Authentication;
-import com.github.ljtfreitas.restify.http.client.request.authentication.BasicAuthentication;
-import com.github.ljtfreitas.restify.spring.configure.RestifyApiClient.Basic;
-import com.github.ljtfreitas.restify.spring.configure.RestifyApiClient.RestifyApiAuthentication;
 
 public abstract class BaseRestifyConfigurationRegistrar implements ImportBeanDefinitionRegistrar, BeanFactoryAware, EnvironmentAware {
 
@@ -67,13 +64,12 @@ public abstract class BaseRestifyConfigurationRegistrar implements ImportBeanDef
 
 		String endpoint = type.endpoint().map(e -> resolve(e)).orElseGet(restifyApiClient::getEndpoint);
 
-		RestifyProxyBeanBuilder builder = new RestifyProxyBeanBuilder()
+		BeanDefinition bean = new RestifyProxyBeanBuilder()
 				.objectType(type.objectType())
-					.endpoint(endpoint)
-						.asyncExecutorServiceName(Async.EXECUTOR_SERVICE_BEAN_NAME)
-							.authentication(apiAuthentication(restifyApiClient.getAuthentication()));
-
-		BeanDefinition bean = builder.build();
+				.endpoint(endpoint)
+				.asyncExecutorServiceName(Async.EXECUTOR_SERVICE_BEAN_NAME)
+				.configurations(configurationsOf(type))
+					.build();
 
 		registry.registerBeanDefinition(type.name(), bean);
 
@@ -81,19 +77,15 @@ public abstract class BaseRestifyConfigurationRegistrar implements ImportBeanDef
 				type.objectType(), type.name(), type.description(), endpoint);
 	}
 
+	private Collection<RestifyProxyConfiguration> configurationsOf(RestifyableType type) {
+		return type.configurations().stream()
+				.map(beanFactory::getBean)
+					.collect(Collectors.toList());
+	}
+
 	private String resolve(String expression) {
 		return Optional.ofNullable(properties.resolve(expression))
 				.orElseGet(() -> ((ConfigurableBeanFactory) beanFactory).resolveEmbeddedValue(expression));
-	}
-
-	private Authentication apiAuthentication(RestifyApiAuthentication authentication) {
-		if (authentication != null) {
-			Basic basic = authentication.getBasic();
-			if (basic != null) {
-				return new BasicAuthentication(basic.getUsername(), basic.getPassword());
-			}
-		}
-		return null;
 	}
 
 	@Override

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyApiClient.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyApiClient.java
@@ -29,87 +29,11 @@ class RestifyApiClient {
 
 	private String endpoint;
 
-	private RestifyApiAuthentication authentication;
-
 	public String getEndpoint() {
 		return endpoint;
 	}
 
 	public void setEndpoint(String endpoint) {
 		this.endpoint = endpoint;
-	}
-
-	public RestifyApiAuthentication getAuthentication() {
-		return authentication;
-	}
-
-	public void setAuthentication(RestifyApiAuthentication authentication) {
-		this.authentication = authentication;
-	}
-
-	public static class RestifyApiAuthentication {
-
-		private Basic basic;
-		private OAuth oauth;
-
-		public Basic getBasic() {
-			return basic;
-		}
-
-		public void setBasic(Basic basic) {
-			this.basic = basic;
-		}
-
-		public OAuth getOauth() {
-			return oauth;
-		}
-
-		public void setOauth(OAuth oauth) {
-			this.oauth = oauth;
-		}
-	}
-
-	public static class Basic {
-
-		private String username;
-		private String password;
-
-		public String getUsername() {
-			return username;
-		}
-
-		public void setUsername(String username) {
-			this.username = username;
-		}
-
-		public String getPassword() {
-			return password;
-		}
-
-		public void setPassword(String password) {
-			this.password = password;
-		}
-	}
-
-	public static class OAuth {
-
-		private String clientId;
-		private String clientSecret;
-
-		public String getClientId() {
-			return clientId;
-		}
-
-		public void setClientId(String clientId) {
-			this.clientId = clientId;
-		}
-
-		public String getClientSecret() {
-			return clientSecret;
-		}
-
-		public void setClientSecret(String clientSecret) {
-			this.clientSecret = clientSecret;
-		}
 	}
 }

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyApiClientProperties.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyApiClientProperties.java
@@ -32,16 +32,18 @@ import org.springframework.core.env.Environment;
 
 class RestifyApiClientProperties {
 
+	private static final String RESTIFY_PROPERTY_PREFIX = "restify.";
+
 	private final Environment environment;
+	private final Binder binder;
 
 	RestifyApiClientProperties(Environment environment) {
 		this.environment = environment;
+		this.binder = Binder.get(environment);
 	}
 
 	public RestifyApiClient client(RestifyableType type) {
-		Binder binder = Binder.get(environment);
-
-		BindResult<RestifyApiClient> result = binder.bind("restify." + type.name(), RestifyApiClient.class);
+		BindResult<RestifyApiClient> result = binder.bind(RESTIFY_PROPERTY_PREFIX + type.name(), RestifyApiClient.class);
 
 		return result.orElseGet(RestifyApiClient::new);
 	}

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyAsyncConfiguration.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyAsyncConfiguration.java
@@ -52,10 +52,10 @@ public class RestifyAsyncConfiguration {
 	@Conditional(RestifyAsyncConfiguration.RestifyAsyncTaskExecutorCondition.class)
 	@Bean @Async
 	public AsyncListenableTaskExecutor restifyAsyncTaskExecutor() {
-		return new SimpleAsyncTaskExecutor("RestifyAsyncTaskExecutor");
+		return new SimpleAsyncTaskExecutor("restify-async-task-executor");
 	}
 
-	@Conditional(RestifyAsyncConfiguration.RestifyAsyncExecutorServiceCondition.class)
+	@Conditional(RestifyAsyncExecutorServiceCondition.class)
 	@Bean(name = Async.EXECUTOR_SERVICE_BEAN_NAME) @Async
 	public ExecutorService restifyAsyncExecutorService(@Async AsyncTaskExecutor executor) {
 		return new ExecutorServiceAdapter(executor);
@@ -96,23 +96,6 @@ public class RestifyAsyncConfiguration {
 		return new WebAsyncTaskEndpointCallHandlerAdapter<>(properties.getAsync().getTimeout(), executor);
 	}
 
-	static class RestifyAsyncTaskExecutorCondition extends AllNestedConditions {
-
-		RestifyAsyncTaskExecutorCondition() {
-			super(ConfigurationPhase.REGISTER_BEAN);
-		}
-
-		@ConditionalOnMissingBean(value = AsyncListenableTaskExecutor.class, annotation = Async.class)
-		@Async
-		static class OnRestifyAsyncTaskExecutorMissing {
-		}
-
-		@ConditionalOnMissingBean(value = AsyncListenableTaskExecutor.class, ignored = {
-				SchedulingTaskExecutor.class, TaskScheduler.class, ScheduledExecutorService.class })
-		static class OnAsyncListenableTaskExecutorMissing {
-		}
-	}
-
 	static class RestifyAsyncExecutorServiceCondition extends AllNestedConditions {
 
 		RestifyAsyncExecutorServiceCondition() {
@@ -127,6 +110,23 @@ public class RestifyAsyncConfiguration {
 		@ConditionalOnMissingBean(value = ExecutorService.class, ignored = { SchedulingTaskExecutor.class,
 				TaskScheduler.class, ScheduledExecutorService.class })
 		static class OnExecutorServiceMissing {
+		}
+	}
+	
+	static class RestifyAsyncTaskExecutorCondition extends AllNestedConditions {
+
+		RestifyAsyncTaskExecutorCondition() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnMissingBean(value = AsyncListenableTaskExecutor.class, annotation = Async.class)
+		@Async
+		static class OnRestifyAsyncTaskExecutorMissing {
+		}
+
+		@ConditionalOnMissingBean(value = AsyncListenableTaskExecutor.class, ignored = {
+				SchedulingTaskExecutor.class, TaskScheduler.class, ScheduledExecutorService.class })
+		static class OnAsyncListenableTaskExecutorMissing {
 		}
 	}
 }

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyContractConfiguration.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyContractConfiguration.java
@@ -40,7 +40,7 @@ public class RestifyContractConfiguration {
 	@Configuration
 	@ConditionalOnProperty(name = "restify.contract", havingValue = "jax-rs")
 	@ConditionalOnClass(JaxRsContractReader.class)
-	static class RestifyJaxRSContractConfiguration {
+	static class JaxRSContractConfiguration {
 
 		@ConditionalOnMissingBean
 		@Bean

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyEndpointCallHandlersConfiguration.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyEndpointCallHandlersConfiguration.java
@@ -1,0 +1,267 @@
+/*******************************************************************************
+ *
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.spring.configure;
+
+import java.util.concurrent.ExecutorService;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.ljtfreitas.restify.http.client.call.handler.guava.ListenableFutureCallbackEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.guava.ListenableFutureEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.guava.ListenableFutureTaskEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.guava.OptionalEndpointCallHandlerFactory;
+import com.github.ljtfreitas.restify.http.client.call.handler.jsoup.JsoupDocumentEndpointCallHandlerFactory;
+import com.github.ljtfreitas.restify.http.client.call.handler.rxjava.RxJavaCompletableEndpointCallHandlerFactory;
+import com.github.ljtfreitas.restify.http.client.call.handler.rxjava.RxJavaObservableEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.rxjava.RxJavaSingleEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.rxjava2.RxJava2CompletableEndpointCallHandlerFactory;
+import com.github.ljtfreitas.restify.http.client.call.handler.rxjava2.RxJava2FlowableEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.rxjava2.RxJava2MaybeEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.rxjava2.RxJava2ObservableEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.rxjava2.RxJava2SingleEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.ArrayEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.EitherWithStringEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.EitherWithThrowableEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.FutureEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.IndexedSeqEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.LazyEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.ListEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.OptionEndpointCallHandlerFactory;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.QueueEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.SeqEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.SetEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.TraversableEndpointCallHandlerAdapter;
+import com.github.ljtfreitas.restify.http.client.call.handler.vavr.TryEndpointCallHandlerAdapter;
+
+@Configuration
+public class RestifyEndpointCallHandlersConfiguration {
+
+	@Configuration
+	@ConditionalOnClass(OptionalEndpointCallHandlerFactory.class)
+	static class GuavaEndpointCallHandlersConfiguration {
+
+		@ConditionalOnMissingBean
+		@Bean
+		public OptionalEndpointCallHandlerFactory<Object> guavaOptionalEndpointCallHandlerFactory() {
+			return new OptionalEndpointCallHandlerFactory<>();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public ListenableFutureCallbackEndpointCallHandlerAdapter<Object, Object> guavaListenableFutureCallbackEndpointCallHandlerAdapter(
+				@Async ExecutorService executorService) {
+			return new ListenableFutureCallbackEndpointCallHandlerAdapter<>(executorService);
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public ListenableFutureEndpointCallHandlerAdapter<Object, Object> guavaListenableFutureEndpointCallHandlerAdapter(
+				@Async ExecutorService executorService) {
+			return new ListenableFutureEndpointCallHandlerAdapter<>(executorService);
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public ListenableFutureTaskEndpointCallHandlerAdapter<Object, Object> guavaListenableFutureTaskEndpointCallHandlerAdapter(
+				@Async ExecutorService executorService) {
+			return new ListenableFutureTaskEndpointCallHandlerAdapter<>(executorService);
+		}
+	}
+
+	@Configuration
+	@ConditionalOnClass(JsoupDocumentEndpointCallHandlerFactory.class)
+	static class JsoupEndpointCallHandlersConfiguration {
+
+		@ConditionalOnMissingBean
+		@Bean
+		public JsoupDocumentEndpointCallHandlerFactory jsoupDocumentEndpointCallHandlerFactory() {
+			return new JsoupDocumentEndpointCallHandlerFactory();
+		}
+	}
+
+	@Configuration
+	@ConditionalOnClass(RxJava2ObservableEndpointCallHandlerAdapter.class)
+	static class RxJava2EndpointCallHandlersConfiguration {
+
+		@ConditionalOnMissingBean(value = io.reactivex.Scheduler.class, annotation = Async.class)
+		@Bean @Async
+		public io.reactivex.Scheduler rxJava2Scheduler() {
+			return io.reactivex.schedulers.Schedulers.io();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public RxJava2CompletableEndpointCallHandlerFactory rxJava2CompletableEndpointCallHandlerFactory(
+				@Async io.reactivex.Scheduler scheduler) {
+			return new RxJava2CompletableEndpointCallHandlerFactory(scheduler);
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public RxJava2FlowableEndpointCallHandlerAdapter<Object, Object> RxJava2FlowableEndpointCallHandlerAdapter(
+				@Async io.reactivex.Scheduler scheduler) {
+			return new RxJava2FlowableEndpointCallHandlerAdapter<>(scheduler);
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public RxJava2MaybeEndpointCallHandlerAdapter<Object, Object> rxJava2MaybeEndpointCallHandlerAdapter(
+				@Async io.reactivex.Scheduler scheduler) {
+			return new RxJava2MaybeEndpointCallHandlerAdapter<>(scheduler);
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public RxJava2ObservableEndpointCallHandlerAdapter<Object, Object> rxJava2ObservableEndpointCallHandlerAdapter(
+				@Async io.reactivex.Scheduler scheduler) {
+			return new RxJava2ObservableEndpointCallHandlerAdapter<>(scheduler);
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public RxJava2SingleEndpointCallHandlerAdapter<Object, Object> rxJava2SingleEndpointCallHandlerAdapter(
+				@Async io.reactivex.Scheduler scheduler) {
+			return new RxJava2SingleEndpointCallHandlerAdapter<>(scheduler);
+		}
+	}
+
+	@Configuration
+	@ConditionalOnClass(RxJavaObservableEndpointCallHandlerAdapter.class)
+	static class RxJavaEndpointCallHandlersConfiguration {
+
+		@ConditionalOnMissingBean(value = rx.Scheduler.class, annotation = Async.class)
+		@Bean @Async
+		public rx.Scheduler rxJavaScheduler() {
+			return rx.schedulers.Schedulers.io();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public RxJavaCompletableEndpointCallHandlerFactory rxJavaCompletableEndpointCallHandlerFactory(
+				@Async rx.Scheduler scheduler) {
+			return new RxJavaCompletableEndpointCallHandlerFactory(scheduler);
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public RxJavaObservableEndpointCallHandlerAdapter<Object, Object> rxJavaObservableEndpointCallHandlerAdapter(
+				@Async rx.Scheduler scheduler) {
+			return new RxJavaObservableEndpointCallHandlerAdapter<>(scheduler);
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public RxJavaSingleEndpointCallHandlerAdapter<Object, Object> rxJavaSingleEndpointCallHandlerAdapter(
+				@Async rx.Scheduler scheduler) {
+			return new RxJavaSingleEndpointCallHandlerAdapter<>(scheduler);
+		}
+	}
+	
+	@Configuration
+	@ConditionalOnClass(OptionEndpointCallHandlerFactory.class)
+	static class VavrEndpointCallHandlersConfiguration {
+		
+		@ConditionalOnMissingBean
+		@Bean
+		public ArrayEndpointCallHandlerAdapter<Object, Object> vavrArrayEndpointCallHandlerAdapter() {
+			return new ArrayEndpointCallHandlerAdapter<>();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public EitherWithStringEndpointCallHandlerAdapter<Object, Object> vavrEitherWithStringEndpointCallHandlerAdapter() {
+			return new EitherWithStringEndpointCallHandlerAdapter<>();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public EitherWithThrowableEndpointCallHandlerAdapter<Throwable, Object, Object> vavrEitherWithThrowableEndpointCallHandlerAdapter() {
+			return new EitherWithThrowableEndpointCallHandlerAdapter<>();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public FutureEndpointCallHandlerAdapter<Object, Object> vavrFutureEndpointCallHandlerAdapter() {
+			return new FutureEndpointCallHandlerAdapter<>();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public IndexedSeqEndpointCallHandlerAdapter<Object, Object> vavrIndexedSeqEndpointCallHandlerAdapter() {
+			return new IndexedSeqEndpointCallHandlerAdapter<>();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public LazyEndpointCallHandlerAdapter<Object, Object> vavrLazyEndpointCallHandlerAdapter() {
+			return new LazyEndpointCallHandlerAdapter<>();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public ListEndpointCallHandlerAdapter<Object, Object> vavrListEndpointCallHandlerAdapter() {
+			return new ListEndpointCallHandlerAdapter<>();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public OptionEndpointCallHandlerFactory<Object> vavrOptionEndpointCallHandlerFactory() {
+			return new OptionEndpointCallHandlerFactory<>();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public QueueEndpointCallHandlerAdapter<Object, Object> vavrQueueEndpointCallHandlerAdapter() {
+			return new QueueEndpointCallHandlerAdapter<>();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public SeqEndpointCallHandlerAdapter<Object, Object> vavrSeqEndpointCallHandlerAdapter() {
+			return new SeqEndpointCallHandlerAdapter<>();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public SetEndpointCallHandlerAdapter<Object, Object> vavrSetEndpointCallHandlerAdapter() {
+			return new SetEndpointCallHandlerAdapter<>();
+		}
+
+		@ConditionalOnMissingBean
+		@Bean
+		public TraversableEndpointCallHandlerAdapter<Object, Object> traversableEndpointCallHandlerAdapter() {
+			return new TraversableEndpointCallHandlerAdapter<>();
+		}
+		
+		@ConditionalOnMissingBean
+		@Bean
+		public TryEndpointCallHandlerAdapter<Object, Object> vavrTryEndpointCallHandlerAdapter() {
+			return new TryEndpointCallHandlerAdapter<>();
+		}
+	}
+}

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyHttpMessageConvertersConfiguration.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyHttpMessageConvertersConfiguration.java
@@ -66,11 +66,11 @@ import com.google.gson.Gson;
 public class RestifyHttpMessageConvertersConfiguration {
 
 	@Configuration
-	public static class JsonHttpMessageConverterConfiguration {
+	static class JsonHttpMessageConverterConfiguration {
 	
 		@Configuration
 		@ConditionalOnClass(JacksonMessageConverter.class)
-		public static class JacksonHttpMesssageConverterConfiguration {
+		static class JacksonHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -82,7 +82,7 @@ public class RestifyHttpMessageConvertersConfiguration {
 		
 		@Configuration
 		@ConditionalOnClass(GsonMessageConverter.class)
-		public static class GsonHttpMesssageConverterConfiguration {
+		static class GsonHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -94,7 +94,7 @@ public class RestifyHttpMessageConvertersConfiguration {
 
 		@Configuration
 		@ConditionalOnClass(JsonPMessageConverter.class)
-		public static class JsonPHttpMesssageConverterConfiguration {
+		static class JsonPHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -122,7 +122,7 @@ public class RestifyHttpMessageConvertersConfiguration {
 
 		@Configuration
 		@ConditionalOnClass(JsonBMessageConverter.class)
-		public static class JsonBHttpMesssageConverterConfiguration {
+		static class JsonBHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -145,11 +145,11 @@ public class RestifyHttpMessageConvertersConfiguration {
 	}
 	
 	@Configuration
-	public static class XmlHttpMessageConverterConfiguration {
+	static class XmlHttpMessageConverterConfiguration {
 	
 		@Configuration
 		@ConditionalOnClass(JaxBXmlMessageConverter.class)
-		public static class JaxBHttpMesssageConverterConfiguration {
+		static class JaxBHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -160,11 +160,11 @@ public class RestifyHttpMessageConvertersConfiguration {
 	}
 	
 	@Configuration
-	public static class FormUrlEncodedHttpMessageConverterConfiguration {
+	static class FormUrlEncodedHttpMessageConverterConfiguration {
 	
 		@Configuration
 		@ConditionalOnClass(FormURLEncodedFormObjectMessageConverter.class)
-		public static class FormURLEncodedFormObjectHttpMesssageConverterConfiguration {
+		static class FormURLEncodedFormObjectHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -175,7 +175,7 @@ public class RestifyHttpMessageConvertersConfiguration {
 
 		@Configuration
 		@ConditionalOnClass(FormURLEncodedMapMessageConverter.class)
-		public static class FormURLEncodedMapHttpMesssageConverterConfiguration {
+		static class FormURLEncodedMapHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -186,7 +186,7 @@ public class RestifyHttpMessageConvertersConfiguration {
 
 		@Configuration
 		@ConditionalOnClass(FormURLEncodedParametersMessageConverter.class)
-		public static class FormURLEncodedParametersHttpMesssageConverterConfiguration {
+		static class FormURLEncodedParametersHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -197,11 +197,11 @@ public class RestifyHttpMessageConvertersConfiguration {
 	}
 
 	@Configuration
-	public static class MultipartFormHttpMessageConverterConfiguration {
+	static class MultipartFormHttpMessageConverterConfiguration {
 	
 		@Configuration
 		@ConditionalOnClass(MultipartFormFileObjectMessageWriter.class)
-		public static class MultipartFormFileObjectHttpMesssageConverterConfiguration {
+		static class MultipartFormFileObjectHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -212,7 +212,7 @@ public class RestifyHttpMessageConvertersConfiguration {
 
 		@Configuration
 		@ConditionalOnClass(MultipartFormMapMessageWriter.class)
-		public static class MultipartFormMapHttpMesssageConverterConfiguration {
+		static class MultipartFormMapHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -223,7 +223,7 @@ public class RestifyHttpMessageConvertersConfiguration {
 
 		@Configuration
 		@ConditionalOnClass(MultipartFormObjectMessageWriter.class)
-		public static class MultipartFormObjectHttpMesssageConverterConfiguration {
+		static class MultipartFormObjectHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -234,7 +234,7 @@ public class RestifyHttpMessageConvertersConfiguration {
 
 		@Configuration
 		@ConditionalOnClass(MultipartFormParametersMessageWriter.class)
-		public static class MultipartFormParametersHttpMesssageConverterConfiguration {
+		static class MultipartFormParametersHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -245,11 +245,11 @@ public class RestifyHttpMessageConvertersConfiguration {
 	}
 
 	@Configuration
-	public static class TextHttpMessageConverterConfiguration {
+	static class TextHttpMessageConverterConfiguration {
 	
 		@Configuration
 		@ConditionalOnClass(ScalarMessageConverter.class)
-		public static class ScalarHttpMesssageConverterConfiguration {
+		static class ScalarHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -260,7 +260,7 @@ public class RestifyHttpMessageConvertersConfiguration {
 
 		@Configuration
 		@ConditionalOnClass(TextHtmlMessageConverter.class)
-		public static class TextHtmlHttpMesssageConverterConfiguration {
+		static class TextHtmlHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -271,7 +271,7 @@ public class RestifyHttpMessageConvertersConfiguration {
 
 		@Configuration
 		@ConditionalOnClass(TextPlainMessageConverter.class)
-		public static class TextPlainHttpMesssageConverterConfiguration {
+		static class TextPlainHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -282,11 +282,11 @@ public class RestifyHttpMessageConvertersConfiguration {
 	}
 
 	@Configuration
-	public static class OctetStreamHttpMessageConverterConfiguration {
+	static class OctetStreamHttpMessageConverterConfiguration {
 	
 		@Configuration
 		@ConditionalOnClass(OctetByteArrayMessageConverter.class)
-		public static class OctetStreamHttpMesssageConverterConfiguration {
+		static class OctetStreamHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -297,7 +297,7 @@ public class RestifyHttpMessageConvertersConfiguration {
 
 		@Configuration
 		@ConditionalOnClass(OctetInputStreamMessageConverter.class)
-		public static class OctetInputHttpMesssageConverterConfiguration {
+		static class OctetInputHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean
@@ -308,7 +308,7 @@ public class RestifyHttpMessageConvertersConfiguration {
 
 		@Configuration
 		@ConditionalOnClass(OctetSerializableMessageConverter.class)
-		public static class OctetSerializableHttpMesssageConverterConfiguration {
+		static class OctetSerializableHttpMesssageConverterConfiguration {
 		
 			@ConditionalOnMissingBean
 			@Bean

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyProxyBeanBuilder.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyProxyBeanBuilder.java
@@ -25,11 +25,11 @@
  *******************************************************************************/
 package com.github.ljtfreitas.restify.spring.configure;
 
+import java.util.Collection;
+
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
-
-import com.github.ljtfreitas.restify.http.client.request.authentication.Authentication;
 
 class RestifyProxyBeanBuilder {
 
@@ -39,25 +39,23 @@ class RestifyProxyBeanBuilder {
 		this.builder = BeanDefinitionBuilder.genericBeanDefinition(RestifyProxyFactoryBean.class);
 	}
 
-	public RestifyProxyBeanBuilder objectType(Class<?> objectType) {
+	RestifyProxyBeanBuilder objectType(Class<?> objectType) {
 		builder.addPropertyValue("objectType", objectType);
 		return this;
 	}
 
-	public RestifyProxyBeanBuilder endpoint(String endpoint) {
+	RestifyProxyBeanBuilder endpoint(String endpoint) {
 		builder.addPropertyValue("endpoint", endpoint);
 		return this;
 	}
 
-	public RestifyProxyBeanBuilder asyncExecutorServiceName(String executorServiceName) {
+	RestifyProxyBeanBuilder asyncExecutorServiceName(String executorServiceName) {
 		builder.addPropertyReference("asyncExecutorService", executorServiceName);
 		return this;
 	}
 
-	public RestifyProxyBeanBuilder authentication(Authentication authentication) {
-		if (authentication != null) {
-			builder.addPropertyValue("authentication", authentication);
-		}
+	RestifyProxyBeanBuilder configurations(Collection<RestifyProxyConfiguration> configurations) {
+		builder.addPropertyValue("configurations", configurations);
 		return this;
 	}
 
@@ -69,7 +67,8 @@ class RestifyProxyBeanBuilder {
 
 	private BeanDefinition doBuild() {
 		return builder.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_TYPE)
-						.setLazyInit(true)
-							.getBeanDefinition();
+					.setLazyInit(true)
+						.getBeanDefinition();
 	}
+
 }

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyProxyConfiguration.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyProxyConfiguration.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.spring.configure;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+
+import com.github.ljtfreitas.restify.http.client.call.handler.EndpointCallHandlerProvider;
+import com.github.ljtfreitas.restify.http.client.jdk.HttpClientRequestConfiguration;
+import com.github.ljtfreitas.restify.http.client.message.converter.HttpMessageConverter;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequestExecutor;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequestFactory;
+import com.github.ljtfreitas.restify.http.client.request.authentication.Authentication;
+import com.github.ljtfreitas.restify.http.client.request.interceptor.EndpointRequestInterceptor;
+import com.github.ljtfreitas.restify.http.client.request.interceptor.HttpClientRequestInterceptor;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponseErrorFallback;
+import com.github.ljtfreitas.restify.http.client.retry.RetryConfiguration;
+import com.github.ljtfreitas.restify.http.contract.metadata.ContractExpressionResolver;
+import com.github.ljtfreitas.restify.http.contract.metadata.ContractReader;
+
+public interface RestifyProxyConfiguration {
+
+	public default HttpClientRequestFactory httpClientRequestFactory() {
+		return null;
+	}
+
+	public default HttpClientRequestConfiguration httpClientRequestConfiguration() {
+		return null;
+	}
+	
+	public default ContractReader contractReader() {
+		return null;
+	}
+	
+	public default ContractExpressionResolver contractExpressionResolver() {
+		return null;
+	}
+
+	public default EndpointRequestExecutor endpointRequestExecutor() {
+		return null;
+	}
+
+	public default Collection<EndpointRequestInterceptor> endpointRequestInterceptors() {
+		return Collections.emptyList();
+	}
+
+	public default Collection<HttpClientRequestInterceptor> httpClientRequestInterceptors() {
+		return Collections.emptyList();
+	}
+
+	public default Collection<HttpMessageConverter> converters() {
+		return Collections.emptyList();
+	}
+
+	public default Collection<EndpointCallHandlerProvider> handlers() {
+		return Collections.emptyList();
+	}
+
+	public default Authentication authentication() {
+		return null;
+	}
+
+	public default EndpointResponseErrorFallback endpointResponseErrorFallback() {
+		return null;
+	}
+
+	public default ExecutorService asyncExecutorService() {
+		return null;
+	}
+	
+	public default RetryConfiguration retry() {
+		return null;
+	}
+}

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyProxyFactoryBean.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyProxyFactoryBean.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -108,7 +109,6 @@ public class RestifyProxyFactoryBean implements FactoryBean<Object> {
 				.using(retry())
 			.handlers()
 				.add(handlers())
-					.async(asyncExecutorService())
 				.discovery()
 					.disabled()
 				.and()
@@ -118,6 +118,7 @@ public class RestifyProxyFactoryBean implements FactoryBean<Object> {
 				.discovery()
 					.disabled()
 				.and()
+			.async(asyncExecutor())
 			.error(endpointResponseErrorFallback());
 
 		authentication()
@@ -126,7 +127,8 @@ public class RestifyProxyFactoryBean implements FactoryBean<Object> {
 									.interceptors()
 										.authentication(a));
 
-		return builder.target(objectType, endpoint()).build();
+		return builder.target(objectType, endpoint())
+				.build();
 	}
 
 	@Override
@@ -258,8 +260,8 @@ public class RestifyProxyFactoryBean implements FactoryBean<Object> {
 					.toArray(EndpointCallHandlerProvider[]::new);
 	}
 
-	private ExecutorService asyncExecutorService() {
-		return configured(RestifyProxyConfiguration::asyncExecutorService)
+	private Executor asyncExecutor() {
+		return configured(RestifyProxyConfiguration::asyncExecutor)
 				.orElse(asyncExecutorService);
 	}
 

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifySpringWebConfiguration.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifySpringWebConfiguration.java
@@ -64,21 +64,20 @@ public class RestifySpringWebConfiguration {
 		return new RestOperationsEndpointRequestExecutor(restOperations, endpointResponseErrorFallback);
 	}
 
+	@ConditionalOnMissingBean
+	@Bean
+	public ContractExpressionResolver spelDynamicExpressionResolver(ConfigurableBeanFactory beanFactory) {
+		return new SpelDynamicParameterExpressionResolver(beanFactory);
+	}
+
 	@Configuration
 	@ConditionalOnProperty(name = "restify.contract", havingValue = "spring-web", matchIfMissing = true)
-	public static class RestifySpringWebContractConfiguration {
+	static class SpringWebContractConfiguration {
 
 		@ConditionalOnMissingBean
 		@Bean
 		public ContractReader springWebContractReader(ContractExpressionResolver expressionResolver) {
 			return new SpringWebContractReader(expressionResolver);
 		}
-
-	}
-
-	@ConditionalOnMissingBean
-	@Bean
-	public ContractExpressionResolver spelDynamicExpressionResolver(ConfigurableBeanFactory beanFactory) {
-		return new SpelDynamicParameterExpressionResolver(beanFactory);
 	}
 }

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifySpringWebConfiguration.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifySpringWebConfiguration.java
@@ -74,10 +74,11 @@ public class RestifySpringWebConfiguration {
 			return new SpringWebContractReader(expressionResolver);
 		}
 
-		@ConditionalOnMissingBean
-		@Bean
-		public ContractExpressionResolver spelDynamicExpressionResolver(ConfigurableBeanFactory beanFactory) {
-			return new SpelDynamicParameterExpressionResolver(beanFactory);
-		}
+	}
+
+	@ConditionalOnMissingBean
+	@Bean
+	public ContractExpressionResolver spelDynamicExpressionResolver(ConfigurableBeanFactory beanFactory) {
+		return new SpelDynamicParameterExpressionResolver(beanFactory);
 	}
 }

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifySpringWebFluxConfiguration.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifySpringWebFluxConfiguration.java
@@ -40,6 +40,9 @@ import com.github.ljtfreitas.restify.http.client.request.EndpointRequestExecutor
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponseErrorFallback;
 import com.github.ljtfreitas.restify.http.spring.client.request.async.WebClientEndpointRequestExecutor;
 
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
 @Configuration
 @ConditionalOnClass(WebClient.class)
 public class RestifySpringWebFluxConfiguration {
@@ -59,7 +62,13 @@ public class RestifySpringWebFluxConfiguration {
 	@Configuration
 	@ConditionalOnClass(FluxEndpointCallHandlerAdapter.class)
 	static class ReactiveHandlersConfiguration {
-	
+
+		@ConditionalOnMissingBean
+		@Bean @Async
+		public Scheduler reactorScheduler() {
+			return Schedulers.newElastic("java-restify-reactor-scheduler");
+		}
+
 		@ConditionalOnMissingBean
 		@Bean
 		public FluxEndpointCallHandlerAdapter<Object, Object> fluxEndpointCallHandlerAdater() {

--- a/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyableType.java
+++ b/java-restify-spring-autoconfigure/src/main/java/com/github/ljtfreitas/restify/spring/configure/RestifyableType.java
@@ -28,7 +28,10 @@ package com.github.ljtfreitas.restify.spring.configure;
 import static org.springframework.core.annotation.AnnotationUtils.findAnnotation;
 
 import java.beans.Introspector;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.github.ljtfreitas.restify.util.Try;
 
@@ -49,11 +52,11 @@ class RestifyableType {
 				.orElseThrow(() -> new IllegalArgumentException("[" + objectType.getCanonicalName() + "] must be annotated with @Restifyable."));
 	}
 
-	public Class<?> objectType() {
+	Class<?> objectType() {
 		return objectType;
 	}
 
-	public String name() {
+	String name() {
 		return Optional.ofNullable(restifyable.name())
 				.filter(n -> !n.isEmpty())
 					.map(RestifyableTypeName::new)
@@ -61,12 +64,16 @@ class RestifyableType {
 							.toString();
 	}
 
-	public String description() {
+	String description() {
 		return restifyable.description();
 	}
 
-	public Optional<String> endpoint() {
+	Optional<String> endpoint() {
 		return Optional.ofNullable(restifyable.endpoint()).filter(endpoint -> !endpoint.isEmpty());
+	}
+	
+	Collection<Class<? extends RestifyProxyConfiguration>> configurations() {
+		return Arrays.stream(restifyable.configuration()).collect(Collectors.toList());
 	}
 
 	private static class RestifyableTypeName {

--- a/java-restify-spring-autoconfigure/src/test/java/com/github/ljtfreitas/restify/spring/autoconfigure/MyCustomizedApi.java
+++ b/java-restify-spring-autoconfigure/src/test/java/com/github/ljtfreitas/restify/spring/autoconfigure/MyCustomizedApi.java
@@ -1,0 +1,12 @@
+package com.github.ljtfreitas.restify.spring.autoconfigure;
+
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.github.ljtfreitas.restify.spring.configure.Restifyable;
+
+@Restifyable(name = "my-customized-api", configuration = MyCustomizedApiConfiguration.class)
+public interface MyCustomizedApi {
+
+	@GetMapping("/sample-customized")
+	String sample();
+}

--- a/java-restify-spring-autoconfigure/src/test/java/com/github/ljtfreitas/restify/spring/autoconfigure/MyCustomizedApiConfiguration.java
+++ b/java-restify-spring-autoconfigure/src/test/java/com/github/ljtfreitas/restify/spring/autoconfigure/MyCustomizedApiConfiguration.java
@@ -23,22 +23,28 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-package com.github.ljtfreitas.restify.spring.configure;
+package com.github.ljtfreitas.restify.spring.autoconfigure;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.util.Arrays;
+import java.util.Collection;
 
-@Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
-public @interface Restifyable {
+import org.springframework.context.annotation.Configuration;
 
-	String name() default "";
+import com.github.ljtfreitas.restify.http.client.message.Header;
+import com.github.ljtfreitas.restify.http.client.request.authentication.BasicAuthentication;
+import com.github.ljtfreitas.restify.http.client.request.interceptor.EndpointRequestInterceptor;
+import com.github.ljtfreitas.restify.http.client.request.interceptor.HeaderEndpointRequestInterceptor;
+import com.github.ljtfreitas.restify.http.client.request.interceptor.authentication.AuthenticationEndpoinRequestInterceptor;
+import com.github.ljtfreitas.restify.spring.configure.RestifyProxyConfiguration;
 
-	String description() default "";
+@Configuration
+class MyCustomizedApiConfiguration implements RestifyProxyConfiguration {
+	
+	@Override
+	public Collection<EndpointRequestInterceptor> endpointRequestInterceptors() {
+		EndpointRequestInterceptor header = new HeaderEndpointRequestInterceptor(Header.of("X-Customized", "true"));
+		EndpointRequestInterceptor authentication = new AuthenticationEndpoinRequestInterceptor(new BasicAuthentication("username", "password"));
 
-	String endpoint() default "";
-
-	Class<? extends RestifyProxyConfiguration>[] configuration() default {};
+		return Arrays.asList(header, authentication);
+	}
 }

--- a/java-restify-spring-autoconfigure/src/test/java/com/github/ljtfreitas/restify/spring/autoconfigure/RestifyAutoConfigurationTest.java
+++ b/java-restify-spring-autoconfigure/src/test/java/com/github/ljtfreitas/restify/spring/autoconfigure/RestifyAutoConfigurationTest.java
@@ -93,6 +93,17 @@ public class RestifyAutoConfigurationTest {
 						.withStatusCode(200)
 						.withHeader("Content-Type", "text/plain")
 						.withBody("It's works!"));
+			
+			mockServerClient
+				.when(request()
+					.withMethod("GET")
+					.withPath("/sample-customized")
+					.withHeader("X-Customized", "true")
+					.withHeader("Authorization", "Basic dXNlcm5hbWU6cGFzc3dvcmQ="))
+				.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "text/plain")
+					.withBody("It's works!"));
 		}
 	
 		@Test
@@ -106,6 +117,20 @@ public class RestifyAutoConfigurationTest {
 				MyApi myApi = context.getBean(MyApi.class);
 	
 				assertEquals("It's works!", myApi.sample());
+			});
+		}
+
+		@Test
+		public void shouldCreateBeanOfMyCustomizedApiType() {
+			ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+					.withUserConfiguration(TestRestifyConfiguration.class)
+					.withConfiguration(AutoConfigurations.of(RestifyAutoConfiguration.class))
+					.withPropertyValues("restify.my-customized-api.endpoint:http://localhost:8080");
+	
+			contextRunner.run(context -> {
+				MyCustomizedApi myCustomizedApi = context.getBean(MyCustomizedApi.class);
+
+				assertEquals("It's works!", myCustomizedApi.sample());
 			});
 		}
 	}
@@ -408,7 +433,7 @@ public class RestifyAutoConfigurationTest {
 	}
 
 	@Configuration
-	@Import(TestRestifyConfigurationRegistrar.class)
+	@Import({MyCustomizedApiConfiguration.class, TestRestifyConfigurationRegistrar.class})
 	static class TestRestifyConfiguration {
 
 		static class TestRestifyConfigurationRegistrar implements ImportBeanDefinitionRegistrar {

--- a/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/client/call/handler/async/ListenableFutureEndpointCallHandlerAdapter.java
+++ b/java-restify-spring/src/main/java/com/github/ljtfreitas/restify/http/spring/client/call/handler/async/ListenableFutureEndpointCallHandlerAdapter.java
@@ -39,10 +39,15 @@ import com.github.ljtfreitas.restify.http.client.call.handler.async.AsyncEndpoin
 import com.github.ljtfreitas.restify.http.client.call.handler.async.AsyncEndpointCallHandlerAdapter;
 import com.github.ljtfreitas.restify.http.contract.metadata.EndpointMethod;
 import com.github.ljtfreitas.restify.reflection.JavaType;
+import com.github.ljtfreitas.restify.util.async.DisposableExecutors;
 
 public class ListenableFutureEndpointCallHandlerAdapter<T, O> implements AsyncEndpointCallHandlerAdapter<ListenableFuture<T>, T, O> {
 
 	private final Executor executor;
+
+	public ListenableFutureEndpointCallHandlerAdapter() {
+		this(DisposableExecutors.newCachedThreadPool());
+	}
 
 	public ListenableFutureEndpointCallHandlerAdapter(Executor executor) {
 		this.executor = executor;

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
 		<developerConnection>scm:git:git@github.com:ljtfreitas/java-restify.git</developerConnection>
 		<url>https://github.com/ljtfreitas/java-restify</url>
 	  <tag>HEAD</tag>
-  </scm>
+  	</scm>
 
 	<issueManagement>
 		<system>Github Issues</system>


### PR DESCRIPTION
## Configuração de bean do Spring/CDI

### Descrição
- Permite customização específica para proxies gerados pela autoconfiguração do Spring ou pelo plugin do CDI

### Changelog
- Adiciona o parâmetro `configuration` à anotação *@Restifyable*, para permitir a criação de configurações específicas por objeto
