### PR TITLE
[fix-spring-webflux-dependency-scope] Corrige escopo das dependências do spring-webflux

### DIFF
--- a/java-restify-http-client-netty/src/main/java/com/github/ljtfreitas/restify/http/client/netty/NettyRequestExecuteHandler.java
+++ b/java-restify-http-client-netty/src/main/java/com/github/ljtfreitas/restify/http/client/netty/NettyRequestExecuteHandler.java
@@ -80,7 +80,6 @@ class NettyRequestExecuteHandler extends SimpleChannelInboundHandler<FullHttpRes
 
 	@Override
 	public void exceptionCaught(ChannelHandlerContext context, Throwable cause) throws Exception {
-		System.out.println("failure");
 		future.completeExceptionally(handle(cause));
 	}
 

--- a/java-restify-netflix-spring-autoconfigure/pom.xml
+++ b/java-restify-netflix-spring-autoconfigure/pom.xml
@@ -59,6 +59,16 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webflux</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor.netty</groupId>
+			<artifactId>reactor-netty</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/java-restify-spring-autoconfigure/pom.xml
+++ b/java-restify-spring-autoconfigure/pom.xml
@@ -35,6 +35,16 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webflux</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor.netty</groupId>
+			<artifactId>reactor-netty</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>java-restify</artifactId>
 			<version>${project.version}</version>

--- a/java-restify-spring-reactive/pom.xml
+++ b/java-restify-spring-reactive/pom.xml
@@ -45,11 +45,13 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webflux</artifactId>
 			<version>${spring.framework.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.projectreactor.netty</groupId>
 			<artifactId>reactor-netty</artifactId>
 			<version>${reactor.netty.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>


### PR DESCRIPTION
## Corrige escopo das dependências do spring-webflux

### Descrição
- Corrige escopo das dependências do *spring-webflux*. As dependências passam a ser do escopo *provided*, incluindo o `reactor-netty`. A motivação para essa modificação foi que esse módulo foi concebido para ser utilizado com o Spring, que fornece as dependências.