### PR TITLE
[grizzly-http-client] Grizzly HTTP Client

### DIFF
--- a/java-restify-http-client-apache-httpclient/src/main/java/com/github/ljtfreitas/restify/http/client/apache/httpclient/ApacheAsyncHttpClientRequest.java
+++ b/java-restify-http-client-apache-httpclient/src/main/java/com/github/ljtfreitas/restify/http/client/apache/httpclient/ApacheAsyncHttpClientRequest.java
@@ -139,11 +139,6 @@ class ApacheAsyncHttpClientRequest implements AsyncHttpClientRequest {
 		}
 	}
 
-	@Override
-	public HttpClientResponse execute() throws HttpClientException {
-		return doExecuteAsync().toCompletableFuture().join();
-	}
-
 	private class ApacheHttpAsyncRequestCallback implements FutureCallback<HttpResponse> {
 
 		private final CompletableFuture<HttpClientResponse> future;

--- a/java-restify-http-client-grizzly/pom.xml
+++ b/java-restify-http-client-grizzly/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.github.ljtfreitas</groupId>
+		<artifactId>java-restify-group</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+	</parent>
+	<artifactId>java-restify-http-client-grizzly</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-http-client</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-reflection</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-http-message</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-util</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.grizzly</groupId>
+			<artifactId>grizzly-http-client</artifactId>
+			<version>1.16</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/java-restify-http-client-grizzly/src/main/java/com/github/ljtfreitas/restify/http/client/request/grizzly/GrizzlyHttpClientRequest.java
+++ b/java-restify-http-client-grizzly/src/main/java/com/github/ljtfreitas/restify/http/client/request/grizzly/GrizzlyHttpClientRequest.java
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.grizzly;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import com.github.ljtfreitas.restify.http.client.HttpClientException;
+import com.github.ljtfreitas.restify.http.client.message.Header;
+import com.github.ljtfreitas.restify.http.client.message.Headers;
+import com.github.ljtfreitas.restify.http.client.message.converter.HttpMessageReadException;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.BufferedHttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestBody;
+import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
+import com.github.ljtfreitas.restify.http.client.message.response.StatusCode;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.Timeout;
+import com.github.ljtfreitas.restify.http.client.request.async.AsyncHttpClientRequest;
+import com.github.ljtfreitas.restify.http.client.response.HttpClientResponse;
+import com.github.ljtfreitas.restify.util.Try;
+import com.ning.http.client.AsyncCompletionHandler;
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.Request;
+import com.ning.http.client.RequestBuilder;
+import com.ning.http.client.Response;
+import com.ning.http.client.generators.ByteArrayBodyGenerator;
+
+class GrizzlyHttpClientRequest implements AsyncHttpClientRequest {
+
+	private final AsyncHttpClient asyncHttpClient;
+	private final EndpointRequest source;
+	private final Headers headers;
+	private final Charset charset;
+	private final BufferedHttpRequestBody body;
+
+	GrizzlyHttpClientRequest(AsyncHttpClient asyncHttpClient, EndpointRequest source, Charset charset) {
+		this(asyncHttpClient, source, new Headers(source.headers()), charset, new BufferedByteArrayHttpRequestBody(charset));
+	}
+
+	private GrizzlyHttpClientRequest(AsyncHttpClient asyncHttpClient, EndpointRequest source, Headers headers,
+			Charset charset, BufferedHttpRequestBody body) {
+		this.asyncHttpClient = asyncHttpClient;
+		this.source = source;
+		this.headers = headers;
+		this.charset = charset;
+		this.body = body;
+	}
+
+	@Override
+	public URI uri() {
+		return source.endpoint();
+	}
+
+	@Override
+	public String method() {
+		return source.method();
+	}
+
+	@Override
+	public HttpRequestBody body() {
+		return body;
+	}
+
+	@Override
+	public Charset charset() {
+		return charset;
+	}
+
+	@Override
+	public HttpRequestMessage replace(Header header) {
+		return new GrizzlyHttpClientRequest(asyncHttpClient, source, headers.replace(header), charset, body);
+	}
+
+	@Override
+	public Headers headers() {
+		return headers;
+	}
+
+	@Override
+	public CompletionStage<HttpClientResponse> executeAsync() throws HttpClientException {
+		CompletableFuture<HttpClientResponse> future = new CompletableFuture<>();
+
+		Request request = buildRequest();
+
+		asyncHttpClient.prepareRequest(request)
+			.execute(new AsyncCompletionHandler<HttpClientResponse>() {
+
+				@Override
+				public HttpClientResponse onCompleted(Response response) throws Exception {
+					HttpClientResponse httpClientResponse = read(response);
+
+					future.complete(httpClientResponse);
+
+					return httpClientResponse;
+				}
+
+				private HttpClientResponse read(Response response) {
+					StatusCode statusCode = StatusCode.of(response.getStatusCode(), response.getStatusText());
+
+					Headers responseHeaders = response.getHeaders().entrySet().stream()
+							.reduce(new Headers(), (h, e) -> h.add(e.getKey(), e.getValue()), (a, b) -> b);
+
+					InputStream body = Try.of(response::getResponseBodyAsStream)
+							.error(HttpMessageReadException::new)
+							.get();
+
+					return new GrizzlyHttpClientResponse(statusCode, responseHeaders, body, GrizzlyHttpClientRequest.this);
+				}
+
+				@Override
+				public void onThrowable(Throwable t) {
+					future.completeExceptionally(new HttpClientException("I/O error on HTTP request: [" + request.getMethod() + " " +
+							request.getUrl() + "]", t));
+				}
+			});
+
+		return future;
+	}
+
+	private Request buildRequest() {
+		RequestBuilder builder = new RequestBuilder()
+				.setMethod(source.method())
+				.setUrl(source.endpoint().toString());
+		
+		byte[] bodyAsBytes = body.asBytes();
+		if (bodyAsBytes.length != 0) {
+			builder.setBody(new ByteArrayBodyGenerator(bodyAsBytes));
+		}
+		
+		source.metadata().get(Timeout.class).ifPresent(timeout -> {
+			builder.setRequestTimeout((int) timeout.read());
+		});
+
+		headers.forEach(header -> builder.addHeader(header.name(), header.value()));
+
+		return builder.build();
+	}
+}

--- a/java-restify-http-client-grizzly/src/main/java/com/github/ljtfreitas/restify/http/client/request/grizzly/GrizzlyHttpClientRequestFactory.java
+++ b/java-restify-http-client-grizzly/src/main/java/com/github/ljtfreitas/restify/http/client/request/grizzly/GrizzlyHttpClientRequestFactory.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.grizzly;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import com.github.ljtfreitas.restify.http.client.message.Encoding;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.async.AsyncHttpClientRequestFactory;
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
+
+public class GrizzlyHttpClientRequestFactory implements AsyncHttpClientRequestFactory, Closeable {
+
+	private final AsyncHttpClient asyncHttpClient;
+	private final Charset charset;
+
+	public GrizzlyHttpClientRequestFactory() {
+		this(new AsyncHttpClient());
+	}
+	
+	public GrizzlyHttpClientRequestFactory(AsyncHttpClient asyncHttpClient) {
+		this(asyncHttpClient, Encoding.UTF_8.charset());
+	}
+
+	public GrizzlyHttpClientRequestFactory(Charset charset) {
+		this(new AsyncHttpClient(), charset);
+	}
+
+	public GrizzlyHttpClientRequestFactory(AsyncHttpClientConfig asyncHttpClientConfig) {
+		this(new AsyncHttpClient(asyncHttpClientConfig));
+	}
+
+	public GrizzlyHttpClientRequestFactory(AsyncHttpClientConfig asyncHttpClientConfig, Charset charset) {
+		this(new AsyncHttpClient(asyncHttpClientConfig), charset);
+	}
+
+	public GrizzlyHttpClientRequestFactory(AsyncHttpClient asyncHttpClient, Charset charset) {
+		this.asyncHttpClient = asyncHttpClient;
+		this.charset = charset;
+	}
+
+	@Override
+	public GrizzlyHttpClientRequest createAsyncOf(EndpointRequest endpointRequest) {
+		return new GrizzlyHttpClientRequest(asyncHttpClient, endpointRequest, charset);
+	}
+
+	@Override
+	public void close() throws IOException {
+		asyncHttpClient.close();
+	}
+}

--- a/java-restify-http-client-grizzly/src/main/java/com/github/ljtfreitas/restify/http/client/request/grizzly/GrizzlyHttpClientResponse.java
+++ b/java-restify-http-client-grizzly/src/main/java/com/github/ljtfreitas/restify/http/client/request/grizzly/GrizzlyHttpClientResponse.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Tiago de Freitas Lima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+package com.github.ljtfreitas.restify.http.client.request.grizzly;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.github.ljtfreitas.restify.http.client.message.Headers;
+import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
+import com.github.ljtfreitas.restify.http.client.message.response.StatusCode;
+import com.github.ljtfreitas.restify.http.client.response.BaseHttpClientResponse;
+
+class GrizzlyHttpClientResponse extends BaseHttpClientResponse {
+
+	protected GrizzlyHttpClientResponse(StatusCode status, Headers headers, InputStream body,
+			HttpRequestMessage httpRequest) {
+		super(status, headers, body, httpRequest);
+	}
+
+	@Override
+	public void close() throws IOException {
+		
+	}
+
+}

--- a/java-restify-http-client-grizzly/src/test/java/com/github/ljtfreitas/restify/http/client/request/grizzly/GrizzlyHttpClientRequestFactoryTest.java
+++ b/java-restify-http-client-grizzly/src/test/java/com/github/ljtfreitas/restify/http/client/request/grizzly/GrizzlyHttpClientRequestFactoryTest.java
@@ -1,0 +1,252 @@
+package com.github.ljtfreitas.restify.http.client.request.grizzly;
+
+import static org.hamcrest.Matchers.isA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+import static org.mockserver.model.StringBody.exact;
+import static org.mockserver.verify.VerificationTimes.once;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.hamcrest.CustomTypeSafeMatcher;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockserver.client.server.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.HttpRequest;
+
+import com.github.ljtfreitas.restify.http.client.HttpClientException;
+import com.github.ljtfreitas.restify.http.client.message.Header;
+import com.github.ljtfreitas.restify.http.client.message.Headers;
+import com.github.ljtfreitas.restify.http.client.message.io.InputStreamContent;
+import com.github.ljtfreitas.restify.http.client.message.response.HttpResponseMessage;
+import com.github.ljtfreitas.restify.http.client.message.response.StatusCode;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.EndpointRequestMetadata;
+import com.github.ljtfreitas.restify.http.client.request.Timeout;
+import com.github.ljtfreitas.restify.http.client.response.HttpClientResponse;
+import com.ning.http.client.AsyncHttpClientConfig;
+import com.ning.http.client.Realm;
+import com.ning.http.client.Realm.AuthScheme;
+
+public class GrizzlyHttpClientRequestFactoryTest {
+
+	@Rule
+	public MockServerRule mockServerRule = new MockServerRule(this, 7080);
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	private MockServerClient mockServerClient;
+
+	private GrizzlyHttpClientRequestFactory subject;
+
+	@Before
+	public void setup() {
+		mockServerClient = new MockServerClient("localhost", 7080);
+
+		subject = new GrizzlyHttpClientRequestFactory();
+	}
+
+	@Test
+	public void shouldSendGetRequest() throws Exception {
+		String responseBody = "{\"name\": \"Tiago de Freitas Lima\",\"age\":31}";
+
+		mockServerClient
+			.when(request()
+					.withMethod("GET")
+					.withPath("/json"))
+			.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "application/json")
+					.withBody(json(responseBody)));
+
+		CompletableFuture<HttpClientResponse> responseAsFuture = subject
+				.createAsyncOf(new EndpointRequest(URI.create("http://localhost:7080/json"), "GET"))
+					.executeAsync()
+						.toCompletableFuture();
+
+		HttpResponseMessage response = responseAsFuture.get();
+
+		assertEquals(responseBody, new InputStreamContent(response.body().input()).asString());
+		assertEquals("application/json", response.headers().get("Content-Type").get().value());
+		assertEquals(StatusCode.ok(), response.status());
+	}
+
+	@Test
+	public void shouldSendPostRequest() throws IOException, Exception {
+		String requestBody = "{\"name\":\"Tiago de Freitas Lima\",\"age\":31}";
+		String responseBody = "OK";
+
+		HttpRequest httpRequest = request()
+			.withMethod("POST")
+			.withPath("/json")
+			.withHeader("Content-Type", "application/json")
+			.withBody(json(requestBody));
+
+		mockServerClient
+			.when(httpRequest)
+			.respond(response()
+				.withStatusCode(201)
+				.withHeader("Content-Type", "text/plain")
+				.withBody(exact(responseBody)));
+
+		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "POST",
+				new Headers(Header.contentType("application/json")), requestBody);
+
+		GrizzlyHttpClientRequest request = subject.createAsyncOf(endpointRequest);
+		request.body().output().write(requestBody.getBytes());
+		request.body().output().flush();
+
+		HttpResponseMessage response = request.executeAsync().toCompletableFuture().get();
+
+		assertEquals(responseBody, new InputStreamContent(response.body().input()).asString());
+		assertEquals("text/plain", response.headers().get("Content-Type").get().value());
+		assertEquals(StatusCode.created(), response.status());
+
+		mockServerClient.verify(httpRequest, once());
+	}
+
+	@Test
+	public void shouldThrowExceptionOnTimeout() throws Exception {
+		mockServerClient
+			.when(request()
+				.withMethod("GET")
+				.withPath("/slow"))
+			.respond(response()
+				.withDelay(TimeUnit.MILLISECONDS, 3000));
+
+		AsyncHttpClientConfig configuration = new AsyncHttpClientConfig.Builder()
+				.setRequestTimeout(2000)
+					.build();
+
+		subject = new GrizzlyHttpClientRequestFactory(configuration);
+
+		expectedException.expect(ExecutionException.class);
+		expectedException.expectCause(isA(HttpClientException.class));
+		expectedException.expect(deepCauseIsA(TimeoutException.class));
+
+		CompletableFuture<HttpClientResponse> future = subject
+			.createAsyncOf(new EndpointRequest(URI.create("http://localhost:7080/slow"), "GET"))
+				.executeAsync()
+					.toCompletableFuture();
+
+		Thread.sleep(3000);
+
+		assertTrue(future.isCompletedExceptionally());
+
+		future.get();
+	}
+
+	@Test
+	public void shouldThrowExceptionOnTimeoutUsingAnnotation() throws Exception {
+		mockServerClient
+			.when(request()
+				.withMethod("GET")
+				.withPath("/slow"))
+			.respond(response()
+				.withDelay(TimeUnit.MILLISECONDS, 3000));
+
+		Timeout timeout = new Timeout() {
+
+			@Override
+			public Class<? extends Annotation> annotationType() {
+				return Timeout.class;
+			}
+
+			@Override
+			public long read() {
+				return 2000;
+			}
+
+			@Override
+			public long connection() {
+				return 2000;
+			}
+		};
+
+		expectedException.expect(ExecutionException.class);
+		expectedException.expectCause(isA(HttpClientException.class));
+		expectedException.expect(deepCauseIsA(TimeoutException.class));
+
+		EndpointRequest request = new EndpointRequest(URI.create("http://localhost:7080/slow"), "GET", new Headers(), null, void.class, null,
+				new EndpointRequestMetadata(Arrays.asList(timeout)));
+
+		CompletableFuture<HttpClientResponse> future = subject
+			.createAsyncOf(request)
+				.executeAsync()
+					.toCompletableFuture();
+
+		Thread.sleep(3000);
+
+		assertTrue(future.isCompletedExceptionally());
+
+		future.get();
+	}
+
+	private Matcher<Exception> deepCauseIsA(Class<? extends Exception> type) {
+		return new CustomTypeSafeMatcher<Exception>("The root cause should be..." + type) {
+
+			@Override
+			protected boolean matchesSafely(Exception e) {
+				Throwable deepCause = deepCauseOf(e);
+				return type.isAssignableFrom(deepCause.getClass());
+			}
+
+			private Throwable deepCauseOf(Throwable e) {
+				return e.getCause() == null ? e : deepCauseOf(e.getCause());
+			}
+		};
+	}
+
+	@Test
+	public void shouldExecuteAuthenticatedRequest() throws Exception {
+		Realm realm = new Realm.RealmBuilder()
+				.setPrincipal("user")
+				.setPassword("password")
+				.setScheme(AuthScheme.BASIC)
+				.setUsePreemptiveAuth(true)
+				.build();
+
+		AsyncHttpClientConfig configuration = new AsyncHttpClientConfig.Builder()
+				.setRealm(realm)
+				.build();
+
+		subject = new GrizzlyHttpClientRequestFactory(configuration);
+
+		HttpRequest authenticatedRequest = request()
+				.withMethod("GET")
+				.withPath("/authenticated")
+				.withHeader("Authorization", "Basic dXNlcjpwYXNzd29yZA==");
+
+		mockServerClient
+			.when(authenticatedRequest)
+			.respond(response()
+					.withStatusCode(200)
+					.withHeader("Content-Type", "text/plain")
+					.withBody(exact("ok")));
+
+		HttpResponseMessage response = subject
+				.createAsyncOf(new EndpointRequest(URI.create("http://localhost:7080/authenticated"), "GET"))
+					.executeAsync()
+						.toCompletableFuture()
+							.get();
+
+		assertEquals("ok", new InputStreamContent(response.body().input()).asString());
+
+		mockServerClient.verify(authenticatedRequest);
+	}
+}

