### PR TITLE
[jersey-http-client-async] Jersey HTTP Client Async

### DIFF
--- a/java-restify-http-client-jersey/pom.xml
+++ b/java-restify-http-client-jersey/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.github.ljtfreitas</groupId>
@@ -30,6 +32,16 @@
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
 			<version>2.27</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.ext.rx</groupId>
+			<artifactId>jersey-rx-client-rxjava</artifactId>
+			<version>2.28</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.ext.rx</groupId>
+			<artifactId>jersey-rx-client-rxjava2</artifactId>
+			<version>2.28</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>

--- a/java-restify-http-client-jersey/src/main/java/com/github/ljtfreitas/restify/http/client/request/jersey/EndpointResponseConverter.java
+++ b/java-restify-http-client-jersey/src/main/java/com/github/ljtfreitas/restify/http/client/request/jersey/EndpointResponseConverter.java
@@ -36,7 +36,7 @@ import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponseErrorFallback;
 import com.github.ljtfreitas.restify.reflection.JavaType;
 
-class EndpointResponseConverter {
+public class EndpointResponseConverter {
 
 	private final EndpointResponseErrorFallback endpointResponseErrorFallback;
 

--- a/java-restify-http-client-jersey/src/main/java/com/github/ljtfreitas/restify/http/client/request/jersey/JerseyAsyncHttpClientEndpointRequestExecutor.java
+++ b/java-restify-http-client-jersey/src/main/java/com/github/ljtfreitas/restify/http/client/request/jersey/JerseyAsyncHttpClientEndpointRequestExecutor.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.jersey;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.Response;
+
+import com.github.ljtfreitas.restify.http.client.HttpException;
+import com.github.ljtfreitas.restify.http.client.message.converter.HttpMessageReadException;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.async.AsyncEndpointRequestExecutor;
+import com.github.ljtfreitas.restify.http.client.response.EmptyOnNotFoundEndpointResponseErrorFallback;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponseErrorFallback;
+
+public class JerseyAsyncHttpClientEndpointRequestExecutor implements AsyncEndpointRequestExecutor {
+
+	private final InvocationBuilder invocationBuilder;
+	private final EndpointResponseConverter endpointResponseConverter;
+
+	public JerseyAsyncHttpClientEndpointRequestExecutor() {
+		this(ClientBuilder.newClient());
+	}
+
+	public JerseyAsyncHttpClientEndpointRequestExecutor(EndpointResponseErrorFallback endpointResponseErrorFallback) {
+		this(ClientBuilder.newClient(), endpointResponseErrorFallback);
+	}
+
+	public JerseyAsyncHttpClientEndpointRequestExecutor(Configuration configuration) {
+		this(ClientBuilder.newClient(configuration));
+	}
+
+	public JerseyAsyncHttpClientEndpointRequestExecutor(Configuration configuration, EndpointResponseErrorFallback endpointResponseErrorFallback) {
+		this(ClientBuilder.newClient(configuration), endpointResponseErrorFallback);
+	}
+
+	public JerseyAsyncHttpClientEndpointRequestExecutor(Client client) {
+		this(client, new EmptyOnNotFoundEndpointResponseErrorFallback());
+	}
+
+	public JerseyAsyncHttpClientEndpointRequestExecutor(Client client, EndpointResponseErrorFallback endpointResponseErrorFallback) {
+		this.invocationBuilder = new InvocationBuilder(client);
+		this.endpointResponseConverter = new EndpointResponseConverter(endpointResponseErrorFallback);
+	}
+
+	@Override
+	public <T> CompletionStage<EndpointResponse<T>> executeAsync(EndpointRequest endpointRequest) {
+		CompletionStage<Response> stage = invocationBuilder.of(endpointRequest).rx();
+		return stage.<EndpointResponse<T>> thenApplyAsync(response -> endpointResponseConverter.convert(response, endpointRequest))
+						.whenCompleteAsync((response, e) -> doHandle(response, e, endpointRequest));
+	}
+
+	private <T> void doHandle(EndpointResponse<T> response, Throwable throwable, EndpointRequest endpointRequest) {
+		if (throwable != null) {
+			if (throwable instanceof HttpException) {
+				throw (HttpException) throwable;
+
+			} else if (throwable instanceof WebApplicationException) {
+				throw new HttpMessageReadException(throwable);
+
+			} else {
+				throw new HttpException("Error on HTTP request: [" + endpointRequest.method() + " " + endpointRequest.endpoint() + "]", throwable);
+			}
+		}
+	}
+}

--- a/java-restify-http-client-jersey/src/main/java/com/github/ljtfreitas/restify/http/client/request/jersey/JerseyHttpClientEndpointRequestExecutor.java
+++ b/java-restify-http-client-jersey/src/main/java/com/github/ljtfreitas/restify/http/client/request/jersey/JerseyHttpClientEndpointRequestExecutor.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.jersey;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.Response;
+
+import com.github.ljtfreitas.restify.http.client.HttpException;
+import com.github.ljtfreitas.restify.http.client.message.converter.HttpMessageReadException;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequestExecutor;
+import com.github.ljtfreitas.restify.http.client.response.EmptyOnNotFoundEndpointResponseErrorFallback;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponseErrorFallback;
+
+public class JerseyHttpClientEndpointRequestExecutor implements EndpointRequestExecutor {
+
+	private final InvocationBuilder invocationBuilder;
+	private final EndpointResponseConverter endpointResponseConverter;
+
+	public JerseyHttpClientEndpointRequestExecutor() {
+		this(ClientBuilder.newClient());
+	}
+
+	public JerseyHttpClientEndpointRequestExecutor(EndpointResponseErrorFallback endpointResponseErrorFallback) {
+		this(ClientBuilder.newClient(), endpointResponseErrorFallback);
+	}
+
+	public JerseyHttpClientEndpointRequestExecutor(Configuration configuration) {
+		this(ClientBuilder.newClient(configuration));
+	}
+
+	public JerseyHttpClientEndpointRequestExecutor(Configuration configuration, EndpointResponseErrorFallback endpointResponseErrorFallback) {
+		this(ClientBuilder.newClient(configuration), endpointResponseErrorFallback);
+	}
+
+	public JerseyHttpClientEndpointRequestExecutor(Client client) {
+		this(client, new EmptyOnNotFoundEndpointResponseErrorFallback());
+	}
+
+	public JerseyHttpClientEndpointRequestExecutor(Client client, EndpointResponseErrorFallback endpointResponseErrorFallback) {
+		this.invocationBuilder = new InvocationBuilder(client);
+		this.endpointResponseConverter = new EndpointResponseConverter(endpointResponseErrorFallback);
+	}
+
+	@Override
+	public <T> EndpointResponse<T> execute(EndpointRequest endpointRequest) {
+		try {
+			Invocation invocation = invocationBuilder.of(endpointRequest).build();
+
+			Response response = invocation.invoke();
+
+			EndpointResponse<T> endpointResponse = endpointResponseConverter.convert(response, endpointRequest);
+
+			response.close();
+
+			return endpointResponse;
+
+		} catch (HttpException e) {
+			throw e;
+
+		} catch (WebApplicationException e) {
+			throw new HttpMessageReadException(e);
+
+		} catch (Exception e) {
+			throw new HttpException("Error on HTTP request: [" + endpointRequest.method() + " " + endpointRequest.endpoint() + "]", e);
+		}
+	}
+}

--- a/java-restify-http-client-jersey/src/main/java/com/github/ljtfreitas/restify/http/client/request/jersey/JerseyRxFlowableHttpClientEndpointRequestExecutor.java
+++ b/java-restify-http-client-jersey/src/main/java/com/github/ljtfreitas/restify/http/client/request/jersey/JerseyRxFlowableHttpClientEndpointRequestExecutor.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.jersey;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.Response;
+
+import org.glassfish.jersey.client.rx.rxjava2.RxFlowableInvoker;
+import org.glassfish.jersey.client.rx.rxjava2.RxFlowableInvokerProvider;
+
+import com.github.ljtfreitas.restify.http.client.HttpException;
+import com.github.ljtfreitas.restify.http.client.message.converter.HttpMessageReadException;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.async.AsyncEndpointRequestExecutor;
+import com.github.ljtfreitas.restify.http.client.response.EmptyOnNotFoundEndpointResponseErrorFallback;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponseErrorFallback;
+
+import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
+
+public class JerseyRxFlowableHttpClientEndpointRequestExecutor implements AsyncEndpointRequestExecutor {
+
+	private final InvocationBuilder invocationBuilder;
+	private final EndpointResponseConverter endpointResponseConverter;
+
+	public JerseyRxFlowableHttpClientEndpointRequestExecutor() {
+		this(ClientBuilder.newClient());
+	}
+
+	public JerseyRxFlowableHttpClientEndpointRequestExecutor(EndpointResponseErrorFallback endpointResponseErrorFallback) {
+		this(ClientBuilder.newClient(), endpointResponseErrorFallback);
+	}
+
+	public JerseyRxFlowableHttpClientEndpointRequestExecutor(Configuration configuration) {
+		this(ClientBuilder.newClient(configuration));
+	}
+
+	public JerseyRxFlowableHttpClientEndpointRequestExecutor(Configuration configuration, EndpointResponseErrorFallback endpointResponseErrorFallback) {
+		this(ClientBuilder.newClient(configuration), endpointResponseErrorFallback);
+	}
+
+	public JerseyRxFlowableHttpClientEndpointRequestExecutor(Client client) {
+		this(client, new EmptyOnNotFoundEndpointResponseErrorFallback());
+	}
+
+	public JerseyRxFlowableHttpClientEndpointRequestExecutor(Client client, EndpointResponseErrorFallback endpointResponseErrorFallback) {
+		this.invocationBuilder = new InvocationBuilder(configure(client));
+		this.endpointResponseConverter = new EndpointResponseConverter(endpointResponseErrorFallback);
+	}
+
+	private Client configure(Client client) {
+		return client.register(RxFlowableInvokerProvider.class);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> CompletionStage<EndpointResponse<T>> executeAsync(EndpointRequest endpointRequest) {
+		Flowable<Response> flowable = invocationBuilder.of(endpointRequest).rx(RxFlowableInvoker.class);
+
+		CompletableFuture<EndpointResponse<T>> future = new CompletableFuture<>();
+
+		Function<Throwable, Flowable<EndpointResponse<T>>> onError = e -> handleException(e, endpointRequest);
+
+		flowable
+			.<EndpointResponse<T>> map(response -> endpointResponseConverter.convert(response, endpointRequest))
+			.onErrorResumeNext(onError)
+				.subscribe(future::complete, future::completeExceptionally);
+
+		return future;
+	}
+
+	private <T> Flowable<EndpointResponse<T>> handleException(Throwable throwable, EndpointRequest endpointRequest) {
+		if (throwable instanceof HttpException) {
+			return Flowable.error(throwable);
+
+		} else if (throwable instanceof WebApplicationException) {
+			return Flowable.error(new HttpMessageReadException(throwable));
+
+		} else {
+			return Flowable.error(new HttpException("Error on HTTP request: [" + endpointRequest.method() + " " + endpointRequest.endpoint() + "]", throwable));
+		}
+	}
+}

--- a/java-restify-http-client-jersey/src/test/java/com/github/ljtfreitas/restify/http/client/request/jersey/JerseyAsyncHttpClientEndpointRequestExecutorTest.java
+++ b/java-restify-http-client-jersey/src/test/java/com/github/ljtfreitas/restify/http/client/request/jersey/JerseyAsyncHttpClientEndpointRequestExecutorTest.java
@@ -1,0 +1,227 @@
+package com.github.ljtfreitas.restify.http.client.request.jersey;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+import static org.mockserver.model.StringBody.exact;
+import static org.mockserver.verify.VerificationTimes.once;
+
+import java.net.URI;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockserver.client.server.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.HttpRequest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.ljtfreitas.restify.http.client.message.Header;
+import com.github.ljtfreitas.restify.http.client.message.Headers;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponseException;
+
+public class JerseyAsyncHttpClientEndpointRequestExecutorTest {
+
+	@Rule
+	public MockServerRule mockServerRule = new MockServerRule(this, 7080);
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	private JerseyAsyncHttpClientEndpointRequestExecutor executor;
+
+	private MockServerClient mockServerClient;
+
+	@Before
+	public void setup() {
+		mockServerClient = new MockServerClient("localhost", 7080);
+
+		executor = new JerseyAsyncHttpClientEndpointRequestExecutor();
+	}
+
+	@Test
+	public void shouldSendGetRequestOnJsonFormat() {
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/json"))
+			.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "application/json")
+					.withBody(json("{\"name\": \"Tiago de Freitas Lima\",\"age\":31}")));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "GET", MyModel.class);
+
+		EndpointResponse<MyModel> myModelResponse = executor.<MyModel> executeAsync(endpointRequest)
+				.toCompletableFuture().join();
+
+		assertTrue(myModelResponse.status().isOk());
+
+		MyModel myModel = myModelResponse.body();
+
+		assertEquals("Tiago de Freitas Lima", myModel.name);
+		assertEquals(31, myModel.age);
+	}
+
+	@Test
+	public void shouldSendPostRequestOnJsonFormat() {
+		HttpRequest httpRequest = request()
+			.withMethod("POST")
+			.withPath("/json")
+			.withHeader("Content-Type", "application/json")
+			.withBody(json("{\"name\":\"Tiago de Freitas Lima\",\"age\":31}"));
+
+		mockServerClient
+			.when(httpRequest)
+				.respond(response()
+						.withStatusCode(201)
+						.withHeader("Content-Type", "text/plain")
+						.withBody(exact("OK")));
+
+		MyModel myModel = new MyModel("Tiago de Freitas Lima", 31);
+
+		Headers headers = new Headers()
+				.add(new Header("Content-Type", "application/json"));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "POST", headers,
+				myModel, String.class);
+
+		EndpointResponse<String> myModelResponse = executor.<String> executeAsync(endpointRequest)
+				.toCompletableFuture()
+					.join();
+
+		assertTrue(myModelResponse.status().isCreated());
+
+		assertEquals("OK", myModelResponse.body());
+
+		mockServerClient.verify(httpRequest, once());
+	}
+
+	@Test
+	public void shouldSendGetRequestOnXmlFormat() {
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/xml"))
+			.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "application/xml")
+					.withBody(exact("<model><name>Tiago de Freitas Lima</name><age>31</age></model>")));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/xml"), "GET", MyModel.class);
+
+		EndpointResponse<MyModel> myModelResponse = executor.<MyModel> executeAsync(endpointRequest)
+				.toCompletableFuture()
+					.join();
+
+		assertTrue(myModelResponse.status().isOk());
+
+		MyModel myModel = myModelResponse.body();
+
+		assertEquals("Tiago de Freitas Lima", myModel.name);
+		assertEquals(31, myModel.age);
+	}
+
+	@Test
+	public void shouldSendPostRequestOnXmlFormat() {
+		HttpRequest httpRequest = request()
+			.withMethod("POST")
+			.withPath("/xml")
+			.withHeader("Content-Type", "application/xml")
+			.withBody(exact("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><model><name>Tiago de Freitas Lima</name><age>31</age></model>"));
+
+		mockServerClient
+			.when(httpRequest)
+				.respond(response()
+						.withStatusCode(201)
+						.withHeader("Content-Type", "text/plain")
+						.withBody(exact("OK")));
+
+		MyModel myModel = new MyModel("Tiago de Freitas Lima", 31);
+
+		Headers headers = new Headers()
+				.add(new Header("Content-Type", "application/xml"));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/xml"), "POST", headers,
+				myModel, String.class);
+
+		EndpointResponse<String> myModelResponse = executor.<String> executeAsync(endpointRequest)
+				.toCompletableFuture()
+					.join();
+
+		assertTrue(myModelResponse.status().isCreated());
+
+		assertEquals("OK", myModelResponse.body());
+
+		mockServerClient.verify(httpRequest, once());
+	}
+
+	@Test
+	public void shouldReadServerErrorResponse() {
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/json"))
+			.respond(response()
+					.withStatusCode(500));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "GET", MyModel.class);
+
+		EndpointResponse<Object> endpointResponse = executor.executeAsync(endpointRequest)
+			.exceptionally(e -> EndpointResponse.error((EndpointResponseException) e.getCause()))
+				.toCompletableFuture()
+					.join();
+
+		assertThat(endpointResponse.status().isInternalServerError(), is(true));
+	}
+
+	@Test
+	public void shouldReturnNullBodyWhenResponseIsNotFound() {
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/json"))
+			.respond(response()
+					.withStatusCode(404));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "GET", MyModel.class);
+
+		EndpointResponse<Object> endpointResponse = executor.<Object> executeAsync(endpointRequest)
+				.toCompletableFuture()
+					.join();
+
+		assertTrue(endpointResponse.status().isNotFound());
+		assertNull(endpointResponse.body());
+	}
+
+	@XmlRootElement(name = "model")
+	@XmlAccessorType(XmlAccessType.FIELD)
+	public static class MyModel {
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		int age;
+
+		public MyModel() {
+		}
+
+		public MyModel(@JsonProperty String name, @JsonProperty int age) {
+			this.name = name;
+			this.age = age;
+		}
+	}
+}

