### PR TITLE
[fix-reactor-return-endpoint-response-without-body] Implementa tratamento de respostas sem corpo usando objetos reativos

### DIFF
--- a/java-restify-reactor-hystrix/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/reactor/HystrixMonoEndpointCallHandlerAdapterTest.java
+++ b/java-restify-reactor-hystrix/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/reactor/HystrixMonoEndpointCallHandlerAdapterTest.java
@@ -56,7 +56,7 @@ public class HystrixMonoEndpointCallHandlerAdapterTest {
 	}
 
 	@Test
-	public void shouldCreateMonoFromHystrixCommand() throws Exception {
+	public void shouldGetMonoFromHystrixCommand() throws Exception {
 		AsyncEndpointCallHandler<Mono<String>, String> handler = adapter
 				.adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("monoOnCircuitBreaker")), delegate);
 
@@ -68,7 +68,7 @@ public class HystrixMonoEndpointCallHandlerAdapterTest {
 	}
 
 	@Test
-	public void shouldCreateMonoFromFallbackWhenHystrixCommandFail() throws Exception {
+	public void shouldGetMonoWithFallbackWhenHystrixCommandFail() throws Exception {
 		CompletableFuture<String> exceptionAsFuture = new CompletableFuture<>();
 		exceptionAsFuture.completeExceptionally(new RuntimeException("ooops"));
 

--- a/java-restify-reactor/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/reactor/FluxEndpointCallHandlerAdapterTest.java
+++ b/java-restify-reactor/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/reactor/FluxEndpointCallHandlerAdapterTest.java
@@ -76,7 +76,7 @@ public class FluxEndpointCallHandlerAdapterTest {
 	}
 
 	@Test
-	public void shouldCreateHandlerFromEndpointMethodWithFluxReturnType() throws Exception {
+	public void shouldGetFluxWithResponseOfCall() throws Exception {
 		AsyncEndpointCallHandler<Flux<String>, Collection<String>> handler = adapter
 				.adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("flux")), delegate);
 
@@ -91,7 +91,7 @@ public class FluxEndpointCallHandlerAdapterTest {
 	}
 
 	@Test
-	public void shouldSubscribeErrorOnFluxWhenCreatedHandlerWithFluxReturnTypeThrowException() throws Exception {
+	public void shouldGetFluxWithErrorWhenEndpointCallThrowsException() throws Exception {
 		AsyncEndpointCallHandler<Flux<String>, Collection<String>> handler = adapter
 				.adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("flux")), delegate);
 
@@ -112,17 +112,34 @@ public class FluxEndpointCallHandlerAdapterTest {
 			.verify();
 	}
 
+    @Test
+    public void shouldGetEmptyFluxWhenEndpointCallReturnsNull() throws Exception {
+        when(asyncEndpointCall.executeAsync())
+            .thenReturn(CompletableFuture.completedFuture(null));
+
+        AsyncEndpointCallHandler<Flux<String>, Collection<String>> handler = adapter
+            .adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("flux")), delegate);
+
+        Flux<String> flux = handler.handleAsync(asyncEndpointCall, null);
+
+        assertNotNull(flux);
+
+        StepVerifier.create(flux)
+            .expectComplete()
+            .verify();
+    }
+
 	@Test
-	public void shouldCreateSyncHandlerFromEndpointMethodWithFluxReturnType() throws Exception {
+	public void shouldGetFluxWithResponseOfSyncCall() throws Exception {
 		EndpointCallHandler<Flux<String>, Collection<String>> handler = adapter
 				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("flux")), delegate);
 
 		when(asyncEndpointCall.execute())
 			.thenReturn(Arrays.asList(expectedAsyncResult));
 
-		Flux<String> flux = handler.handle(asyncEndpointCall, null);
+        Flux<String> flux = handler.handle(asyncEndpointCall, null);
 
-		assertNotNull(flux);
+        assertNotNull(flux);
 
 		StepVerifier.create(flux)
 			.expectNext(expectedAsyncResult)

--- a/java-restify-reactor/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/reactor/MonoEndpointCallHandlerAdapterTest.java
+++ b/java-restify-reactor/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/reactor/MonoEndpointCallHandlerAdapterTest.java
@@ -73,7 +73,7 @@ public class MonoEndpointCallHandlerAdapterTest {
 	}
 
 	@Test
-	public void shouldCreateHandlerFromEndpointMethodWithMonoReturnType() throws Exception {
+	public void shouldGetMonoWithResponseOfCall() throws Exception {
 		AsyncEndpointCallHandler<Mono<String>, String> handler = adapter
 				.adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("mono")), delegate);
 
@@ -88,7 +88,7 @@ public class MonoEndpointCallHandlerAdapterTest {
 	}
 
 	@Test
-	public void shouldSubscribeErrorOnSingleWhenCreatedHandlerWithRxJava2SingleReturnTypeThrowException() throws Exception {
+	public void shouldGetMonoWithErrorWhenEndpointCallThrowsException() throws Exception {
 		AsyncEndpointCallHandler<Mono<String>, String> handler = adapter
 				.adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("mono")), delegate);
 
@@ -109,8 +109,25 @@ public class MonoEndpointCallHandlerAdapterTest {
 			.verify();
 	}
 
+    @Test
+    public void shouldGetEmptyMonoWhenEndpointCallReturnsNull() throws Exception {
+        when(asyncEndpointCall.executeAsync())
+            .thenReturn(CompletableFuture.completedFuture(null));
+
+        AsyncEndpointCallHandler<Mono<String>, String> handler = adapter
+            .adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("mono")), delegate);
+
+        Mono<String> mono = handler.handleAsync(asyncEndpointCall, null);
+
+        assertNotNull(mono);
+
+        StepVerifier.create(mono)
+            .expectComplete()
+            .verify();
+    }
+
 	@Test