--- a/java-restify-http-client-grizzly/src/test/resources/logback.xml
+++ b/java-restify-http-client-grizzly/src/test/resources/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- <logger name="org.mockserver" level="OFF"/> -->
+
+    <root level="INFO">
+        <appender class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%date %level [%thread] %logger{35} [%file:%line] %msg%n</pattern>
+            </encoder>
+        </appender>
+    </root>
+</configuration>

--- a/java-restify-http-client-netty/src/main/java/com/github/ljtfreitas/restify/http/client/netty/NettyHttpClientRequest.java
+++ b/java-restify-http-client-netty/src/main/java/com/github/ljtfreitas/restify/http/client/netty/NettyHttpClientRequest.java
@@ -29,7 +29,6 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
 
 import com.github.ljtfreitas.restify.http.client.HttpClientException;
 import com.github.ljtfreitas.restify.http.client.message.Header;
@@ -109,16 +108,6 @@ class NettyHttpClientRequest implements AsyncHttpClientRequest {
 	@Override
 	public CompletionStage<HttpClientResponse> executeAsync() throws HttpClientException {
 		return doExecuteAsync();
-	}
-
-	@Override
-	public HttpClientResponse execute() throws HttpClientException {
-		try {
-			return doExecuteAsync().get();
-
-		} catch (InterruptedException | ExecutionException e) {
-			throw new HttpClientException("I/O error on HTTP request: [" + method + " " + uri + "]", e);
-		}
 	}
 
 	private CompletableFuture<HttpClientResponse> doExecuteAsync() {

--- a/java-restify-http-client-netty/src/main/java/com/github/ljtfreitas/restify/http/client/netty/NettyHttpClientRequestFactory.java
+++ b/java-restify-http-client-netty/src/main/java/com/github/ljtfreitas/restify/http/client/netty/NettyHttpClientRequestFactory.java
@@ -57,15 +57,6 @@ public class NettyHttpClientRequestFactory implements AsyncHttpClientRequestFact
 	}
 
 	@Override
-	public NettyHttpClientRequest createOf(EndpointRequest endpointRequest) {
-		Bootstrap bootstrap = new NettyBootstrapFactory(eventLoopGroup, nettyHttpClientRequestConfiguration)
-				.createTo(endpointRequest);
-
-		return new NettyHttpClientRequest(bootstrap, endpointRequest.endpoint(), endpointRequest.headers(), endpointRequest.method(),
-				nettyHttpClientRequestConfiguration.charset());
-	}
-
-	@Override
 	public NettyHttpClientRequest createAsyncOf(EndpointRequest endpointRequest) {
 		Bootstrap bootstrap = new NettyBootstrapFactory(eventLoopGroup, nettyHttpClientRequestConfiguration)
 				.createTo(endpointRequest);

--- a/java-restify-http-client-netty/src/main/java/com/github/ljtfreitas/restify/http/client/netty/NettyRequestExecuteHandler.java
+++ b/java-restify-http-client-netty/src/main/java/com/github/ljtfreitas/restify/http/client/netty/NettyRequestExecuteHandler.java
@@ -28,6 +28,7 @@ package com.github.ljtfreitas.restify.http.client.netty;
 import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
 
+import com.github.ljtfreitas.restify.http.client.HttpClientException;
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
 import com.github.ljtfreitas.restify.http.client.message.request.HttpRequestMessage;
@@ -79,6 +80,11 @@ class NettyRequestExecuteHandler extends SimpleChannelInboundHandler<FullHttpRes
 
 	@Override
 	public void exceptionCaught(ChannelHandlerContext context, Throwable cause) throws Exception {
-		future.completeExceptionally(cause);
+		System.out.println("failure");
+		future.completeExceptionally(handle(cause));
+	}
+
+	private Throwable handle(Throwable cause) {
+		return new HttpClientException("I/O error on HTTP request: [" + source.method() + " " + source.uri() + "]", cause);
 	}
 }

--- a/java-restify-http-client-netty/src/test/java/com/github/ljtfreitas/restify/http/client/netty/NettyHttpClientRequestFactoryTest.java
+++ b/java-restify-http-client-netty/src/test/java/com/github/ljtfreitas/restify/http/client/netty/NettyHttpClientRequestFactoryTest.java
@@ -406,8 +406,7 @@ public class NettyHttpClientRequestFactoryTest {
 		return new BaseMatcher<Throwable>() {
 			@Override
 			public boolean matches(Object argument) {
-				Throwable exception = (Throwable) argument;
-				Throwable cause = exception.getCause();
+				Throwable cause = (Throwable) argument;
 
 				while (cause != null) {
 					if (expectedCause.isInstance(cause)) return true;

--- a/java-restify-http-client-okhttp/src/main/java/com/github/ljtfreitas/restify/http/client/okhttp/OkHttpClientRequestFactory.java
+++ b/java-restify-http-client-okhttp/src/main/java/com/github/ljtfreitas/restify/http/client/okhttp/OkHttpClientRequestFactory.java
@@ -59,12 +59,6 @@ public class OkHttpClientRequestFactory implements AsyncHttpClientRequestFactory
 	}
 
 	@Override
-	public OkHttpClientRequest createOf(EndpointRequest endpointRequest) {
-		return new OkHttpClientRequest(okHttpClient, endpointRequest.endpoint(), endpointRequest.method(), endpointRequest.headers(),
-				charset);
-	}
-
-	@Override
 	public AsyncHttpClientRequest createAsyncOf(EndpointRequest endpointRequest) {
 		return new OkHttpClientRequest(okHttpClient, endpointRequest.endpoint(), endpointRequest.method(), endpointRequest.headers(),
 				charset);

--- a/java-restify-http-client-okhttp/src/test/java/com/github/ljtfreitas/restify/http/client/okhttp/OkHttpClientRequestFactoryTest.java
+++ b/java-restify-http-client-okhttp/src/test/java/com/github/ljtfreitas/restify/http/client/okhttp/OkHttpClientRequestFactoryTest.java
@@ -121,7 +121,7 @@ public class OkHttpClientRequestFactoryTest {
 		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "POST",
 				new Headers(Header.contentType("application/json")), requestBody);
 
-		OkHttpClientRequest request = okHttpClientRequestFactory.createOf(endpointRequest);
+		OkHttpClientRequest request = (OkHttpClientRequest) okHttpClientRequestFactory.createOf(endpointRequest);
 		request.body().output().write(requestBody.getBytes());
 		request.body().output().flush();
 
@@ -155,7 +155,7 @@ public class OkHttpClientRequestFactoryTest {
 		EndpointRequest endpointRequest = new EndpointRequest(URI.create("http://localhost:7080/json"), "POST",
 				new Headers(Header.contentType("application/json")), requestBody);
 
-		OkHttpClientRequest request = okHttpClientRequestFactory.createOf(endpointRequest);
+		OkHttpClientRequest request = (OkHttpClientRequest) okHttpClientRequestFactory.createOf(endpointRequest);
 		request.body().output().write(requestBody.getBytes());
 		request.body().output().flush();
 

--- a/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/async/AsyncHttpClientRequestFactory.java
+++ b/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/async/AsyncHttpClientRequestFactory.java
@@ -26,9 +26,15 @@
 package com.github.ljtfreitas.restify.http.client.request.async;
 
 import com.github.ljtfreitas.restify.http.client.request.EndpointRequest;
+import com.github.ljtfreitas.restify.http.client.request.HttpClientRequest;
 import com.github.ljtfreitas.restify.http.client.request.HttpClientRequestFactory;
 
 public interface AsyncHttpClientRequestFactory extends HttpClientRequestFactory {
+
+	@Override
+	default HttpClientRequest createOf(EndpointRequest endpointRequest) {
+		return createAsyncOf(endpointRequest);
+	}
 
 	public AsyncHttpClientRequest createAsyncOf(EndpointRequest endpointRequest);
 }

--- a/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/async/interceptor/log/AsyncLoggableHttpClientRequest.java
+++ b/java-restify-http-client/src/main/java/com/github/ljtfreitas/restify/http/client/request/async/interceptor/log/AsyncLoggableHttpClientRequest.java
@@ -84,17 +84,6 @@ class AsyncLoggableHttpClientRequest implements AsyncHttpClientRequest {
 	}
 
 	@Override
-	public HttpClientResponse execute() throws HttpClientException {
-		log.info(requestAsLog());
-
-		LoggableHttpClientResponse response = new LoggableHttpClientResponse(source.execute());
-
-		log.info(responseAsLog(response));
-
-		return response;
-	}
-
-	@Override
 	public CompletionStage<HttpClientResponse> executeAsync() throws HttpClientException {
 		log.info(requestAsLog());
 

--- a/java-restify-netflix-ribbon/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/async/AsyncRibbonHttpClientRequest.java
+++ b/java-restify-netflix-ribbon/src/main/java/com/github/ljtfreitas/restify/http/netflix/client/request/ribbon/async/AsyncRibbonHttpClientRequest.java
@@ -31,7 +31,6 @@ import java.nio.charset.Charset;
 import java.util.concurrent.CompletionStage;
 
 import com.github.ljtfreitas.restify.http.client.HttpClientException;
-import com.github.ljtfreitas.restify.http.client.HttpException;
 import com.github.ljtfreitas.restify.http.client.message.Header;
 import com.github.ljtfreitas.restify.http.client.message.Headers;
 import com.github.ljtfreitas.restify.http.client.message.request.BufferedByteArrayHttpRequestBody;
@@ -47,7 +46,6 @@ import com.github.ljtfreitas.restify.http.netflix.client.request.ribbon.RibbonHt
 import com.github.ljtfreitas.restify.http.netflix.client.request.ribbon.RibbonRequest;
 import com.github.ljtfreitas.restify.http.netflix.client.request.ribbon.RibbonResponse;
 import com.github.ljtfreitas.restify.util.Try;
-import com.netflix.client.ClientException;
 
 public class AsyncRibbonHttpClientRequest extends BaseRibbonHttpClientRequest implements AsyncHttpClientRequest {
 
@@ -117,22 +115,8 @@ public class AsyncRibbonHttpClientRequest extends BaseRibbonHttpClientRequest im
 	}
 
 	@Override
-	public HttpClientResponse execute() throws HttpException {
-		try {
-			RibbonResponse response = ribbonLoadBalancedClient.withLoadBalancer(new RibbonRequest(this));
-
-			return response.unwrap();
-
-		} catch (ClientException e) {
-			throw new HttpClientException("Error on HTTP request: [" + endpointRequest.method() + " " +
-					endpointRequest.endpoint() + "]", e);
-		}
-	}
-
-
-	@Override
 	public CompletionStage<HttpClientResponse> executeAsync() throws HttpClientException {
 		return ribbonLoadBalancedClient.executeAsync(new RibbonRequest(this))
-			.thenApply(RibbonResponse::unwrap);
+			.thenApplyAsync(RibbonResponse::unwrap);
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 		<module>java-restify-http-client-okhttp</module>
 		<module>java-restify-http-client-netty</module>
 		<module>java-restify-http-client-jersey</module>
+		<module>java-restify-http-client-grizzly</module>
 
 		<module>java-restify-retry</module>
 		<module>java-restify-guava</module>


### PR DESCRIPTION
## Descrição
- Implementa suporte ao uso do Grizzly como cliente HTTP para requisições assíncronas.

## Changelog
- Cria nova implementação *GrizzlyHttpClientRequestFactory*, usando o [Grizzly](https://github.com/javaee/grizzly-ahc). Essa implementação é específica para requisições assíncronas
- Cria implementação padrão para requisições síncronas em interfaces assíncronas, usando métodos `default` que podem ser sobrescritos.