--- a/java-restify-http-client-jersey/src/test/java/com/github/ljtfreitas/restify/http/client/request/jersey/JerseyHttpClientEndpointRequestExecutorTest.java
+++ b/java-restify-http-client-jersey/src/test/java/com/github/ljtfreitas/restify/http/client/request/jersey/JerseyHttpClientEndpointRequestExecutorTest.java
@@ -1,0 +1,211 @@
+package com.github.ljtfreitas.restify.http.client.request.jersey;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+import static org.mockserver.model.StringBody.exact;
+import static org.mockserver.verify.VerificationTimes.once;
+
+import java.net.URI;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockserver.client.server.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.HttpRequest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.ljtfreitas.restify.http.client.message.Header;
+import com.github.ljtfreitas.restify.http.client.message.Headers;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponseInternalServerErrorException;
+
+public class JerseyHttpClientEndpointRequestExecutorTest {
+
+	@Rule
+	public MockServerRule mockServerRule = new MockServerRule(this, 7080);
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	private JerseyHttpClientEndpointRequestExecutor executor;
+
+	private MockServerClient mockServerClient;
+
+	@Before
+	public void setup() {
+		mockServerClient = new MockServerClient("localhost", 7080);
+
+		executor = new JerseyHttpClientEndpointRequestExecutor();
+	}
+
+	@Test
+	public void shouldSendGetRequestOnJsonFormat() {
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/json"))
+			.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "application/json")
+					.withBody(json("{\"name\": \"Tiago de Freitas Lima\",\"age\":31}")));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "GET", MyModel.class);
+
+		EndpointResponse<MyModel> myModelResponse = executor.execute(endpointRequest);
+
+		assertTrue(myModelResponse.status().isOk());
+
+		MyModel myModel = myModelResponse.body();
+
+		assertEquals("Tiago de Freitas Lima", myModel.name);
+		assertEquals(31, myModel.age);
+	}
+
+	@Test
+	public void shouldSendPostRequestOnJsonFormat() {
+		HttpRequest httpRequest = request()
+			.withMethod("POST")
+			.withPath("/json")
+			.withHeader("Content-Type", "application/json")
+			.withBody(json("{\"name\":\"Tiago de Freitas Lima\",\"age\":31}"));
+
+		mockServerClient
+			.when(httpRequest)
+				.respond(response()
+						.withStatusCode(201)
+						.withHeader("Content-Type", "text/plain")
+						.withBody(exact("OK")));
+
+		MyModel myModel = new MyModel("Tiago de Freitas Lima", 31);
+
+		Headers headers = new Headers()
+				.add(new Header("Content-Type", "application/json"));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "POST", headers,
+				myModel, String.class);
+
+		EndpointResponse<String> myModelResponse = executor.execute(endpointRequest);
+
+		assertTrue(myModelResponse.status().isCreated());
+
+		assertEquals("OK", myModelResponse.body());
+
+		mockServerClient.verify(httpRequest, once());
+	}
+
+	@Test
+	public void shouldSendGetRequestOnXmlFormat() {
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/xml"))
+			.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "application/xml")
+					.withBody(exact("<model><name>Tiago de Freitas Lima</name><age>31</age></model>")));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/xml"), "GET", MyModel.class);
+
+		EndpointResponse<MyModel> myModelResponse = executor.execute(endpointRequest);
+
+		assertTrue(myModelResponse.status().isOk());
+
+		MyModel myModel = myModelResponse.body();
+
+		assertEquals("Tiago de Freitas Lima", myModel.name);
+		assertEquals(31, myModel.age);
+	}
+
+	@Test
+	public void shouldSendPostRequestOnXmlFormat() {
+		HttpRequest httpRequest = request()
+			.withMethod("POST")
+			.withPath("/xml")
+			.withHeader("Content-Type", "application/xml")
+			.withBody(exact("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><model><name>Tiago de Freitas Lima</name><age>31</age></model>"));
+
+		mockServerClient
+			.when(httpRequest)
+				.respond(response()
+						.withStatusCode(201)
+						.withHeader("Content-Type", "text/plain")
+						.withBody(exact("OK")));
+
+		MyModel myModel = new MyModel("Tiago de Freitas Lima", 31);
+
+		Headers headers = new Headers()
+				.add(new Header("Content-Type", "application/xml"));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/xml"), "POST", headers,
+				myModel, String.class);
+
+		EndpointResponse<String> myModelResponse = executor.execute(endpointRequest);
+
+		assertTrue(myModelResponse.status().isCreated());
+
+		assertEquals("OK", myModelResponse.body());
+
+		mockServerClient.verify(httpRequest, once());
+	}
+
+	@Test(expected = EndpointResponseInternalServerErrorException.class)
+	public void shouldReadServerErrorResponse() {
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/json"))
+			.respond(response()
+					.withStatusCode(500));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "GET", MyModel.class);
+
+		executor.execute(endpointRequest);
+	}
+
+	@Test
+	public void shouldReturnNullBodyWhenResponseIsNotFound() {
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/json"))
+			.respond(response()
+					.withStatusCode(404));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "GET", MyModel.class);
+
+		EndpointResponse<Object> endpointResponse = executor.execute(endpointRequest);
+
+		assertTrue(endpointResponse.status().isNotFound());
+		assertNull(endpointResponse.body());
+	}
+
+	@XmlRootElement(name = "model")
+	@XmlAccessorType(XmlAccessType.FIELD)
+	public static class MyModel {
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		int age;
+
+		public MyModel() {
+		}
+
+		public MyModel(@JsonProperty String name, @JsonProperty int age) {
+			this.name = name;
+			this.age = age;
+		}
+	}
+}