-	public void shouldCreateSyncHandlerFromEndpointMethodWithMonoReturnType() throws Exception {
+	public void shouldGetMonoWithResponseOfSyncCall() throws Exception {
 		EndpointCallHandler<Mono<String>, String> handler = adapter
 				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("mono")), delegate);
 

--- a/java-restify-rxjava-2/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava2/RxJava2FlowableEndpointCallHandlerAdapter.java
+++ b/java-restify-rxjava-2/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava2/RxJava2FlowableEndpointCallHandlerAdapter.java
@@ -125,6 +125,8 @@ public class RxJava2FlowableEndpointCallHandlerAdapter<T, O> implements AsyncEnd
 			future.whenComplete((value, throwable) -> {
 				if (throwable != null) {
 					emitter.onError(throwable);
+				} else if (value == null) {
+				    emitter.onComplete();
 				} else {
 					emitter.onNext(value);
 					emitter.onComplete();

--- a/java-restify-rxjava-2/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava2/RxJava2ObservableEndpointCallHandlerAdapter.java
+++ b/java-restify-rxjava-2/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava2/RxJava2ObservableEndpointCallHandlerAdapter.java
@@ -124,6 +124,8 @@ public class RxJava2ObservableEndpointCallHandlerAdapter<T, O> implements AsyncE
 			future.whenComplete((value, throwable) -> {
 				if (throwable != null) {
 					emitter.onError(throwable);
+				} else if (value == null) {
+				    emitter.onComplete();
 				} else {
 					emitter.onNext(value);
 					emitter.onComplete();

--- a/java-restify-rxjava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaObservableEndpointCallHandlerAdapter.java
+++ b/java-restify-rxjava/src/main/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaObservableEndpointCallHandlerAdapter.java
@@ -125,6 +125,8 @@ public class RxJavaObservableEndpointCallHandlerAdapter<T, O> implements AsyncEn
 			future.whenComplete((value, throwable) -> {
 				if (throwable != null) {
 					emitter.onError(throwable);
+				} else if (value == null) {
+				    emitter.onCompleted();
 				} else {
 					emitter.onNext(value);
 					emitter.onCompleted();

--- a/java-restify-rxjava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaSingleEndpointCallHandlerAdapterTest.java
+++ b/java-restify-rxjava/src/test/java/com/github/ljtfreitas/restify/http/client/call/handler/rxjava/RxJavaSingleEndpointCallHandlerAdapterTest.java
@@ -40,12 +40,26 @@ public class RxJavaSingleEndpointCallHandlerAdapterTest {
 
 	private RxJavaSingleEndpointCallHandlerAdapter<String, String> adapter;
 
+    private CompletableFuture<String> resultAsFuture;
+
+    private String result;
+
 	@Before
 	public void setup() {
 		adapter = new RxJavaSingleEndpointCallHandlerAdapter<>(Schedulers.immediate());
 
 		when(delegate.returnType())
 			.thenReturn(JavaType.of(String.class));
+
+		result = "single result";
+
+		when(endpointCall.execute())
+		    .thenReturn(result);
+
+		resultAsFuture = CompletableFuture.completedFuture(result);
+
+		when(asyncEndpointCall.executeAsync())
+		    .thenReturn(resultAsFuture);
 	}
 
 	@Test
@@ -70,16 +84,9 @@ public class RxJavaSingleEndpointCallHandlerAdapterTest {
 	}
 
 	@Test
-	public void shouldCreateHandlerFromEndpointMethodWithRxJavaSingleReturnType() throws Exception {
+	public void shouldGetSingleWithResponseOfCall() throws Exception {
 		AsyncEndpointCallHandler<Single<String>, String> handler = adapter
 				.adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("single")), delegate);
-
-		String result = "single result";
-
-		CompletableFuture<String> resultAsFuture = CompletableFuture.completedFuture(result);
-
-		when(asyncEndpointCall.executeAsync())
-			.thenReturn(resultAsFuture);
 
 		when(delegate.handle(any(), anyVararg()))
 			.thenReturn(resultAsFuture.join());
@@ -96,7 +103,7 @@ public class RxJavaSingleEndpointCallHandlerAdapterTest {
 	}
 
 	@Test
-	public void shouldSubscribeErrorOnSingleWhenCreatedHandlerWithRxJavaSingleReturnTypeThrowException() throws Exception {
+	public void shouldSingleWithErrorWhenEndpointcallThrowsException() throws Exception {
 		AsyncEndpointCallHandler<Single<String>, String> handler = adapter
 				.adaptAsync(new SimpleEndpointMethod(SomeType.class.getMethod("single")), delegate);
 
@@ -118,7 +125,7 @@ public class RxJavaSingleEndpointCallHandlerAdapterTest {
 	}
 
 	@Test
-	public void shouldCreateSyncHandlerFromEndpointMethodWithRxJavaSingleReturnType() throws Exception {
+	public void shouldGetSingleWithResponseOfSyncCall() throws Exception {
 		EndpointCallHandler<Single<String>, String> handler = adapter
 				.adapt(new SimpleEndpointMethod(SomeType.class.getMethod("single")), delegate);
 


### PR DESCRIPTION
## Tratamento de respostas sem corpo usando objetos reativos

### Descrição
- Implementa tratamento de respostas sem corpo usando objetos reativos; passa a emitir apenas o evento *onComplete* quando o `EndpointResponse` não retornar nenhum corpo (valor nulo)

### Changelog
- O tratamento foi implementado no suporte aos objetos do RxJava; o *Reactor* já implementa esse tratamento ao converter um `CompletableFuture` para um `Mono`, que é a implementação atual.