### PR TITLE
[fix-spring-retry-configuration] Corrige configuracao de retry na criação do proxy

### DIFF
--- a/java-restify-http-client-vertx/src/main/java/com/github/ljtfreitas/restify/http/client/request/vertx/VertxHttpClientResponse.java
+++ b/java-restify-http-client-vertx/src/main/java/com/github/ljtfreitas/restify/http/client/request/vertx/VertxHttpClientResponse.java
@@ -40,12 +40,16 @@ import io.vertx.ext.web.client.HttpResponse;
 
 class VertxHttpClientResponse extends BaseHttpClientResponse {
 
+	private final InputStream body;
+
 	VertxHttpClientResponse(StatusCode status, Headers headers, InputStream body, HttpRequestMessage httpRequest) {
 		super(status, headers, body, httpRequest);
+		this.body = body;
 	}
 
 	@Override
 	public void close() throws IOException {
+		body.close();
 	}
 
 	static VertxHttpClientResponse read(HttpResponse<Buffer> result, HttpRequestMessage source) {

--- a/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
+++ b/java-restify/src/main/java/com/github/ljtfreitas/restify/http/RestifyProxyBuilder.java
@@ -876,7 +876,7 @@ public class RestifyProxyBuilder {
 		}
 
 		public RestifyProxyBuilder using(RetryConfiguration configuration) {
-			this.enabled = true;
+			this.enabled = (configuration != null);
 			this.configuration = configuration;
 			return RestifyProxyBuilder.this;
 		}


### PR DESCRIPTION
## Descrição

- Corrige atribuicao de configuracao de retry ao RestifyProxyBuilder. Esse problema afetava a autoconfiguração do Spring Boot e o plugin CDI, pois o `retry` sempre permanecia habilitado mesmo quando não havia configuração.