--- a/java-restify-http-client-jersey/src/test/java/com/github/ljtfreitas/restify/http/client/request/jersey/JerseyRxObservableHttpClientEndpointRequestExecutorTest.java
+++ b/java-restify-http-client-jersey/src/test/java/com/github/ljtfreitas/restify/http/client/request/jersey/JerseyRxObservableHttpClientEndpointRequestExecutorTest.java
@@ -1,0 +1,227 @@
+package com.github.ljtfreitas.restify.http.client.request.jersey;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+import static org.mockserver.model.StringBody.exact;
+import static org.mockserver.verify.VerificationTimes.once;
+
+import java.net.URI;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockserver.client.server.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.HttpRequest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.ljtfreitas.restify.http.client.message.Header;
+import com.github.ljtfreitas.restify.http.client.message.Headers;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
+import com.github.ljtfreitas.restify.http.client.response.EndpointResponseException;
+
+public class JerseyRxObservableHttpClientEndpointRequestExecutorTest {
+
+	@Rule
+	public MockServerRule mockServerRule = new MockServerRule(this, 7080);
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	private JerseyRxObservableHttpClientEndpointRequestExecutor executor;
+
+	private MockServerClient mockServerClient;
+
+	@Before
+	public void setup() {
+		mockServerClient = new MockServerClient("localhost", 7080);
+
+		executor = new JerseyRxObservableHttpClientEndpointRequestExecutor();
+	}
+
+	@Test
+	public void shouldSendGetRequestOnJsonFormat() {
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/json"))
+			.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "application/json")
+					.withBody(json("{\"name\": \"Tiago de Freitas Lima\",\"age\":31}")));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "GET", MyModel.class);
+
+		EndpointResponse<MyModel> myModelResponse = executor.<MyModel> executeAsync(endpointRequest)
+				.toCompletableFuture().join();
+
+		assertTrue(myModelResponse.status().isOk());
+
+		MyModel myModel = myModelResponse.body();
+
+		assertEquals("Tiago de Freitas Lima", myModel.name);
+		assertEquals(31, myModel.age);
+	}
+
+	@Test
+	public void shouldSendPostRequestOnJsonFormat() {
+		HttpRequest httpRequest = request()
+			.withMethod("POST")
+			.withPath("/json")
+			.withHeader("Content-Type", "application/json")
+			.withBody(json("{\"name\":\"Tiago de Freitas Lima\",\"age\":31}"));
+
+		mockServerClient
+			.when(httpRequest)
+				.respond(response()
+						.withStatusCode(201)
+						.withHeader("Content-Type", "text/plain")
+						.withBody(exact("OK")));
+
+		MyModel myModel = new MyModel("Tiago de Freitas Lima", 31);
+
+		Headers headers = new Headers()
+				.add(new Header("Content-Type", "application/json"));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "POST", headers,
+				myModel, String.class);
+
+		EndpointResponse<String> myModelResponse = executor.<String> executeAsync(endpointRequest)
+				.toCompletableFuture()
+					.join();
+
+		assertTrue(myModelResponse.status().isCreated());
+
+		assertEquals("OK", myModelResponse.body());
+
+		mockServerClient.verify(httpRequest, once());
+	}
+
+	@Test
+	public void shouldSendGetRequestOnXmlFormat() {
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/xml"))
+			.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "application/xml")
+					.withBody(exact("<model><name>Tiago de Freitas Lima</name><age>31</age></model>")));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/xml"), "GET", MyModel.class);
+
+		EndpointResponse<MyModel> myModelResponse = executor.<MyModel> executeAsync(endpointRequest)
+				.toCompletableFuture()
+					.join();
+
+		assertTrue(myModelResponse.status().isOk());
+
+		MyModel myModel = myModelResponse.body();
+
+		assertEquals("Tiago de Freitas Lima", myModel.name);
+		assertEquals(31, myModel.age);
+	}
+
+	@Test
+	public void shouldSendPostRequestOnXmlFormat() {
+		HttpRequest httpRequest = request()
+			.withMethod("POST")
+			.withPath("/xml")
+			.withHeader("Content-Type", "application/xml")
+			.withBody(exact("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><model><name>Tiago de Freitas Lima</name><age>31</age></model>"));
+
+		mockServerClient
+			.when(httpRequest)
+				.respond(response()
+						.withStatusCode(201)
+						.withHeader("Content-Type", "text/plain")
+						.withBody(exact("OK")));
+
+		MyModel myModel = new MyModel("Tiago de Freitas Lima", 31);
+
+		Headers headers = new Headers()
+				.add(new Header("Content-Type", "application/xml"));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/xml"), "POST", headers,
+				myModel, String.class);
+
+		EndpointResponse<String> myModelResponse = executor.<String> executeAsync(endpointRequest)
+				.toCompletableFuture()
+					.join();
+
+		assertTrue(myModelResponse.status().isCreated());
+
+		assertEquals("OK", myModelResponse.body());
+
+		mockServerClient.verify(httpRequest, once());
+	}
+
+	@Test
+	public void shouldReadServerErrorResponse() {
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/json"))
+			.respond(response()
+					.withStatusCode(500));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "GET", MyModel.class);
+
+		EndpointResponse<Object> endpointResponse = executor.executeAsync(endpointRequest)
+			.exceptionally(e -> EndpointResponse.error((EndpointResponseException) e))
+				.toCompletableFuture()
+					.join();
+
+		assertThat(endpointResponse.status().isInternalServerError(), is(true));
+	}
+
+	@Test
+	public void shouldReturnNullBodyWhenResponseIsNotFound() {
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/json"))
+			.respond(response()
+					.withStatusCode(404));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "GET", MyModel.class);
+
+		EndpointResponse<Object> endpointResponse = executor.<Object> executeAsync(endpointRequest)
+				.toCompletableFuture()
+					.join();
+
+		assertTrue(endpointResponse.status().isNotFound());
+		assertNull(endpointResponse.body());
+	}
+
+	@XmlRootElement(name = "model")
+	@XmlAccessorType(XmlAccessType.FIELD)
+	public static class MyModel {
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		int age;
+
+		public MyModel() {
+		}
+
+		public MyModel(@JsonProperty String name, @JsonProperty int age) {
+			this.name = name;
+			this.age = age;
+		}
+	}
+}

--- a/java-restify-http-client-jersey/src/test/resources/logback.xml
+++ b/java-restify-http-client-jersey/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <logger name="org.mockserver" level="OFF"/>
+    <!-- <logger name="org.mockserver" level="OFF"/> -->
 
     <root level="INFO">
         <appender class="ch.qos.logback.core.ConsoleAppender">

--- a/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/async/DefaultAsyncEndpointRequestExecutor.java
+++ b/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/async/DefaultAsyncEndpointRequestExecutor.java
@@ -35,9 +35,7 @@ import com.github.ljtfreitas.restify.http.client.HttpClientException;
 import com.github.ljtfreitas.restify.http.client.HttpException;
 import com.github.ljtfreitas.restify.http.client.message.HttpMessageException;
 import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
-import com.github.ljtfreitas.restify.http.client.request.DefaultEndpointRequestExecutor;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
-import com.github.ljtfreitas.restify.http.client.request.EndpointRequestExecutor;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequestWriter;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponseReader;
@@ -51,27 +49,13 @@ public class DefaultAsyncEndpointRequestExecutor implements AsyncEndpointRequest
 	private final AsyncHttpClientRequestFactory httpClientRequestFactory;
 	private final EndpointRequestWriter endpointRequestWriter;
 	private final EndpointResponseReader endpointResponseReader;
-	private final EndpointRequestExecutor delegate;
 
 	public DefaultAsyncEndpointRequestExecutor(Executor executor, AsyncHttpClientRequestFactory httpClientRequestFactory,
 			EndpointRequestWriter endpointRequestWriter, EndpointResponseReader endpointResponseReader) {
-		this(executor, httpClientRequestFactory, endpointRequestWriter, endpointResponseReader,
-				new DefaultEndpointRequestExecutor(httpClientRequestFactory, endpointRequestWriter, endpointResponseReader));
-	}
-
-	public DefaultAsyncEndpointRequestExecutor(Executor executor, AsyncHttpClientRequestFactory httpClientRequestFactory,
-			EndpointRequestWriter endpointRequestWriter, EndpointResponseReader endpointResponseReader,
-			EndpointRequestExecutor delegate) {
 		this.executor = executor;
 		this.httpClientRequestFactory = httpClientRequestFactory;
 		this.endpointRequestWriter = endpointRequestWriter;
 		this.endpointResponseReader = endpointResponseReader;
-		this.delegate = delegate;
-	}
-
-	@Override
-	public <T> EndpointResponse<T> execute(EndpointRequest endpointRequest) {
-		return delegate.execute(endpointRequest);
 	}
 
 	@Override

--- a/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/async/interceptor/AsyncInterceptedEndpointRequestExecutor.java
+++ b/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/async/interceptor/AsyncInterceptedEndpointRequestExecutor.java
@@ -48,6 +48,6 @@ public class AsyncInterceptedEndpointRequestExecutor implements AsyncEndpointReq
 
 	@Override
 	public <T> CompletionStage<EndpointResponse<T>> executeAsync(EndpointRequest endpointRequest) {
-		return interceptors.applyAsync(endpointRequest).thenCompose(r -> delegate.executeAsync(r));
+		return interceptors.applyAsync(endpointRequest).thenComposeAsync(delegate::executeAsync);
 	}
 }

--- a/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/async/DefaultAsyncEndpointRequestExecutorTest.java
+++ b/java-restify-http-client/src/test/java/com/github/ljtfreitas/restify/http/client/request/async/DefaultAsyncEndpointRequestExecutorTest.java
@@ -29,7 +29,6 @@ import com.github.ljtfreitas.restify.http.client.message.Headers;
 import com.github.ljtfreitas.restify.http.client.message.HttpMessageException;
 import com.github.ljtfreitas.restify.http.client.message.response.StatusCode;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
-import com.github.ljtfreitas.restify.http.client.request.EndpointRequestExecutor;
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequestWriter;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponse;
 import com.github.ljtfreitas.restify.http.client.response.EndpointResponseReader;
@@ -49,9 +48,6 @@ public class DefaultAsyncEndpointRequestExecutorTest {
 	private EndpointResponseReader reader;
 
 	@Mock
-	private EndpointRequestExecutor endpointRequestExecutor;
-
-	@Mock
 	private AsyncHttpClientRequest asyncHttpClientRequest;
 
 	@Mock
@@ -66,7 +62,7 @@ public class DefaultAsyncEndpointRequestExecutorTest {
 	public void before() {
 		Executor executor = r -> r.run();
 
-		subject = new DefaultAsyncEndpointRequestExecutor(executor, asyncHttpClientRequestFactory, writer, reader, endpointRequestExecutor);
+		subject = new DefaultAsyncEndpointRequestExecutor(executor, asyncHttpClientRequestFactory, writer, reader);
 
 		when(asyncHttpClientRequestFactory.createAsyncOf(notNull(EndpointRequest.class)))
 			.thenReturn(asyncHttpClientRequest);

--- a/java-restify-netflix-ribbon/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/async/AsyncRibbonHttpClientRequestFactoryTest.java
+++ b/java-restify-netflix-ribbon/src/test/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/async/AsyncRibbonHttpClientRequestFactoryTest.java
@@ -82,7 +82,7 @@ public class AsyncRibbonHttpClientRequestFactoryTest {
 		executor = DisposableExecutors.newSingleThreadExecutor();
 
 		requestExecutor = new DefaultAsyncEndpointRequestExecutor(executor, asyncRibbonHttpClientRequestFactory, new EndpointRequestWriter(messageConverters),
-				new EndpointResponseReader(messageConverters), null);
+				new EndpointResponseReader(messageConverters));
 	}
 
 	@Test

--- a/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AuthorizationServerHttpClientFactory.java
+++ b/java-restify-oauth2-authentication/src/main/java/com/github/ljtfreitas/restify/http/client/request/authentication/oauth2/AuthorizationServerHttpClientFactory.java
@@ -81,7 +81,7 @@ public class AuthorizationServerHttpClientFactory {
 		ExecutorService threadPool = DisposableExecutors.newCachedThreadPool();
 		return httpClientRequestFactory instanceof AsyncHttpClientRequestFactory ?
 			new DefaultAsyncEndpointRequestExecutor(threadPool, (AsyncHttpClientRequestFactory) httpClientRequestFactory,
-					endpointRequestWriter(converters), endpointResponseReader(converters), doCreate()) :
+					endpointRequestWriter(converters), endpointResponseReader(converters)) :
 				new AsyncEndpointRequestExecutorAdapter(threadPool, doCreate());
 	}
 

--- a/java-restify-retry/src/main/java/com/github/ljtfreitas/restify/http/client/retry/async/AsyncRetryableEndpointRequestExecutor.java
+++ b/java-restify-retry/src/main/java/com/github/ljtfreitas/restify/http/client/retry/async/AsyncRetryableEndpointRequestExecutor.java
@@ -38,14 +38,12 @@ import com.github.ljtfreitas.restify.http.client.retry.RetryConfiguration;
 import com.github.ljtfreitas.restify.http.client.retry.RetryConfigurationFactory;
 import com.github.ljtfreitas.restify.http.client.retry.RetryPolicy;
 import com.github.ljtfreitas.restify.http.client.retry.RetryPolicyFactory;
-import com.github.ljtfreitas.restify.http.client.retry.RetryableEndpointRequestExecutor;
 
 public class AsyncRetryableEndpointRequestExecutor implements AsyncEndpointRequestExecutor {
 
 	private final AsyncEndpointRequestExecutor asyncEndpointRequestExecutor;
 	private final ScheduledExecutorService scheduler;
 	private final RetryConfigurationFactory retryConfigurationFactory;
-	private final RetryableEndpointRequestExecutor delegate;
 
 	public AsyncRetryableEndpointRequestExecutor(AsyncEndpointRequestExecutor asyncEndpointRequestExecutor,
 			ScheduledExecutorService scheduledExecutorService) {
@@ -54,21 +52,9 @@ public class AsyncRetryableEndpointRequestExecutor implements AsyncEndpointReque
 
 	public AsyncRetryableEndpointRequestExecutor(AsyncEndpointRequestExecutor asyncEndpointRequestExecutor,
 			ScheduledExecutorService scheduledExecutorService, RetryConfiguration configuration) {
-		this(asyncEndpointRequestExecutor, scheduledExecutorService, configuration,
-				new RetryableEndpointRequestExecutor(asyncEndpointRequestExecutor, configuration));
-	}
-
-	public AsyncRetryableEndpointRequestExecutor(AsyncEndpointRequestExecutor asyncEndpointRequestExecutor,
-			ScheduledExecutorService scheduledExecutorService, RetryConfiguration configuration, RetryableEndpointRequestExecutor delegate) {
 		this.asyncEndpointRequestExecutor = asyncEndpointRequestExecutor;
 		this.scheduler = scheduledExecutorService;
 		this.retryConfigurationFactory = new RetryConfigurationFactory(configuration);
-		this.delegate = delegate;
-	}
-
-	@Override
-	public <T> EndpointResponse<T> execute(EndpointRequest endpointRequest) {
-		return delegate.execute(endpointRequest);
 	}
 
 	@Override

--- a/java-restify-spring-reactive/src/main/java/com/github/ljtfreitas/restify/http/spring/client/request/async/WebClientEndpointRequestExecutor.java
+++ b/java-restify-spring-reactive/src/main/java/com/github/ljtfreitas/restify/http/spring/client/request/async/WebClientEndpointRequestExecutor.java
@@ -86,14 +86,6 @@ public class WebClientEndpointRequestExecutor implements AsyncEndpointRequestExe
 		this.fallback = fallback;
 	}
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public <T> EndpointResponse<T> execute(EndpointRequest endpointRequest) {
-		return doExecute(endpointRequest)
-			.map(e -> (EndpointResponse<T>) e)
-			.block();
-	}
-
 	@Override
 	public <T> CompletionStage<EndpointResponse<T>> executeAsync(EndpointRequest endpointRequest) {
 		Mono<EndpointResponse<T>> mono = doExecute(endpointRequest);

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
@@ -315,8 +315,7 @@ public class RestifyProxyBuilder {
 		private EndpointRequestExecutor asyncEndpointRequestExecutor(AsyncHttpClientRequestFactory asyncHttpClientRequestFactory,
 				EndpointRequestWriter writer, EndpointResponseReader reader) {
 			return new DefaultAsyncEndpointRequestExecutor(asyncBuilder.executor,
-					asyncHttpClientRequestFactory, writer, reader,
-						endpointRequestExecutor(asyncHttpClientRequestFactory, writer, reader));
+					asyncHttpClientRequestFactory, writer, reader);
 		}
 
 		private EndpointRequestExecutor endpointRequestExecutor(HttpClientRequestFactory httpClientRequestFactory,


### PR DESCRIPTION
## Descrição
- Implementa suporte à requisições assíncronas usando o Jersey

## Changelog
- Adiciona a implementação *JerseyAsyncHttpClientEndpointRequestExecutor*, que utiliza o suporte `async` do Jersey
- Adiciona as implementações `JerseyRxFlowableHttpClientEndpointRequestExecutor` e `JerseyRxObservableHttpClientEndpointRequestExecutor`, que usa o suporte do Jersey para requisições assíncronas usando o RxJava. Essas implementações utilizam o `Flowable` e o `Observable`, respectivamente.